### PR TITLE
feat: Allow no template_config, enabling you to use litestar-vite with html frameworks other than Jinja2

### DIFF
--- a/src/py/litestar_vite/plugin.py
+++ b/src/py/litestar_vite/plugin.py
@@ -128,20 +128,15 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
         """
         from litestar_vite.loader import render_asset_tag, render_hmr_client
 
-        if app_config.template_config is None:  # pyright: ignore[reportUnknownMemberType]
-            msg = "A template configuration is required for Vite."
-            raise ImproperlyConfiguredException(msg)
-        if not isinstance(app_config.template_config.engine_instance, JinjaTemplateEngine):  # pyright: ignore[reportUnknownMemberType]
-            msg = "Jinja2 template engine is required for Vite."
-            raise ImproperlyConfiguredException(msg)
-        app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
-            key="vite_hmr",
-            template_callable=render_hmr_client,
-        )
-        app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
-            key="vite",
-            template_callable=render_asset_tag,
-        )
+        if app_config.template_config and isinstance(app_config.template_config.engine_instance, JinjaTemplateEngine):  # pyright: ignore[reportUnknownMemberType]
+            app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
+                key="vite_hmr",
+                template_callable=render_hmr_client,
+            )
+            app_config.template_config.engine_instance.register_template_callable(  # pyright: ignore[reportUnknownMemberType]
+                key="vite",
+                template_callable=render_asset_tag,
+            )
         if self._config.set_static_folders:
             static_dirs = [Path(self._config.bundle_dir), Path(self._config.resource_dir)]
             if Path(self._config.public_dir).exists() and self._config.public_dir != self._config.bundle_dir:

--- a/src/py/litestar_vite/plugin.py
+++ b/src/py/litestar_vite/plugin.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Iterator, cast
 
 from litestar.cli._utils import console
 from litestar.contrib.jinja import JinjaTemplateEngine
-from litestar.exceptions import ImproperlyConfiguredException
 from litestar.plugins import CLIPlugin, InitPluginProtocol
 from litestar.static_files import create_static_files_router  # pyright: ignore[reportUnknownVariableType]
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

Allowing no template_config enables you to use litestar-vite with html frameworks other than `Jinja2`.

main.py
```python
from typing import Any

from litestar import Litestar, MediaType, Request, Response, get
from litestar_vite import ViteConfig, VitePlugin
from weba import ui

from app import env
from app.components.layout import Layout

plugins: list[Any] = [
    VitePlugin(
        config=ViteConfig(
            hot_reload=env.debug,
            use_server_lifespan=env.debug,
            dev_mode=env.debug,
            port=env.vite_port,
        ),
    )
]


@get("/")
async def index(request: Request[Any, Any, Any]) -> Response[str]:
    async with Layout(request) as html:
        with html.main:
            ui.h1("Hello, World!")

    return Response(
        content=str(html),
        media_type=MediaType.HTML,
        status_code=200,
    )


app = Litestar(
    [index],
    openapi_config=None,
    plugins=plugins,
    debug=env.debug,
)
```

layout.py
```python
from typing import Any

from litestar import Request
from litestar_vite.loader import render_asset_tag, render_hmr_client
from weba import Component, Tag, tag, ui

from app import env


class Layout(Component):
    html = "./layout.html"

    def __init__(self, request: Request[Any, Any, Any], title: str | None = None):
        self.title = f" | {title}" if title else ""
        self.context = {"request": request}

    @tag("title")
    def title_tag(self, t: Tag):
        t.string = self.title

    @tag("body")
    def body(self):
        pass

    @tag("body > main")
    def main(self):
        pass

    @tag("body > header")
    def header(self):
        pass

    @tag("body > footer")
    def footer(self):
        pass

    async def render(self):
        self._append_hmr()
        self._append_assets()

    def _append_hmr(self):
        if not env.debug:
            return

        self.body.append(ui.raw(render_hmr_client(self.context)))
        self.body.append(
            ui.script(
                src="/__reload__/static/reload-listener.js",
                data_worker_script_path="/__reload__/static/reload-worker.js",
                data_ws_path="/__reload__",
                defer=True,
                async_=True,
            )
        )

    def _append_assets(self):
        self.body.append(ui.raw(render_asset_tag(self.context, path=["app/scripts/main.js", "app/styles/main.css"])))
```

