### PR TITLE
feat: Allow static file config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 .vscode
 
 node_modules
+.aider*

--- a/src/py/litestar_vite/plugin.py
+++ b/src/py/litestar_vite/plugin.py
@@ -180,7 +180,7 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
                 "include_in_schema": False,
                 "opt": {"exclude_from_auth": True},
             }
-            static_files_config: dict[str, Any] = {**base_config, **self._static_files_config.__dict__}
+            static_files_config: dict[str, Any] = {**base_config, **self._static_files_config}
             app_config.route_handlers.append(create_static_files_router(**static_files_config))
         return app_config
 


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description

This allows you to set things like the `cache_control` for the static paths to improve lighthouse scores.

```python
from litestar.datastructures import CacheControlHeader
from litestar_vite import ViteConfig, VitePlugin
from litestar_vite.plugin import StaticFilesConfig

VitePlugin(
        config=ViteConfig(
            hot_reload=env.debug,
            use_server_lifespan=env.debug,
            dev_mode=env.debug,
            port=env.vite_port,
        ),
        static_files_config=StaticFilesConfig(
            cache_control=CacheControlHeader(max_age=31536000, immutable=True, public=True),
        ),
    )
```
