### PR TITLE
chore: bypass CI check for GIF generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,6 +72,8 @@ jobs:
         env:
           # Disable Chrome sandbox for headless rendering
           VHS_NO_SANDBOX: "true"
+          # Bypass CI environment check - demos intentionally run dev commands
+          LITESTAR_BYPASS_ENV_CHECK: "1"
 
       - name: List generated files
         run: ls -la docs/_static/demos/ || echo "No demos generated"


### PR DESCRIPTION
Enable bypassing the CI environment check to allow GIF to record the correct output.