### PR TITLE
fix: detect inertia mode from 'hybrid' in .litestar.json

### DIFF
--- a/src/js/src/index.ts
+++ b/src/js/src/index.ts
@@ -940,7 +940,8 @@ function resolvePluginConfig(config: string | string[] | PluginConfig): Resolved
   }
 
   // Auto-detect Inertia mode from .litestar.json if not explicitly set
-  const inertiaMode = resolvedConfig.inertiaMode ?? pythonDefaults?.mode === "inertia"
+  // Check for both "hybrid" and "inertia" since Python normalizes "inertia" -> "hybrid"
+  const inertiaMode = resolvedConfig.inertiaMode ?? (pythonDefaults?.mode === "hybrid" || pythonDefaults?.mode === "inertia")
 
   const effectiveResourceDir = resolvedConfig.resourceDir ?? pythonDefaults?.resourceDir ?? "src"
 


### PR DESCRIPTION
## Summary

- Fixes inertiaMode auto-detection when Python normalizes `mode="inertia"` to `mode="hybrid"`
- Previously, the JS plugin only checked for `"inertia"`, so the placeholder was never served in Inertia apps
- Now checks for both `"hybrid"` and `"inertia"` modes

## Problem

When using Inertia mode, Python normalizes the mode before writing `.litestar.json`:
```python
elif self.mode == "inertia":
    self.mode = "hybrid"
```

But the JS plugin was only checking for `"inertia"`:
```typescript
const inertiaMode = resolvedConfig.inertiaMode ?? pythonDefaults?.mode === "inertia"
// .litestar.json has mode: "hybrid" → check fails → inertiaMode = false
```

This caused Vite to serve the user's `index.html` directly instead of the dev placeholder, bypassing Litestar.

## Fix

```typescript
const inertiaMode = resolvedConfig.inertiaMode ?? (pythonDefaults?.mode === "hybrid" || pythonDefaults?.mode === "inertia")
```

## Test plan

- [x] Added test: `serves placeholder when mode is 'hybrid' in .litestar.json`
- [x] Added test: `serves placeholder when mode is 'inertia' in .litestar.json`
- [x] All 271 JS tests pass
- [x] Lint passes