### PR TITLE
fix: include package.json in sdist for build hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.16.0"
+version = "0.16.1"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -51,7 +51,7 @@ requires = ["hatchling"]
 
 [tool.hatch.build.targets.sdist]
 exclude = ["/.github", "/docs"]
-include = ["src/py/*","src/js/*","tools/*"]
+include = ["src/py/*","src/js/*","tools/*","package.json","package-lock.json"]
 force-include = { "src/py/litestar_vite/static/server-starting.html" = "src/py/litestar_vite/static/server-starting.html" }
 
 [tool.hatch.build.targets.sdist.hooks.custom]
@@ -103,7 +103,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.16.0"
+current_version = "0.16.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/uv.lock
+++ b/uv.lock
@@ -626,7 +626,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes the v0.16.0 Python release failure by including `package.json` and `package-lock.json` in the source distribution (sdist).

**Root Cause:** The sdist `include` pattern in `pyproject.toml` did not include root-level files. When CI built the wheel from the sdist, the custom build hook tried to run `npm install` but `package.json` was missing.

**Error from [failed CI run](https://github.com/litestar-org/litestar-vite/actions/runs/20701534826/job/59424527959):**
```
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory
subprocess.CalledProcessError: Command '['npm', 'install', '--no-fund', '--quiet']' returned non-zero exit status 254.
```

## Changes

- Added `package.json` and `package-lock.json` to sdist include list
- Bumped version to 0.16.1

## Test plan

- [x] Local `uv build` succeeds
- [ ] CI build passes