### PR TITLE
fix: configure PyPI publish to use dist/py directory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,22 @@ jobs:
         run: uv sync --all-extras
 
       - name: Build package
-        run: uv build
+        run: uv build -o dist/py
+
+      - name: Verify build artifacts
+        run: |
+          echo "=== Build artifacts ==="
+          ls -la dist/py/
+          if ! ls dist/py/*.whl 1>/dev/null 2>&1 || ! ls dist/py/*.tar.gz 1>/dev/null 2>&1; then
+            echo "ERROR: Expected wheel and sdist not found in dist/py/"
+            exit 1
+          fi
+          echo "Build artifacts verified successfully"
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/py/
         # Pre-release versions (alpha, beta, rc) are automatically detected by PyPI
         # based on PEP 440 version format (e.g., 0.15.0a1, 0.15.0b1, 0.15.0rc1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.16.1"
+version = "0.16.2"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -103,7 +103,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.16.1"
+current_version = "0.16.2"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/uv.lock
+++ b/uv.lock
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes the v0.16.1 Python release failure where PyPI tried to upload `dist/js/` as a Python package.

**Error from [failed CI run](https://github.com/litestar-org/litestar-vite/actions/runs/20703067319):**
```
Checking dist/litestar_vite-0.16.1-py3-none-any.whl: PASSED
Checking dist/js: ERROR    InvalidDistribution: Unknown distribution format: 'js'
```

## Root Cause

Two issues:
1. **Build output mismatch**: Makefile uses `uv build -o dist/py` but workflow used bare `uv build` (defaults to `dist/`)
2. **No packages-dir**: PyPI publish scanned entire `dist/` including JS artifacts

## Changes

1. **Build command**: `uv build` → `uv build -o dist/py` (aligns with Makefile)
2. **Verification step**: Fail fast if wheel/sdist missing
3. **packages-dir**: Scope publish to `dist/py/` only
  