### PR TITLE
fix(cli): allow numeric framework selection in assets init prompt

### DIFF
--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -283,7 +283,9 @@ def _select_framework_template(template: "str | None", no_prompt: bool) -> "tupl
         number_choices = [str(i) for i in range(1, len(available) + 1)]
 
         template = Prompt.ask(
-            prompt="\nSelect a framework template (name or number)", choices=[*name_choices, *number_choices], default="react"
+            prompt="\nSelect a framework template (name or number)",
+            choices=[*name_choices, *number_choices],
+            default="react",
         )
         if template.isdigit():
             template = name_choices[int(template) - 1]


### PR DESCRIPTION
## Description

- Accept both framework names and numbered choices when selecting templates interactively, so users can enter `1`, `2`, etc. instead of typing full names like `react-tanstack`.

