### PR TITLE
ci: add node 24 to the ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       LITESTAR_BYPASS_ENV_CHECK: 1
     strategy:
       matrix:
-        node-version: [20,22]
+        node-version: [20,22,24]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
This PR adds node 24 to the tests (previously was 20 and 22)