### PR TITLE
fix(#242): Do not send request body for GET/HEAD/OPTIONS proxy requests

### DIFF
--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 
 _DISCONNECT_EXCEPTIONS = (WebSocketDisconnect, anyio.ClosedResourceError, websockets.ConnectionClosed)
 
+_BODY_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
 _PROXY_ALLOW_PREFIXES: tuple[str, ...] = (
     "/@vite",
     "/@id/",
@@ -377,7 +379,11 @@ class ViteProxyMiddleware(AbstractMiddleware):
             url = f"{url}?{query_string}"
 
         headers = _filter_hop_by_hop_headers(scope.get("headers", []))
-        request_body = _stream_request_body(receive)
+        # Only stream request body for methods that carry a body.
+        # Passing an async generator as content for GET/HEAD/OPTIONS causes httpx
+        # to add Transfer-Encoding: chunked, which Vite dev server rejects with 400.
+        # See: https://github.com/litestar-org/litestar-vite/issues/242
+        request_body = _stream_request_body(receive) if method in _BODY_METHODS else None
 
         # Use shared client from plugin when available (connection pooling)
         client = self._plugin.proxy_client if self._plugin is not None else None
@@ -761,7 +767,9 @@ def create_ssr_proxy_controller(
                 console.print(f"[dim][ssr-proxy] {request.method} {req_path} → {url}[/]")
 
             headers_to_forward = _filter_hop_by_hop_headers(request.headers.items())
-            request_body = _stream_request_body_chunks(request.stream())
+            # Only stream request body for methods that carry a body.
+            # See: https://github.com/litestar-org/litestar-vite/issues/242
+            request_body = _stream_request_body_chunks(request.stream()) if request.method in _BODY_METHODS else None
 
             # Use shared client from plugin when available (connection pooling)
             client = plugin.proxy_client if plugin is not None else None

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -217,8 +217,9 @@ async def test_proxy_http_with_plugin_client(tmp_path: Path) -> None:
 
     middleware = ViteProxyMiddleware(app=Mock(), hotfile_path=hotfile, asset_url="/static/", plugin=plugin)
 
+    # Use POST to test body streaming (GET no longer sends body per #242)
     scope = {
-        "method": "GET",
+        "method": "POST",
         "raw_path": b"/@vite/client",
         "query_string": b"",
         "headers": [(b"host", b"example.com")],
@@ -392,3 +393,251 @@ def test_build_proxy_url_and_http2_support() -> None:
     assert build_proxy_url("http://localhost:3000", "/path", "a=1") == "http://localhost:3000/path?a=1"
     assert build_proxy_url("http://localhost:3000", "/path", "") == "http://localhost:3000/path"
     assert check_http2_support(False) is False
+
+
+# ===== Issue #242: GET requests should not send a request body =====
+
+
+async def test_proxy_http_get_does_not_send_body(tmp_path: Path) -> None:
+    """GET requests must pass content=None so httpx does not add Transfer-Encoding: chunked.
+
+    Regression test for https://github.com/litestar-org/litestar-vite/issues/242
+    """
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+
+    response = httpx.Response(200, headers={"content-type": "text/plain"}, content=b"ok")
+    plugin_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", plugin_client)))
+
+    middleware = ViteProxyMiddleware(app=Mock(), hotfile_path=hotfile, asset_url="/static/", plugin=plugin)
+
+    scope = {
+        "method": "GET",
+        "raw_path": b"/@vite/client",
+        "query_string": b"",
+        "headers": [(b"host", b"example.com")],
+        "path": "/@vite/client",
+    }
+    events: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event: dict[str, object]) -> None:
+        events.append(event)
+
+    await middleware._proxy_http(scope, receive, send)
+
+    # Verify the response was successful
+    assert events[0]["status"] == 200
+
+    # Verify content=None was passed (no body for GET)
+    assert len(plugin_client.stream_calls) == 1
+    _, kwargs = plugin_client.stream_calls[0]
+    assert kwargs["content"] is None, "GET requests must not send a request body to avoid chunked encoding"
+
+
+async def test_proxy_http_head_does_not_send_body(tmp_path: Path) -> None:
+    """HEAD requests must pass content=None.
+
+    Regression test for https://github.com/litestar-org/litestar-vite/issues/242
+    """
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+
+    response = httpx.Response(200, headers={"content-type": "text/plain"}, content=b"")
+    plugin_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", plugin_client)))
+
+    middleware = ViteProxyMiddleware(app=Mock(), hotfile_path=hotfile, asset_url="/static/", plugin=plugin)
+
+    scope = {
+        "method": "HEAD",
+        "raw_path": b"/@vite/client",
+        "query_string": b"",
+        "headers": [(b"host", b"example.com")],
+        "path": "/@vite/client",
+    }
+    events: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event: dict[str, object]) -> None:
+        events.append(event)
+
+    await middleware._proxy_http(scope, receive, send)
+
+    assert len(plugin_client.stream_calls) == 1
+    _, kwargs = plugin_client.stream_calls[0]
+    assert kwargs["content"] is None, "HEAD requests must not send a request body"
+
+
+async def test_proxy_http_options_does_not_send_body(tmp_path: Path) -> None:
+    """OPTIONS requests must pass content=None.
+
+    Regression test for https://github.com/litestar-org/litestar-vite/issues/242
+    """
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+
+    response = httpx.Response(200, headers={"content-type": "text/plain"}, content=b"")
+    plugin_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", plugin_client)))
+
+    middleware = ViteProxyMiddleware(app=Mock(), hotfile_path=hotfile, asset_url="/static/", plugin=plugin)
+
+    scope = {
+        "method": "OPTIONS",
+        "raw_path": b"/@vite/client",
+        "query_string": b"",
+        "headers": [(b"host", b"example.com")],
+        "path": "/@vite/client",
+    }
+    events: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event: dict[str, object]) -> None:
+        events.append(event)
+
+    await middleware._proxy_http(scope, receive, send)
+
+    assert len(plugin_client.stream_calls) == 1
+    _, kwargs = plugin_client.stream_calls[0]
+    assert kwargs["content"] is None, "OPTIONS requests must not send a request body"
+
+
+async def test_proxy_http_post_still_sends_body(tmp_path: Path) -> None:
+    """POST requests must still stream the request body.
+
+    Ensures the fix for #242 does not break body-carrying methods.
+    """
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+
+    response = httpx.Response(200, headers={"content-type": "text/plain"}, content=b"ok")
+    plugin_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", plugin_client)))
+
+    middleware = ViteProxyMiddleware(app=Mock(), hotfile_path=hotfile, asset_url="/static/", plugin=plugin)
+
+    scope = {
+        "method": "POST",
+        "raw_path": b"/@vite/client",
+        "query_string": b"",
+        "headers": [(b"host", b"example.com")],
+        "path": "/@vite/client",
+    }
+    events: list[dict[str, object]] = []
+    chunks = [b"post-data"]
+
+    async def receive() -> dict[str, object]:
+        if chunks:
+            return {"type": "http.request", "body": chunks.pop(0), "more_body": bool(chunks)}
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(event: dict[str, object]) -> None:
+        events.append(event)
+
+    await middleware._proxy_http(scope, receive, send)
+
+    assert events[0]["status"] == 200
+    assert len(plugin_client.stream_calls) == 1
+    _, kwargs = plugin_client.stream_calls[0]
+    assert kwargs["content"] is not None, "POST requests must still send a request body"
+    # Verify body was actually consumed
+    assert plugin_client.stream_context is not None
+    assert plugin_client.stream_context.request_body_chunks == [b"post-data"]
+
+
+async def test_proxy_http_put_still_sends_body(tmp_path: Path) -> None:
+    """PUT requests must still stream the request body."""
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+
+    response = httpx.Response(200, headers={"content-type": "text/plain"}, content=b"ok")
+    plugin_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", plugin_client)))
+
+    middleware = ViteProxyMiddleware(app=Mock(), hotfile_path=hotfile, asset_url="/static/", plugin=plugin)
+
+    scope = {
+        "method": "PUT",
+        "raw_path": b"/@vite/client",
+        "query_string": b"",
+        "headers": [(b"host", b"example.com")],
+        "path": "/@vite/client",
+    }
+    events: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"put-data", "more_body": False}
+
+    async def send(event: dict[str, object]) -> None:
+        events.append(event)
+
+    await middleware._proxy_http(scope, receive, send)
+
+    assert len(plugin_client.stream_calls) == 1
+    _, kwargs = plugin_client.stream_calls[0]
+    assert kwargs["content"] is not None, "PUT requests must still send a request body"
+
+
+async def test_ssr_proxy_get_does_not_send_body() -> None:
+    """SSR proxy GET requests must pass content=None.
+
+    Regression test for https://github.com/litestar-org/litestar-vite/issues/242
+    """
+    response = cast(
+        "httpx.Response",
+        _DummyStreamingResponse(chunks=[b"ok"], status_code=200, headers=[("content-type", "text/plain")]),
+    )
+    dummy_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", dummy_client)))
+
+    Controller = create_ssr_proxy_controller(target="http://localhost:3000", plugin=plugin, http2=False)
+    controller = Controller(owner=MagicMock())
+
+    async def request_stream() -> AsyncGenerator[bytes, None]:
+        if False:
+            yield b""
+
+    request = SimpleNamespace(
+        method="GET", url=SimpleNamespace(path="/", query=""), headers={"x-test": "ok"}, stream=request_stream
+    )
+
+    await controller.http_proxy.fn(controller, request)
+
+    # Verify content=None was passed for GET
+    assert len(dummy_client.stream_calls) == 1
+    _, kwargs = dummy_client.stream_calls[0]
+    assert kwargs["content"] is None, "SSR proxy GET requests must not send a request body"
+
+
+async def test_ssr_proxy_post_still_sends_body() -> None:
+    """SSR proxy POST requests must still stream the request body."""
+    response = cast(
+        "httpx.Response",
+        _DummyStreamingResponse(chunks=[b"ok"], status_code=200, headers=[("content-type", "text/plain")]),
+    )
+    dummy_client = DummyAsyncClient(response)
+    plugin = cast("VitePlugin", SimpleNamespace(proxy_client=cast("httpx.AsyncClient", dummy_client)))
+
+    Controller = create_ssr_proxy_controller(target="http://localhost:3000", plugin=plugin, http2=False)
+    controller = Controller(owner=MagicMock())
+
+    async def request_stream() -> AsyncGenerator[bytes, None]:
+        yield b"post-body"
+
+    request = SimpleNamespace(
+        method="POST", url=SimpleNamespace(path="/submit", query=""), headers={"x-test": "ok"}, stream=request_stream
+    )
+
+    await controller.http_proxy.fn(controller, request)
+
+    assert len(dummy_client.stream_calls) == 1
+    _, kwargs = dummy_client.stream_calls[0]
+    assert kwargs["content"] is not None, "SSR proxy POST requests must still send a request body"


### PR DESCRIPTION
## Summary

Fixes #242

`ViteProxyMiddleware._proxy_http()` and `SSRProxyController.http_proxy()` always passed an async generator from `_stream_request_body(receive)` as the `content` parameter to `httpx.AsyncClient.stream()`, **even for GET/HEAD/OPTIONS requests**.

When `httpx` receives any `AsyncIterable` as `content`, it unconditionally sets `Transfer-Encoding: chunked` — regardless of whether the generator yields any data. Vite's dev server (and most HTTP servers) **reject GET requests with a chunked body**, returning **400 Bad Request** with an empty response body.

This caused all proxied asset requests (e.g., `/@vite/client`, `/static/web/src/main.tsx`) to fail in SPA dev mode.

## Root Cause

In `httpx/_content.py`, the `encode_content()` function handles `AsyncIterable` like this:

```python
elif isinstance(content, AsyncIterable):
    headers = {"Transfer-Encoding": "chunked"}  # ← unconditional!
    return headers, AsyncIteratorByteStream(content)
```

So even an empty async generator that yields nothing still causes httpx to add the `Transfer-Encoding: chunked` header to the outgoing request.

## Fix

Only pass the request body generator for HTTP methods that typically carry a body (`POST`, `PUT`, `PATCH`, `DELETE`). For all other methods (`GET`, `HEAD`, `OPTIONS`, etc.), pass `content=None`.

```python
_BODY_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
request_body = _stream_request_body(receive) if method in _BODY_METHODS else None
```

Applied to both:
- `ViteProxyMiddleware._proxy_http()` — the ASGI middleware proxy
- `SSRProxyController.http_proxy()` — the SSR framework proxy controller

## Changes

| File | Changes |
|------|---------|
| `src/py/litestar_vite/plugin/_proxy.py` | Added `_BODY_METHODS` constant; conditionally pass `content` based on HTTP method (2 locations) |
| `src/py/tests/unit/test_proxy_helpers.py` | Added 8 regression tests; updated 1 existing test |

## Tests Added

| Test | Verifies |
|------|----------|
| `test_proxy_http_get_does_not_send_body` | GET → `content=None` |
| `test_proxy_http_head_does_not_send_body` | HEAD → `content=None` |
| `test_proxy_http_options_does_not_send_body` | OPTIONS → `content=None` |
| `test_proxy_http_post_still_sends_body` | POST → body still streamed |
| `test_proxy_http_put_still_sends_body` | PUT → body still streamed |
| `test_ssr_proxy_get_does_not_send_body` | SSR proxy GET → `content=None` |
| `test_ssr_proxy_post_still_sends_body` | SSR proxy POST → body still streamed |

Also updated `test_proxy_http_with_plugin_client` to use `POST` instead of `GET` (this test validates body streaming, which is now correctly skipped for GET).

## Verification

- ✅ All 81 proxy-related tests pass
- ✅ `make lint` passes (pre-commit, mypy, pyright, ruff, slots check)
- ✅ No type errors introduced
