### PR TITLE
fix(loader): re-read hotfile on demand

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.23.0"
+version = "0.23.1"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -102,7 +102,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.23.0"
+current_version = "0.23.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/src/py/litestar_vite/loader.py
+++ b/src/py/litestar_vite/loader.py
@@ -320,13 +320,13 @@ class ViteAssetLoader:
         """Asynchronously read the hot file for dev server URL."""
         hot_file_path = anyio.Path(self._get_hot_file_path())
         if await hot_file_path.exists():
-            self._vite_base_path = await hot_file_path.read_text()
+            self._vite_base_path = (await hot_file_path.read_text()).strip() or None
 
     def _load_hot_file_sync(self) -> None:
         """Synchronously read the hot file for dev server URL."""
         hot_file_path = self._get_hot_file_path()
         if hot_file_path.exists():
-            self._vite_base_path = hot_file_path.read_text()
+            self._vite_base_path = hot_file_path.read_text().strip() or None
 
     @property
     def manifest_content(self) -> str:
@@ -501,6 +501,13 @@ class ViteAssetLoader:
         Returns:
             Full URL to the asset on the dev server.
         """
+        # Lazy retry: ``parse_manifest()`` runs once at loader init and races the JS
+        # plugin's hotfile write — if the file did not exist yet, ``_vite_base_path``
+        # stays ``None`` for the loader's lifetime and every asset URL silently leaks
+        # the raw Vite dev server origin (breaking the single-port-via-ASGI bridge
+        # contract). Re-reading on demand fixes the race without polling.
+        if self._vite_base_path is None:
+            self._load_hot_file_sync()
         base_path = self._vite_base_path or f"{self._config.protocol}://{self._config.host}:{self._config.port}"
         return urljoin(base_path, urljoin(self._config.asset_url, path if path is not None else ""))
 

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -278,9 +278,19 @@ def _derive_bridge_litestar_port() -> int | None:
 
     if explicit := os.environ.get("APP_URL"):
         parsed = urlparse(explicit)
-        if parsed.port is not None:
-            return parsed.port
-        return _DEFAULT_PORT_BY_SCHEME.get(parsed.scheme)
+        try:
+            port = parsed.port
+        except ValueError:
+            # Unexpanded shell-style placeholders like 'http://localhost:${LITESTAR_PORT}'
+            # leave a non-integer in the port slot. The user clearly intended a real port
+            # value; fall through to LITESTAR_PORT/PORT instead of pretending APP_URL had
+            # no port (which would yield a misleading scheme default of 80/443).
+            pass
+        else:
+            if port is not None:
+                return port
+            if parsed.scheme in _DEFAULT_PORT_BY_SCHEME:
+                return _DEFAULT_PORT_BY_SCHEME[parsed.scheme]
 
     raw = os.environ.get("LITESTAR_PORT") or os.environ.get("PORT")
     if not raw:

--- a/src/py/tests/unit/test_asset_loader.py
+++ b/src/py/tests/unit/test_asset_loader.py
@@ -68,8 +68,10 @@ def test_generate_asset_tags_prod_mode() -> None:
     assert '<script type="module" async="" defer="" src="/static/assets/main.js"></script>' in tags
 
 
-def test_generate_asset_tags_dev_mode() -> None:
-    config = ViteConfig(runtime=RuntimeConfig(dev_mode=True))
+def test_generate_asset_tags_dev_mode(tmp_path: Path) -> None:
+    # Empty bundle_dir guarantees no hotfile is found by the lazy-retry path,
+    # forcing the host:port fallback we're asserting on.
+    config = ViteConfig(paths=PathConfig(bundle_dir=tmp_path), runtime=RuntimeConfig(dev_mode=True))
     loader = ViteAssetLoader(config)
 
     tags = loader.generate_asset_tags("main.js")
@@ -93,6 +95,51 @@ def test_generate_asset_tags_dev_mode_uses_litestar_origin_from_hotfile(tmp_path
     assert "127.0.0.1:5173" not in tags
 
 
+def test_generate_asset_tags_dev_mode_rereads_hotfile_when_initially_missing(tmp_path: Path) -> None:
+    """Race scenario: loader initializes before the JS plugin has written the hotfile.
+
+    The first ``parse_manifest()`` call sees no hotfile and leaves ``_vite_base_path``
+    as ``None``. Without a lazy retry, every subsequent asset URL silently falls back
+    to ``http://<host>:<port>`` (the raw Vite dev server origin), breaking the
+    single-port-via-ASGI contract. The loader MUST re-read the hotfile on demand once
+    it appears.
+    """
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+
+    config = ViteConfig(
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/dist/"), runtime=RuntimeConfig(dev_mode=True)
+    )
+    loader = ViteAssetLoader.initialize_loader(config)
+    assert loader._vite_base_path is None
+
+    # Simulate the JS plugin writing the bridge URL after Vite has started.
+    (bundle_dir / "hot").write_text("http://localhost:5006")
+
+    tags = loader.generate_asset_tags("src/main.js")
+
+    assert 'src="http://localhost:5006/static/dist/src/main.js"' in tags
+
+
+def test_load_hot_file_strips_trailing_whitespace(tmp_path: Path) -> None:
+    """Hotfile written by Node tooling commonly has a trailing newline; that newline
+    must not survive into ``urljoin`` (where it produces malformed URLs like
+    ``http://localhost:5006\\n/static/...``).
+    """
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+    (bundle_dir / "hot").write_text("http://localhost:5006\n")
+
+    config = ViteConfig(
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/dist/"), runtime=RuntimeConfig(dev_mode=True)
+    )
+    loader = ViteAssetLoader.initialize_loader(config)
+
+    assert loader._vite_base_path == "http://localhost:5006"
+    tags = loader.generate_asset_tags("src/main.js")
+    assert "\n" not in tags
+
+
 def test_generate_asset_tags_missing_entry() -> None:
     config = ViteConfig(runtime=RuntimeConfig(dev_mode=False))
     loader = ViteAssetLoader(config)
@@ -102,8 +149,8 @@ def test_generate_asset_tags_missing_entry() -> None:
         loader.generate_asset_tags("missing.js")
 
 
-def test_get_static_asset_dev_mode() -> None:
-    config = ViteConfig(runtime=RuntimeConfig(dev_mode=True))
+def test_get_static_asset_dev_mode(tmp_path: Path) -> None:
+    config = ViteConfig(paths=PathConfig(bundle_dir=tmp_path), runtime=RuntimeConfig(dev_mode=True))
     loader = ViteAssetLoader(config)
     assert loader.get_static_asset("test.png") == "http://127.0.0.1:5173/static/test.png"
 

--- a/src/py/tests/unit/test_runtime_config.py
+++ b/src/py/tests/unit/test_runtime_config.py
@@ -150,6 +150,24 @@ def test_bridge_litestar_port_from_app_url_default_http_port(tmp_path: Path, mon
     assert data["litestarPort"] == 443
 
 
+def test_bridge_litestar_port_falls_back_when_app_url_has_unexpanded_template(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """APP_URL with a shell-style placeholder for the port (e.g. ``${LITESTAR_PORT}``)
+    must not crash; the resolver should fall through to LITESTAR_PORT/PORT.
+    """
+    monkeypatch.setenv("APP_URL", "http://localhost:${LITESTAR_PORT}")
+    monkeypatch.setenv("LITESTAR_PORT", "8000")
+
+    cfg = ViteConfig()
+    cfg.paths.root = tmp_path
+
+    path_str = write_runtime_config_file(cfg)
+    data = decode_json(Path(path_str).read_text())
+
+    assert data["litestarPort"] == 8000
+
+
 # Tests for _path_for_bridge helper function
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1044,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.23.0"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Two related dev-mode bridge bugs:

- **Asset loader race**: `ViteAssetLoader.parse_manifest()` runs once at loader init and tries to read the hotfile. The JS plugin writes that file only after Vite's dev server has bound. When Litestar boots faster than Vite (the common case), the read fails silently, `_vite_base_path` stays `None` for the loader's lifetime, and every asset URL falls back to `http://<config.host>:<config.port>` — leaking Vite's raw origin into rendered HTML and breaking the single-port-via-ASGI bridge contract. Fixed by lazily retrying `_load_hot_file_sync()` in `_vite_server_url` when the cached base is `None`. Also strips trailing whitespace from the file contents so a stray newline doesn't end up inside `urljoin`.

- **Bridge port parsing**: `_derive_bridge_litestar_port` calls `urlparse(APP_URL).port`, which raises `ValueError` on a non-integer port slot. Unexpanded shell-style placeholders (`APP_URL=http://localhost:${LITESTAR_PORT}`) crashed app startup with a confusing traceback. Now catches the `ValueError` and falls through to `LITESTAR_PORT`/`PORT` (rather than the misleading scheme default of 80/443 — clearly not what the user intended when they typed a placeholder).