### PR TITLE
fix(proxy): preserve resolved vite hotfile targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.23.1"
+version = "0.23.2"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -102,7 +102,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.23.1"
+current_version = "0.23.2"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/src/js/src/index.ts
+++ b/src/js/src/index.ts
@@ -617,13 +617,7 @@ function resolveLitestarPlugin(pluginConfig: ResolvedPluginConfig): Plugin {
 
         const isAddressInfo = (x: string | AddressInfo | null | undefined): x is AddressInfo => typeof x === "object"
         if (isAddressInfo(address)) {
-          const explicitServerOrigin = typeof userConfig.server?.origin === "string" && userConfig.server.origin.length > 0 ? userConfig.server.origin : undefined
-          const configuredServerOrigin =
-            typeof server.config.server.origin === "string" && server.config.server.origin.length > 0 && server.config.server.origin !== "__litestar_vite_placeholder__"
-              ? server.config.server.origin
-              : undefined
-          const hotfileOrigin = configuredServerOrigin ?? explicitServerOrigin
-          viteDevServerUrl = hotfileOrigin ? (hotfileOrigin as DevServerUrl) : resolveDevServerUrl(address, server.config, userConfig)
+          viteDevServerUrl = resolveDevServerUrl(address, server.config, userConfig)
           fs.mkdirSync(path.dirname(pluginConfig.hotFile), { recursive: true })
           fs.writeFileSync(pluginConfig.hotFile, viteDevServerUrl)
 

--- a/src/js/tests/index.test.ts
+++ b/src/js/tests/index.test.ts
@@ -391,7 +391,7 @@ describe("litestar-vite-plugin", () => {
     }
   })
 
-  it("writes hotFile using explicit server.origin override", async () => {
+  it("writes hotFile using actual dev server URL even with explicit server.origin override", async () => {
     const configPath = createRuntimeConfig({
       proxyMode: "vite",
     })
@@ -436,13 +436,13 @@ describe("litestar-vite-plugin", () => {
 
       listeningHandlers.forEach((handler) => handler())
 
-      expect(writeSpy).toHaveBeenCalledWith(path.resolve(process.cwd(), "public", "hot"), "https://assets.example.test")
+      expect(writeSpy).toHaveBeenCalledWith(path.resolve(process.cwd(), "public", "hot"), "http://127.0.0.1:4789")
     } finally {
       cleanupRuntimeConfig(configPath)
     }
   })
 
-  it("writes hotFile using bridge appUrl default origin in proxy mode", async () => {
+  it("writes hotFile using actual dev server URL when bridge appUrl defaults server.origin", async () => {
     const configPath = createRuntimeConfig({
       proxyMode: "vite",
       appUrl: "http://localhost:5006",
@@ -481,7 +481,7 @@ describe("litestar-vite-plugin", () => {
 
       listeningHandlers.forEach((handler) => handler())
 
-      expect(writeSpy).toHaveBeenCalledWith(path.resolve(process.cwd(), "public", "hot"), "http://localhost:5006")
+      expect(writeSpy).toHaveBeenCalledWith(path.resolve(process.cwd(), "public", "hot"), "http://127.0.0.1:4789")
     } finally {
       cleanupRuntimeConfig(configPath)
     }

--- a/src/py/litestar_vite/loader.py
+++ b/src/py/litestar_vite/loader.py
@@ -25,6 +25,7 @@ from litestar.exceptions import SerializationException
 from litestar.serialization import decode_json
 
 from litestar_vite.exceptions import AssetNotFoundError, ManifestNotFoundError
+from litestar_vite.utils import read_bridge_config
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -501,14 +502,25 @@ class ViteAssetLoader:
         Returns:
             Full URL to the asset on the dev server.
         """
-        # Lazy retry: ``parse_manifest()`` runs once at loader init and races the JS
-        # plugin's hotfile write — if the file did not exist yet, ``_vite_base_path``
-        # stays ``None`` for the loader's lifetime and every asset URL silently leaks
-        # the raw Vite dev server origin (breaking the single-port-via-ASGI bridge
-        # contract). Re-reading on demand fixes the race without polling.
-        if self._vite_base_path is None:
-            self._load_hot_file_sync()
-        base_path = self._vite_base_path or f"{self._config.protocol}://{self._config.host}:{self._config.port}"
+        # Bridge-config preference (litestar-vite-c1t): when ``.litestar.json``
+        # exists and carries a non-null ``appUrl``, anchor asset URLs at that
+        # value. This is the authoritative single-port-via-ASGI bridge URL and
+        # supersedes the hotfile contents (which in proxyMode='vite' are also
+        # the bridge URL post-JS-C4, so this is consistent — but it removes the
+        # ambiguity for any consumer that races the hotfile write).
+        bridge = read_bridge_config()
+        app_url = bridge.get("appUrl") if bridge is not None else None
+        if isinstance(app_url, str) and app_url:
+            base_path = app_url
+        else:
+            # Lazy retry: ``parse_manifest()`` runs once at loader init and races the JS
+            # plugin's hotfile write — if the file did not exist yet, ``_vite_base_path``
+            # stays ``None`` for the loader's lifetime and every asset URL silently leaks
+            # the raw Vite dev server origin (breaking the single-port-via-ASGI bridge
+            # contract). Re-reading on demand fixes the race without polling.
+            if self._vite_base_path is None:
+                self._load_hot_file_sync()
+            base_path = self._vite_base_path or f"{self._config.protocol}://{self._config.host}:{self._config.port}"
         return urljoin(base_path, urljoin(self._config.asset_url, path if path is not None else ""))
 
     @staticmethod

--- a/src/py/litestar_vite/loader.py
+++ b/src/py/litestar_vite/loader.py
@@ -505,9 +505,8 @@ class ViteAssetLoader:
         # Bridge-config preference (litestar-vite-c1t): when ``.litestar.json``
         # exists and carries a non-null ``appUrl``, anchor asset URLs at that
         # value. This is the authoritative single-port-via-ASGI bridge URL and
-        # supersedes the hotfile contents (which in proxyMode='vite' are also
-        # the bridge URL post-JS-C4, so this is consistent — but it removes the
-        # ambiguity for any consumer that races the hotfile write).
+        # supersedes the hotfile contents, which are reserved for the actual
+        # upstream dev-server URL used by proxy/HMR consumers.
         bridge = read_bridge_config()
         app_url = bridge.get("appUrl") if bridge is not None else None
         if isinstance(app_url, str) and app_url:

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -15,7 +15,7 @@ from litestar.exceptions import WebSocketDisconnect
 from litestar.middleware import AbstractMiddleware
 
 from litestar_vite.plugin._utils import console, is_litestar_route, is_proxy_debug, normalize_prefix
-from litestar_vite.utils import read_bridge_config, read_hotfile_url
+from litestar_vite.utils import read_hotfile_url
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -288,18 +288,14 @@ class ViteProxyMiddleware(AbstractMiddleware):
     def _get_target_base_url(self) -> str | None:
         """Resolve the upstream Vite server URL with permanent caching.
 
-        The hotfile remains the readiness signal — its absence means "Vite is
-        not running, fall through to static". When the hotfile IS present, the
-        bridge config (``.litestar.json``) takes precedence for the target
-        host:port: in ``proxyMode='vite'`` the JS plugin writes the *bridge*
-        URL into the hotfile (post-JS-C4) so the hotfile contents would self-
-        loop the proxy back to Litestar — bridge ``host``+``port`` carry the
-        real Vite endpoint (litestar-vite-c1t).
+        The hotfile is both the readiness signal and the upstream target. Its
+        absence means "Vite is not running, fall through to static". When the
+        hotfile is present, its contents are already the resolved dev-server URL
+        from the frontend side, including scheme, normalized host, and port.
 
         Resolution order:
-            1. Hotfile presence → readiness check; missing → None.
-            2. Bridge config ``host``+``port`` → preferred target.
-            3. Hotfile contents → back-compat fallback.
+            1. Hotfile contents → upstream target.
+            2. Missing hotfile → None.
 
         The result is cached for the lifetime of the middleware instance;
         server restart re-runs the resolution.
@@ -316,21 +312,6 @@ class ViteProxyMiddleware(AbstractMiddleware):
             self._cached_target = None
             self._cache_initialized = True
             return None
-
-        bridge = read_bridge_config()
-        if bridge is not None:
-            host = bridge.get("host")
-            port = bridge.get("port")
-            # Defensive type checks gate the bridge branch — anything else
-            # (missing keys, wrong types, e.g., a stringly-typed port from a
-            # hand-edited config) falls through to hotfile contents.
-            if isinstance(host, str) and host and isinstance(port, int):
-                target = f"http://{host}:{port}"
-                self._cached_target = target
-                self._cache_initialized = True
-                if is_proxy_debug():
-                    console.print(f"[dim][vite-proxy] Target (bridge): {target}[/]")
-                return target.rstrip("/")
 
         self._cached_target = hotfile_url
         self._cache_initialized = True
@@ -438,13 +419,9 @@ def build_hmr_target_url(hotfile_path: Path, scope: dict[str, Any], hmr_path: st
     Vite's HMR WebSocket listens at {base}{hmr.path}, so we preserve
     the full path including the asset prefix (e.g., /static/vite-hmr).
 
-    Resolution order (litestar-vite-c1t):
-        1. Hotfile presence → readiness check; missing → None.
-        2. Bridge config ``host``+``port`` from ``.litestar.json`` — the real
-           Vite host:port. In ``proxyMode='vite'`` the hotfile carries the
-           bridge URL (post-JS-C4) and would otherwise upgrade the WS against
-           Litestar itself.
-        3. Hotfile contents → back-compat fallback.
+    Resolution order:
+        1. Hotfile contents → upstream target.
+        2. Missing hotfile → None.
 
     Returns:
         The target WebSocket URL or None if no source is available.
@@ -454,15 +431,7 @@ def build_hmr_target_url(hotfile_path: Path, scope: dict[str, Any], hmr_path: st
     except FileNotFoundError:
         return None
 
-    vite_url = hotfile_url
-    bridge = read_bridge_config()
-    if bridge is not None:
-        host = bridge.get("host")
-        port = bridge.get("port")
-        if isinstance(host, str) and host and isinstance(port, int):
-            vite_url = f"http://{host}:{port}"
-
-    ws_url = vite_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_url = hotfile_url.replace("http://", "ws://").replace("https://", "wss://")
     original_path = scope.get("path", hmr_path)
     query_string = scope.get("query_string", b"").decode()
 
@@ -676,14 +645,12 @@ def create_hmr_target_getter(
 ) -> "Callable[[], str | None]":
     """Create a function that returns the HMR target URL with permanent caching.
 
-    Resolution order (litestar-vite-c1t):
+    Resolution order:
         1. ``<hotfile>.hmr`` sibling file — JS writes the HMR clientPort
            override here; this MUST win when present (different port than the
            dev server's HTTP port for many configurations).
-        2. Bridge config ``host``+``port`` from ``.litestar.json`` — fallback
-           when no sibling override is in play; in ``proxyMode='vite'`` the
-           plain hotfile points at the bridge URL, so we cannot trust it for
-           the HMR target.
+        2. Main hotfile contents — actual upstream target resolved by the
+           frontend side, preserving scheme and normalized host.
 
     The result is cached for the lifetime of the server; server restart
     refreshes the cache automatically.
@@ -709,18 +676,15 @@ def create_hmr_target_getter(
                 console.print(f"[dim][ssr-proxy] HMR target: {url}[/]")
             return url.rstrip("/")
         except FileNotFoundError:
-            # Sibling missing: fall back to bridge config (real Vite host:port).
-            bridge = read_bridge_config()
-            if bridge is not None:
-                host = bridge.get("host")
-                port = bridge.get("port")
-                if isinstance(host, str) and host and isinstance(port, int):
-                    url = f"http://{host}:{port}"
-                    cached_hmr_target[0] = url
-                    cache_initialized[0] = True
-                    if is_proxy_debug():
-                        console.print(f"[dim][ssr-proxy] HMR target (bridge): {url}[/]")
-                    return url.rstrip("/")
+            try:
+                url = read_hotfile_url(hotfile_path)
+                cached_hmr_target[0] = url
+                cache_initialized[0] = True
+                if is_proxy_debug():
+                    console.print(f"[dim][ssr-proxy] HMR target fallback: {url}[/]")
+                return url.rstrip("/")
+            except FileNotFoundError:
+                pass
             cached_hmr_target[0] = None
             cache_initialized[0] = True
             return None

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -15,7 +15,7 @@ from litestar.exceptions import WebSocketDisconnect
 from litestar.middleware import AbstractMiddleware
 
 from litestar_vite.plugin._utils import console, is_litestar_route, is_proxy_debug, normalize_prefix
-from litestar_vite.utils import read_hotfile_url
+from litestar_vite.utils import read_bridge_config, read_hotfile_url
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -286,16 +286,40 @@ class ViteProxyMiddleware(AbstractMiddleware):
         )
 
     def _get_target_base_url(self) -> str | None:
-        """Read the Vite server URL from the hotfile with permanent caching.
+        """Resolve the upstream Vite server URL with permanent caching.
 
-        The hotfile is read once and cached for the lifetime of the server.
-        Server restart refreshes the cache automatically.
+        Resolution order (litestar-vite-c1t):
+            1. Bridge config ``host``+``port`` from ``.litestar.json`` — the
+               authoritative real Vite host:port. In ``proxyMode='vite'`` the
+               JS plugin's C4 fix writes the *bridge* URL into the hotfile, so
+               the hotfile would otherwise self-loop the proxy back to
+               Litestar.
+            2. Hotfile contents (back-compat for older configs / SSR-style
+               flows where the hotfile still carries an upstream URL).
+
+        The result is cached for the lifetime of the middleware instance;
+        server restart re-runs the resolution.
 
         Returns:
             The Vite server URL or None if unavailable.
         """
         if self._cache_initialized:
             return self._cached_target.rstrip("/") if self._cached_target else None
+
+        bridge = read_bridge_config()
+        if bridge is not None:
+            host = bridge.get("host")
+            port = bridge.get("port")
+            # Defensive type checks gate the bridge branch — anything else
+            # (missing keys, wrong types, e.g., a stringly-typed port from a
+            # hand-edited config) falls through to the hotfile path.
+            if isinstance(host, str) and host and isinstance(port, int):
+                target = f"http://{host}:{port}"
+                self._cached_target = target
+                self._cache_initialized = True
+                if is_proxy_debug():
+                    console.print(f"[dim][vite-proxy] Target (bridge): {target}[/]")
+                return target.rstrip("/")
 
         try:
             url = read_hotfile_url(self.hotfile_path)

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -288,14 +288,18 @@ class ViteProxyMiddleware(AbstractMiddleware):
     def _get_target_base_url(self) -> str | None:
         """Resolve the upstream Vite server URL with permanent caching.
 
-        Resolution order (litestar-vite-c1t):
-            1. Bridge config ``host``+``port`` from ``.litestar.json`` — the
-               authoritative real Vite host:port. In ``proxyMode='vite'`` the
-               JS plugin's C4 fix writes the *bridge* URL into the hotfile, so
-               the hotfile would otherwise self-loop the proxy back to
-               Litestar.
-            2. Hotfile contents (back-compat for older configs / SSR-style
-               flows where the hotfile still carries an upstream URL).
+        The hotfile remains the readiness signal — its absence means "Vite is
+        not running, fall through to static". When the hotfile IS present, the
+        bridge config (``.litestar.json``) takes precedence for the target
+        host:port: in ``proxyMode='vite'`` the JS plugin writes the *bridge*
+        URL into the hotfile (post-JS-C4) so the hotfile contents would self-
+        loop the proxy back to Litestar — bridge ``host``+``port`` carry the
+        real Vite endpoint (litestar-vite-c1t).
+
+        Resolution order:
+            1. Hotfile presence → readiness check; missing → None.
+            2. Bridge config ``host``+``port`` → preferred target.
+            3. Hotfile contents → back-compat fallback.
 
         The result is cached for the lifetime of the middleware instance;
         server restart re-runs the resolution.
@@ -306,13 +310,20 @@ class ViteProxyMiddleware(AbstractMiddleware):
         if self._cache_initialized:
             return self._cached_target.rstrip("/") if self._cached_target else None
 
+        try:
+            hotfile_url = read_hotfile_url(self.hotfile_path)
+        except FileNotFoundError:
+            self._cached_target = None
+            self._cache_initialized = True
+            return None
+
         bridge = read_bridge_config()
         if bridge is not None:
             host = bridge.get("host")
             port = bridge.get("port")
             # Defensive type checks gate the bridge branch — anything else
             # (missing keys, wrong types, e.g., a stringly-typed port from a
-            # hand-edited config) falls through to the hotfile path.
+            # hand-edited config) falls through to hotfile contents.
             if isinstance(host, str) and host and isinstance(port, int):
                 target = f"http://{host}:{port}"
                 self._cached_target = target
@@ -321,17 +332,11 @@ class ViteProxyMiddleware(AbstractMiddleware):
                     console.print(f"[dim][vite-proxy] Target (bridge): {target}[/]")
                 return target.rstrip("/")
 
-        try:
-            url = read_hotfile_url(self.hotfile_path)
-            self._cached_target = url
-            self._cache_initialized = True
-            if is_proxy_debug():
-                console.print(f"[dim][vite-proxy] Target: {url}[/]")
-            return url.rstrip("/")
-        except FileNotFoundError:
-            self._cached_target = None
-            self._cache_initialized = True
-            return None
+        self._cached_target = hotfile_url
+        self._cache_initialized = True
+        if is_proxy_debug():
+            console.print(f"[dim][vite-proxy] Target: {hotfile_url}[/]")
+        return hotfile_url.rstrip("/")
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         scope_dict = cast("dict[str, Any]", scope)
@@ -433,13 +438,29 @@ def build_hmr_target_url(hotfile_path: Path, scope: dict[str, Any], hmr_path: st
     Vite's HMR WebSocket listens at {base}{hmr.path}, so we preserve
     the full path including the asset prefix (e.g., /static/vite-hmr).
 
+    Resolution order (litestar-vite-c1t):
+        1. Hotfile presence → readiness check; missing → None.
+        2. Bridge config ``host``+``port`` from ``.litestar.json`` — the real
+           Vite host:port. In ``proxyMode='vite'`` the hotfile carries the
+           bridge URL (post-JS-C4) and would otherwise upgrade the WS against
+           Litestar itself.
+        3. Hotfile contents → back-compat fallback.
+
     Returns:
-        The target WebSocket URL or None if the hotfile is not found.
+        The target WebSocket URL or None if no source is available.
     """
     try:
-        vite_url = read_hotfile_url(hotfile_path)
+        hotfile_url = read_hotfile_url(hotfile_path)
     except FileNotFoundError:
         return None
+
+    vite_url = hotfile_url
+    bridge = read_bridge_config()
+    if bridge is not None:
+        host = bridge.get("host")
+        port = bridge.get("port")
+        if isinstance(host, str) and host and isinstance(port, int):
+            vite_url = f"http://{host}:{port}"
 
     ws_url = vite_url.replace("http://", "ws://").replace("https://", "wss://")
     original_path = scope.get("path", hmr_path)
@@ -653,12 +674,19 @@ def create_target_url_getter(
 def create_hmr_target_getter(
     hotfile_path: "Path | None", cached_hmr_target: list["str | None"]
 ) -> "Callable[[], str | None]":
-    """Create a function that returns the HMR target URL from hotfile with permanent caching.
+    """Create a function that returns the HMR target URL with permanent caching.
 
-    The hotfile is read once and cached for the lifetime of the server.
-    Server restart refreshes the cache automatically.
+    Resolution order (litestar-vite-c1t):
+        1. ``<hotfile>.hmr`` sibling file — JS writes the HMR clientPort
+           override here; this MUST win when present (different port than the
+           dev server's HTTP port for many configurations).
+        2. Bridge config ``host``+``port`` from ``.litestar.json`` — fallback
+           when no sibling override is in play; in ``proxyMode='vite'`` the
+           plain hotfile points at the bridge URL, so we cannot trust it for
+           the HMR target.
 
-    The JS side writes HMR URLs to a sibling file at ``<hotfile>.hmr``.
+    The result is cached for the lifetime of the server; server restart
+    refreshes the cache automatically.
 
     Returns:
         A callable that returns the HMR target URL or None if unavailable.
@@ -681,6 +709,18 @@ def create_hmr_target_getter(
                 console.print(f"[dim][ssr-proxy] HMR target: {url}[/]")
             return url.rstrip("/")
         except FileNotFoundError:
+            # Sibling missing: fall back to bridge config (real Vite host:port).
+            bridge = read_bridge_config()
+            if bridge is not None:
+                host = bridge.get("host")
+                port = bridge.get("port")
+                if isinstance(host, str) and host and isinstance(port, int):
+                    url = f"http://{host}:{port}"
+                    cached_hmr_target[0] = url
+                    cache_initialized[0] = True
+                    if is_proxy_debug():
+                        console.print(f"[dim][ssr-proxy] HMR target (bridge): {url}[/]")
+                    return url.rstrip("/")
             cached_hmr_target[0] = None
             cache_initialized[0] = True
             return None

--- a/src/py/litestar_vite/utils.py
+++ b/src/py/litestar_vite/utils.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import os
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+from litestar.exceptions import SerializationException
+from litestar.serialization import decode_json
 
 
 def get_package_path(*parts: str) -> Path:
@@ -119,21 +122,18 @@ def read_bridge_config(path: Path | None = None) -> dict[str, Any] | None:
         _BRIDGE_CACHE.pop(key, None)
         return None
 
-    # Defer the msgspec import: ``utils`` is imported during plugin init and we
-    # do not want a hard requirement on a heavy dependency for unrelated callers.
-    import msgspec
-
     try:
-        parsed = msgspec.json.decode(raw)
-    except msgspec.DecodeError:
+        parsed = decode_json(raw)
+    except SerializationException:
         _BRIDGE_CACHE.pop(key, None)
         return None
     if not isinstance(parsed, dict):
         _BRIDGE_CACHE.pop(key, None)
         return None
 
-    _BRIDGE_CACHE[key] = (mtime_ns, parsed)
-    return parsed
+    bridge_config = cast("dict[str, Any]", parsed)
+    _BRIDGE_CACHE[key] = (mtime_ns, bridge_config)
+    return bridge_config
 
 
 def _cache_clear() -> None:

--- a/src/py/litestar_vite/utils.py
+++ b/src/py/litestar_vite/utils.py
@@ -121,7 +121,7 @@ def read_bridge_config(path: Path | None = None) -> dict[str, Any] | None:
 
     # Defer the msgspec import: ``utils`` is imported during plugin init and we
     # do not want a hard requirement on a heavy dependency for unrelated callers.
-    import msgspec  # noqa: PLC0415
+    import msgspec
 
     try:
         parsed = msgspec.json.decode(raw)

--- a/src/py/litestar_vite/utils.py
+++ b/src/py/litestar_vite/utils.py
@@ -1,7 +1,11 @@
 """Utility helpers for litestar-vite."""
 
+from __future__ import annotations
+
+import os
 from importlib.util import find_spec
 from pathlib import Path
+from typing import Any
 
 
 def get_package_path(*parts: str) -> Path:
@@ -52,3 +56,90 @@ def read_hotfile_url(hotfile_path: Path) -> str:
         The Vite server URL from the hotfile, stripped of surrounding whitespace.
     """
     return read_text_file(hotfile_path).strip()
+
+
+# Per-process cache for ``read_bridge_config``: ``{resolved_path: (mtime_ns, parsed_dict)}``.
+# Strategy: mtime-based revalidation per call (Decision Point 1 option (a)).
+# The ``Path.stat()`` cost is sub-microsecond; in exchange we kill the entire class of
+# "stale cache after dev restart" bugs and avoid forcing tests to call ``cache_clear``.
+_BRIDGE_CACHE: dict[str, tuple[int, dict[str, Any]]] = {}
+
+
+def _resolve_bridge_path(path: Path | None) -> Path:
+    """Resolve which ``.litestar.json`` to read.
+
+    Resolution order:
+        1. Explicit ``path`` argument when provided.
+        2. ``LITESTAR_VITE_CONFIG_PATH`` env var when set.
+        3. ``<cwd>/.litestar.json``.
+    """
+    if path is not None:
+        return path
+    env_path = os.environ.get("LITESTAR_VITE_CONFIG_PATH")
+    if env_path:
+        return Path(env_path)
+    return Path.cwd() / ".litestar.json"
+
+
+def read_bridge_config(path: Path | None = None) -> dict[str, Any] | None:
+    """Read the Litestar/Vite bridge config (``.litestar.json``).
+
+    Resolution order for ``path``:
+        1. Explicit ``path`` argument when provided.
+        2. ``LITESTAR_VITE_CONFIG_PATH`` env var when set.
+        3. ``<cwd>/.litestar.json``.
+
+    Returns:
+        The parsed JSON object as a dict, or ``None`` if the file is missing,
+        unreadable, or does not parse as a JSON object.
+
+    Caching:
+        Per-process result cache keyed by resolved path; invalidated on mtime
+        change (a single ``Path.stat()`` per call). Use
+        ``read_bridge_config.cache_clear()`` in tests when the cache must be
+        flushed independently of mtime (e.g., when forcing the same path to be
+        re-parsed without advancing its mtime).
+    """
+    resolved = _resolve_bridge_path(path)
+    key = str(resolved)
+    try:
+        stat = resolved.stat()
+    except (FileNotFoundError, OSError):
+        _BRIDGE_CACHE.pop(key, None)
+        return None
+
+    mtime_ns = stat.st_mtime_ns
+    cached = _BRIDGE_CACHE.get(key)
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1]
+
+    try:
+        raw = resolved.read_bytes()
+    except (FileNotFoundError, OSError):
+        _BRIDGE_CACHE.pop(key, None)
+        return None
+
+    # Defer the msgspec import: ``utils`` is imported during plugin init and we
+    # do not want a hard requirement on a heavy dependency for unrelated callers.
+    import msgspec  # noqa: PLC0415
+
+    try:
+        parsed = msgspec.json.decode(raw)
+    except msgspec.DecodeError:
+        _BRIDGE_CACHE.pop(key, None)
+        return None
+    if not isinstance(parsed, dict):
+        _BRIDGE_CACHE.pop(key, None)
+        return None
+
+    _BRIDGE_CACHE[key] = (mtime_ns, parsed)
+    return parsed
+
+
+def _cache_clear() -> None:
+    """Drop the per-process bridge-config cache (test helper)."""
+    _BRIDGE_CACHE.clear()
+
+
+# Mirror ``functools.lru_cache``'s ``cache_clear`` attribute for ergonomic test use.
+read_bridge_config.cache_clear = _cache_clear  # type: ignore[attr-defined]

--- a/src/py/tests/conftest.py
+++ b/src/py/tests/conftest.py
@@ -25,19 +25,35 @@ _VITE_ENV_VARS = [
     "LITESTAR_PORT",
     "LITESTAR_DEBUG",
     "ASSET_URL",
+    # litestar-vite-c1t: bridge config path leaks across tests; force a
+    # guaranteed-missing default so consumers fall back to legacy hotfile
+    # semantics unless a test explicitly opts in.
+    "LITESTAR_VITE_CONFIG_PATH",
 ]
 
 
 @pytest.fixture(autouse=True)
-def clean_vite_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
-    """Clear Vite-related environment variables before each test for isolation.
+def clean_vite_env(
+    tmp_path_factory: TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> Generator[None, None, None]:
+    """Clear Vite-related env vars and bridge cache before each test for isolation.
+
+    Also points ``LITESTAR_VITE_CONFIG_PATH`` at a guaranteed-missing path so
+    the bridge-config CWD fallback never picks up a developer's stray
+    ``.litestar.json`` from the repo root mid-test.
 
     Returns:
         The result.
     """
+    from litestar_vite.utils import read_bridge_config
+
     for var in _VITE_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
+    sentinel = tmp_path_factory.mktemp("no-bridge") / "missing.json"
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(sentinel))
+    read_bridge_config.cache_clear()
     yield
+    read_bridge_config.cache_clear()
 
 
 @pytest.fixture

--- a/src/py/tests/conftest.py
+++ b/src/py/tests/conftest.py
@@ -33,9 +33,7 @@ _VITE_ENV_VARS = [
 
 
 @pytest.fixture(autouse=True)
-def clean_vite_env(
-    tmp_path_factory: TempPathFactory, monkeypatch: pytest.MonkeyPatch
-) -> Generator[None, None, None]:
+def clean_vite_env(tmp_path_factory: TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
     """Clear Vite-related env vars and bridge cache before each test for isolation.
 
     Also points ``LITESTAR_VITE_CONFIG_PATH`` at a guaranteed-missing path so

--- a/src/py/tests/e2e/test_dev_mode.py
+++ b/src/py/tests/e2e/test_dev_mode.py
@@ -4,13 +4,16 @@ Tests use `litestar assets serve` + `litestar run` to start the dev environment.
 This ensures we test the real developer experience via the Litestar CLI.
 """
 
+import re
+from collections.abc import Generator
+
 import httpx
 import pytest
 
 from .assertions import assert_html_contains_assets
-from .conftest import E2E_TEST_TIMEOUT
+from .conftest import E2E_TEST_TIMEOUT, _dev_servers
 from .health_check import check_api_response, check_html_response
-from .server_manager import ExampleServer
+from .server_manager import EXAMPLE_PORTS, ExampleServer
 
 pytestmark = [pytest.mark.e2e, pytest.mark.timeout(E2E_TEST_TIMEOUT)]
 
@@ -39,3 +42,83 @@ def test_dev_mode_api_summary(dev_mode_server: ExampleServer) -> None:
     base_url = f"http://127.0.0.1:{dev_mode_server.litestar_port}"
     response = httpx.get(f"{base_url}/api/summary", timeout=10.0)
     check_api_response(response)
+
+
+# ===== Bridge-source-of-truth E2E (litestar-vite-c1t) =====
+#
+# These tests use a focused fixture rather than the parametrized `dev_mode_server`
+# because the bridge contract is specific to template-mode (proxyMode='vite').
+# We pin to `jinja-htmx` as a representative single-port template-mode example.
+
+
+_BRIDGE_E2E_EXAMPLE = "jinja-htmx"
+
+
+@pytest.fixture
+def jinja_htmx_dev_server() -> Generator[ExampleServer, None, None]:
+    """Start (or reuse) the jinja-htmx example in dev mode.
+
+    Uses the same caching strategy as ``dev_mode_server`` so successive tests
+    share the running server (avoids port conflicts from TIME_WAIT).
+    """
+    name = _BRIDGE_E2E_EXAMPLE
+    if name in _dev_servers:
+        server = _dev_servers[name]
+        try:
+            server._check_processes_alive()
+            yield server
+            return
+        except RuntimeError:
+            del _dev_servers[name]
+
+    server = ExampleServer(name)
+    server.start_dev_mode()
+    server.wait_until_ready(timeout=float(E2E_TEST_TIMEOUT))
+    _dev_servers[name] = server
+    yield server
+
+
+@pytest.mark.timeout(E2E_TEST_TIMEOUT)
+def test_dev_mode_vite_client_proxies_within_1s(jinja_htmx_dev_server: ExampleServer) -> None:
+    """``/static/@vite/client`` MUST proxy through to Vite within 1 second.
+
+    Pre-fix the proxy self-looped to Litestar (hotfile pointed at the bridge
+    URL post-JS-C4), exhausting the httpx 10s default. This SLA codifies the
+    fix.
+    """
+    base_url = f"http://127.0.0.1:{jinja_htmx_dev_server.litestar_port}"
+    response = httpx.get(f"{base_url}/static/@vite/client", timeout=2.0)
+
+    assert response.status_code == 200, f"unexpected status {response.status_code}: {response.text[:200]}"
+    elapsed = response.elapsed.total_seconds()
+    assert elapsed < 1.0, f"@vite/client took {elapsed:.3f}s (SLA 1.0s — likely a self-loop regression)"
+
+
+@pytest.mark.timeout(E2E_TEST_TIMEOUT)
+def test_dev_mode_html_anchors_on_litestar_origin(jinja_htmx_dev_server: ExampleServer) -> None:
+    """All HTML asset references must be relative or anchored on the Litestar origin.
+
+    No script/link reference may leak the raw Vite port — that would mean the
+    bridge config isn't being honored on the loader side.
+    """
+    base_url = f"http://127.0.0.1:{jinja_htmx_dev_server.litestar_port}"
+    response = httpx.get(f"{base_url}/", timeout=10.0)
+    response.raise_for_status()
+    html = response.text
+
+    refs: list[str] = []
+    refs.extend(re.findall(r"""<script[^>]*\bsrc=["']([^"']+)["']""", html))
+    refs.extend(re.findall(r"""<link[^>]*\bhref=["']([^"']+)["']""", html))
+    assert refs, "page rendered no <script src> or <link href> references"
+
+    vite_port = EXAMPLE_PORTS[_BRIDGE_E2E_EXAMPLE]
+    litestar_origin = f"http://127.0.0.1:{jinja_htmx_dev_server.litestar_port}"
+
+    for ref in refs:
+        if ref.startswith("/"):
+            continue
+        # Reject any reference to the Vite port directly.
+        assert f":{vite_port}" not in ref, f"asset reference leaks Vite port: {ref}"
+        # Absolute URLs must anchor on the Litestar origin.
+        if ref.startswith(("http://", "https://")):
+            assert ref.startswith(litestar_origin), f"asset reference leaks non-Litestar origin: {ref}"

--- a/src/py/tests/integration/test_bridge_contract.py
+++ b/src/py/tests/integration/test_bridge_contract.py
@@ -1,0 +1,116 @@
+"""End-to-end regression for the bridge-as-source-of-truth contract.
+
+Litestar-vite-c1t: ``ViteAssetLoader`` (loader) and ``ViteProxyMiddleware``
+(proxy) read the bridge config (``.litestar.json``) for different fields:
+
+- Loader anchors emitted asset URLs at ``appUrl`` (the bridge URL), keeping
+  asset references on the single ASGI port.
+- Proxy targets the real Vite ``host``/``port``, so when the loader-emitted
+  URL hits Litestar's ``/static/...`` prefix it gets forwarded to the actual
+  Vite dev server (not back to Litestar — that self-loop produced 10s
+  timeouts before this fix).
+
+This test asserts both halves end-to-end with a stub upstream so the regression
+cannot reappear silently.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from litestar_vite import PathConfig, RuntimeConfig, ViteConfig, VitePlugin
+
+if TYPE_CHECKING:
+    pass
+
+
+@pytest.mark.anyio
+async def test_proxy_loader_dual_consumer_no_self_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Loader anchors on bridge appUrl AND proxy hits real Vite host:port.
+
+    Failure mode without the fix: with proxyMode='vite' the JS plugin writes
+    the bridge URL into the hotfile. Both consumers read the hotfile, both end
+    up pointing at the bridge URL, and the proxy self-loops to Litestar.
+    """
+    from litestar_vite.utils import read_bridge_config
+
+    read_bridge_config.cache_clear()
+
+    # ----- Bridge: real Vite host/port + bridge appUrl -----
+    bridge_payload = {
+        "appUrl": "http://testserver",
+        "host": "127.0.0.1",
+        "port": 65431,
+    }
+    bridge_path = tmp_path / ".litestar.json"
+    bridge_path.write_text(json.dumps(bridge_payload))
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge_path))
+
+    # ----- Hotfile: present (readiness signal) but pointing at the bridge URL,
+    # mirroring the JS plugin's C4 behavior in proxyMode='vite' -----
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+    (bundle_dir / "hot").write_text("http://testserver")
+
+    # ----- Stub upstream: returns a sentinel body for the @vite/client request,
+    # records the absolute URL it was called against so we can assert no self-loop.
+    upstream_calls: list[str] = []
+
+    def _upstream_handler(request: httpx.Request) -> httpx.Response:
+        upstream_calls.append(str(request.url))
+        return httpx.Response(200, headers={"content-type": "text/javascript"}, text="// real-vite-stub")
+
+    transport = httpx.MockTransport(_upstream_handler)
+
+    # ----- Build app -----
+    config = ViteConfig(
+        mode="template",
+        paths=PathConfig(
+            root=tmp_path,
+            resource_dir=tmp_path / "resources",
+            bundle_dir=bundle_dir,
+            asset_url="/static/",
+        ),
+        runtime=RuntimeConfig(
+            dev_mode=True, host="127.0.0.1", port=65431, set_environment=False
+        ),
+    )
+    plugin = VitePlugin(config=config)
+    app = Litestar(plugins=[plugin])
+
+    # ----- Loader half: bridge appUrl wins, asset emission anchored on testserver -----
+    loader = plugin.asset_loader
+    asset_url = loader._vite_server_url("@vite/client")
+    assert asset_url.startswith("http://testserver/"), asset_url
+    assert "127.0.0.1:65431" not in asset_url
+
+    # ----- Proxy half: drive a request through the middleware, swap in the
+    # stub-transport client so we can intercept the upstream call.
+    with TestClient(app=app) as client:
+        # Inject the mock transport into the plugin's shared proxy client.
+        # The lifespan has just initialized self._proxy_client; replace it.
+        if plugin._proxy_client is not None:
+            await plugin._proxy_client.aclose()
+        plugin._proxy_client = httpx.AsyncClient(transport=transport)
+
+        response = client.get("/static/@vite/client")
+
+    assert response.status_code == 200, response.text
+    assert response.text == "// real-vite-stub"
+    assert len(upstream_calls) == 1, upstream_calls
+    target_url = upstream_calls[0]
+    # The upstream MUST be the real Vite host:port from the bridge — not the
+    # bridge appUrl (testserver). Otherwise the proxy is self-looping.
+    assert target_url.startswith("http://127.0.0.1:65431"), target_url
+    assert "testserver" not in target_url
+
+    read_bridge_config.cache_clear()

--- a/src/py/tests/integration/test_bridge_contract.py
+++ b/src/py/tests/integration/test_bridge_contract.py
@@ -1,14 +1,13 @@
 """End-to-end regression for the bridge-as-source-of-truth contract.
 
 Litestar-vite-c1t: ``ViteAssetLoader`` (loader) and ``ViteProxyMiddleware``
-(proxy) read the bridge config (``.litestar.json``) for different fields:
+(proxy) intentionally use different source-of-truth files:
 
 - Loader anchors emitted asset URLs at ``appUrl`` (the bridge URL), keeping
   asset references on the single ASGI port.
-- Proxy targets the real Vite ``host``/``port``, so when the loader-emitted
-  URL hits Litestar's ``/static/...`` prefix it gets forwarded to the actual
-  Vite dev server (not back to Litestar — that self-loop produced 10s
-  timeouts before this fix).
+- Proxy targets the hotfile's actual resolved Vite URL, so when the
+  loader-emitted URL hits Litestar's ``/static/...`` prefix it gets forwarded
+  to the actual Vite dev server (not back to Litestar).
 
 This test asserts both halves end-to-end with a stub upstream so the regression
 cannot reappear silently.
@@ -32,34 +31,28 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.anyio
-async def test_proxy_loader_dual_consumer_no_self_loop(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Loader anchors on bridge appUrl AND proxy hits real Vite host:port.
+async def test_proxy_loader_dual_consumer_no_self_loop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loader anchors on bridge appUrl AND proxy hits the hotfile upstream.
 
-    Failure mode without the fix: with proxyMode='vite' the JS plugin writes
-    the bridge URL into the hotfile. Both consumers read the hotfile, both end
-    up pointing at the bridge URL, and the proxy self-loops to Litestar.
+    Failure mode before the contract split: the hotfile could carry the bridge
+    URL while both consumers read it. The revised contract keeps the loader on
+    bridge ``appUrl`` and keeps the proxy on the hotfile's actual upstream URL.
     """
     from litestar_vite.utils import read_bridge_config
 
     read_bridge_config.cache_clear()
 
-    # ----- Bridge: real Vite host/port + bridge appUrl -----
-    bridge_payload = {
-        "appUrl": "http://testserver",
-        "host": "127.0.0.1",
-        "port": 65431,
-    }
+    # ----- Bridge: browser-facing appUrl; host/port must not become target. -----
+    bridge_payload = {"appUrl": "http://testserver", "host": "127.0.0.1", "port": 65431}
     bridge_path = tmp_path / ".litestar.json"
     bridge_path.write_text(json.dumps(bridge_payload))
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge_path))
 
-    # ----- Hotfile: present (readiness signal) but pointing at the bridge URL,
-    # mirroring the JS plugin's C4 behavior in proxyMode='vite' -----
+    # ----- Hotfile: present (readiness signal) and pointing at the actual Vite
+    # upstream URL. The loader must not use this as the browser-facing origin. -----
     bundle_dir = tmp_path / "public"
     bundle_dir.mkdir()
-    (bundle_dir / "hot").write_text("http://testserver")
+    (bundle_dir / "hot").write_text("http://127.0.0.1:65431")
 
     # ----- Stub upstream: returns a sentinel body for the @vite/client request,
     # records the absolute URL it was called against so we can assert no self-loop.
@@ -75,14 +68,9 @@ async def test_proxy_loader_dual_consumer_no_self_loop(
     config = ViteConfig(
         mode="template",
         paths=PathConfig(
-            root=tmp_path,
-            resource_dir=tmp_path / "resources",
-            bundle_dir=bundle_dir,
-            asset_url="/static/",
+            root=tmp_path, resource_dir=tmp_path / "resources", bundle_dir=bundle_dir, asset_url="/static/"
         ),
-        runtime=RuntimeConfig(
-            dev_mode=True, host="127.0.0.1", port=65431, set_environment=False
-        ),
+        runtime=RuntimeConfig(dev_mode=True, host="127.0.0.1", port=65431, set_environment=False),
     )
     plugin = VitePlugin(config=config)
     app = Litestar(plugins=[plugin])
@@ -108,8 +96,8 @@ async def test_proxy_loader_dual_consumer_no_self_loop(
     assert response.text == "// real-vite-stub"
     assert len(upstream_calls) == 1, upstream_calls
     target_url = upstream_calls[0]
-    # The upstream MUST be the real Vite host:port from the bridge — not the
-    # bridge appUrl (testserver). Otherwise the proxy is self-looping.
+    # The upstream MUST be the hotfile's actual Vite URL, not the bridge appUrl
+    # (testserver). Otherwise the proxy is self-looping.
     assert target_url.startswith("http://127.0.0.1:65431"), target_url
     assert "testserver" not in target_url
 

--- a/src/py/tests/unit/test_asset_loader.py
+++ b/src/py/tests/unit/test_asset_loader.py
@@ -115,7 +115,7 @@ def test_generate_asset_tags_dev_mode_rereads_hotfile_when_initially_missing(tmp
     loader = ViteAssetLoader.initialize_loader(config)
     assert loader._vite_base_path is None
 
-    # Simulate the JS plugin writing the bridge URL after Vite has started.
+    # Simulate the JS plugin writing the resolved Vite URL after Vite has started.
     (bundle_dir / "hot").write_text("http://localhost:5006")
 
     tags = loader.generate_asset_tags("src/main.js")
@@ -252,29 +252,22 @@ def _write_bridge_config(tmp_path: Path, payload: object) -> Path:
     return bridge
 
 
-def test_vite_server_url_prefers_bridge_appurl_over_hotfile(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_vite_server_url_prefers_bridge_appurl_over_hotfile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Bridge appUrl beats the hotfile for the loader-side anchor URL.
 
-    This is the dual-consumer-conflict resolution test on the loader side: the
-    JS plugin's C4 fix writes the bridge URL into the hotfile in
-    proxyMode='vite', but here we assert that even when the hotfile carries the
-    real Vite origin, the bridge appUrl wins.
+    This is the dual-consumer-conflict resolution test on the loader side: even
+    when the hotfile carries the real Vite origin for proxy/HMR consumers, the
+    bridge appUrl wins for browser-facing asset emission.
     """
     read_bridge_config.cache_clear()
     bundle_dir = tmp_path / "public"
     bundle_dir.mkdir()
     (bundle_dir / "hot").write_text("http://127.0.0.1:9999")
-    bridge = _write_bridge_config(
-        tmp_path,
-        {"appUrl": "http://localhost:8000", "host": "127.0.0.1", "port": 9999},
-    )
+    bridge = _write_bridge_config(tmp_path, {"appUrl": "http://localhost:8000", "host": "127.0.0.1", "port": 9999})
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
     config = ViteConfig(
-        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
-        runtime=RuntimeConfig(dev_mode=True),
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"), runtime=RuntimeConfig(dev_mode=True)
     )
     loader = ViteAssetLoader.initialize_loader(config)
 
@@ -295,8 +288,7 @@ def test_vite_server_url_falls_back_to_hotfile_when_bridge_missing(
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
 
     config = ViteConfig(
-        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
-        runtime=RuntimeConfig(dev_mode=True),
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"), runtime=RuntimeConfig(dev_mode=True)
     )
     loader = ViteAssetLoader.initialize_loader(config)
 
@@ -326,9 +318,7 @@ def test_vite_server_url_falls_back_to_host_port_when_neither_present(
     read_bridge_config.cache_clear()
 
 
-def test_vite_server_url_ignores_bridge_when_appurl_null(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_vite_server_url_ignores_bridge_when_appurl_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Real-world: backend env vars not set → bridge writer emits ``appUrl: null``."""
     read_bridge_config.cache_clear()
     bundle_dir = tmp_path / "public"
@@ -338,8 +328,7 @@ def test_vite_server_url_ignores_bridge_when_appurl_null(
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
     config = ViteConfig(
-        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
-        runtime=RuntimeConfig(dev_mode=True),
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"), runtime=RuntimeConfig(dev_mode=True)
     )
     loader = ViteAssetLoader.initialize_loader(config)
 

--- a/src/py/tests/unit/test_asset_loader.py
+++ b/src/py/tests/unit/test_asset_loader.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -6,6 +7,7 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar_vite.config import PathConfig, RuntimeConfig, ViteConfig
 from litestar_vite.exceptions import AssetNotFoundError
 from litestar_vite.loader import ViteAssetLoader
+from litestar_vite.utils import read_bridge_config
 
 
 def test_parse_manifest_when_file_exists(tmp_path: Path) -> None:
@@ -239,3 +241,109 @@ async def test_async_initialization_dev_mode(tmp_path: Path) -> None:
 
     assert loader._vite_base_path == "http://localhost:3000"
     assert loader._initialized is True
+
+
+# ===== Bridge-config preference (litestar-vite-c1t) =====
+
+
+def _write_bridge_config(tmp_path: Path, payload: object) -> Path:
+    bridge = tmp_path / ".litestar.json"
+    bridge.write_text(json.dumps(payload))
+    return bridge
+
+
+def test_vite_server_url_prefers_bridge_appurl_over_hotfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bridge appUrl beats the hotfile for the loader-side anchor URL.
+
+    This is the dual-consumer-conflict resolution test on the loader side: the
+    JS plugin's C4 fix writes the bridge URL into the hotfile in
+    proxyMode='vite', but here we assert that even when the hotfile carries the
+    real Vite origin, the bridge appUrl wins.
+    """
+    read_bridge_config.cache_clear()
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+    (bundle_dir / "hot").write_text("http://127.0.0.1:9999")
+    bridge = _write_bridge_config(
+        tmp_path,
+        {"appUrl": "http://localhost:8000", "host": "127.0.0.1", "port": 9999},
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    config = ViteConfig(
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
+        runtime=RuntimeConfig(dev_mode=True),
+    )
+    loader = ViteAssetLoader.initialize_loader(config)
+
+    url = loader._vite_server_url("foo.ts")
+
+    assert url.startswith("http://localhost:8000"), url
+    assert "127.0.0.1:9999" not in url
+    read_bridge_config.cache_clear()
+
+
+def test_vite_server_url_falls_back_to_hotfile_when_bridge_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    read_bridge_config.cache_clear()
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+    (bundle_dir / "hot").write_text("http://hot:5006")
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
+
+    config = ViteConfig(
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
+        runtime=RuntimeConfig(dev_mode=True),
+    )
+    loader = ViteAssetLoader.initialize_loader(config)
+
+    url = loader._vite_server_url("main.js")
+
+    assert url.startswith("http://hot:5006"), url
+    read_bridge_config.cache_clear()
+
+
+def test_vite_server_url_falls_back_to_host_port_when_neither_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Neither bridge nor hotfile: legacy ``protocol://host:port`` fallback wins.
+
+    Mirrors the contract asserted by ``test_generate_asset_tags_dev_mode`` but
+    pinned to ``_vite_server_url`` directly so a regression here is unambiguous.
+    """
+    read_bridge_config.cache_clear()
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
+
+    config = ViteConfig(paths=PathConfig(bundle_dir=tmp_path), runtime=RuntimeConfig(dev_mode=True))
+    loader = ViteAssetLoader(config)
+
+    url = loader._vite_server_url("main.js")
+
+    assert url.startswith("http://127.0.0.1:5173"), url
+    read_bridge_config.cache_clear()
+
+
+def test_vite_server_url_ignores_bridge_when_appurl_null(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real-world: backend env vars not set → bridge writer emits ``appUrl: null``."""
+    read_bridge_config.cache_clear()
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+    (bundle_dir / "hot").write_text("http://hot:5006")
+    bridge = _write_bridge_config(tmp_path, {"appUrl": None, "host": "127.0.0.1", "port": 5173})
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    config = ViteConfig(
+        paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
+        runtime=RuntimeConfig(dev_mode=True),
+    )
+    loader = ViteAssetLoader.initialize_loader(config)
+
+    url = loader._vite_server_url("main.js")
+
+    assert url.startswith("http://hot:5006"), url
+    read_bridge_config.cache_clear()

--- a/src/py/tests/unit/test_bridge_config.py
+++ b/src/py/tests/unit/test_bridge_config.py
@@ -16,7 +16,6 @@ import pytest
 
 from litestar_vite.utils import read_bridge_config
 
-
 # ===== Fixtures and helpers =====
 
 

--- a/src/py/tests/unit/test_bridge_config.py
+++ b/src/py/tests/unit/test_bridge_config.py
@@ -1,8 +1,8 @@
 """Tests for ``litestar_vite.utils.read_bridge_config`` (litestar-vite-c1t.1).
 
-The bridge config (``.litestar.json``) is the single source of truth for URL
-fields consumed by both the loader and the Vite-mode proxy middleware. This
-helper resolves and parses that file with mtime-based caching.
+The bridge config (``.litestar.json``) is the source of truth for browser-facing
+bridge fields such as ``appUrl``. This helper resolves and parses that file with
+mtime-based caching.
 """
 
 from __future__ import annotations
@@ -33,12 +33,9 @@ def _write_bridge(path: Path, payload: object) -> Path:
 # ===== File-presence and shape =====
 
 
-def test_read_bridge_config_returns_dict_when_file_exists(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_returns_dict_when_file_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bridge = _write_bridge(
-        tmp_path / ".litestar.json",
-        {"appUrl": "http://localhost:8000", "host": "127.0.0.1", "port": 5173},
+        tmp_path / ".litestar.json", {"appUrl": "http://localhost:8000", "host": "127.0.0.1", "port": 5173}
     )
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
@@ -50,17 +47,13 @@ def test_read_bridge_config_returns_dict_when_file_exists(
     assert result["port"] == 5173
 
 
-def test_read_bridge_config_returns_none_when_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_returns_none_when_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "does-not-exist.json"))
 
     assert read_bridge_config() is None
 
 
-def test_read_bridge_config_returns_none_when_malformed_json(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_returns_none_when_malformed_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bridge = tmp_path / ".litestar.json"
     bridge.write_text("not json{")
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
@@ -68,9 +61,7 @@ def test_read_bridge_config_returns_none_when_malformed_json(
     assert read_bridge_config() is None
 
 
-def test_read_bridge_config_returns_none_when_not_object(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_returns_none_when_not_object(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bridge = _write_bridge(tmp_path / ".litestar.json", [1, 2, 3])
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
@@ -80,9 +71,7 @@ def test_read_bridge_config_returns_none_when_not_object(
 # ===== Path resolution order =====
 
 
-def test_read_bridge_config_resolution_explicit_arg_wins(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_resolution_explicit_arg_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     file_a = _write_bridge(tmp_path / "a.json", {"appUrl": "http://a", "host": "a", "port": 1})
     file_b = _write_bridge(tmp_path / "b.json", {"appUrl": "http://b", "host": "b", "port": 2})
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(file_a))
@@ -93,9 +82,7 @@ def test_read_bridge_config_resolution_explicit_arg_wins(
     assert result["appUrl"] == "http://b"
 
 
-def test_read_bridge_config_resolution_env_var_then_cwd(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_resolution_env_var_then_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LITESTAR_VITE_CONFIG_PATH", raising=False)
     _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://cwd", "host": "h", "port": 3})
     monkeypatch.chdir(tmp_path)
@@ -109,29 +96,27 @@ def test_read_bridge_config_resolution_env_var_then_cwd(
 # ===== Caching behavior =====
 
 
-def test_read_bridge_config_cache_hit_skips_file_io(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_cache_hit_skips_file_io(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A cache hit must avoid re-parsing JSON (NFR2).
 
     The mtime-revalidation strategy (DP1 option (a)) still performs a single
     ``Path.stat()`` per call to detect changes — but no read or decode should
     occur when the mtime is unchanged.
     """
-    import msgspec
+    import litestar_vite.utils as utils
 
     bridge = _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://cached", "host": "h", "port": 4})
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
     decode_count = 0
-    real_decode = msgspec.json.decode
+    real_decode = utils.decode_json
 
-    def counting_decode(*args: object, **kwargs: object) -> object:
+    def counting_decode(value: str | bytes) -> object:
         nonlocal decode_count
         decode_count += 1
-        return real_decode(*args, **kwargs)
+        return real_decode(value)
 
-    monkeypatch.setattr(msgspec.json, "decode", counting_decode)
+    monkeypatch.setattr(utils, "decode_json", counting_decode)
 
     first = read_bridge_config()
     second = read_bridge_config()
@@ -142,9 +127,7 @@ def test_read_bridge_config_cache_hit_skips_file_io(
     assert decode_count == 1
 
 
-def test_read_bridge_config_cache_invalidated_on_mtime_change(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_read_bridge_config_cache_invalidated_on_mtime_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bridge = _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://before", "host": "h", "port": 5})
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 

--- a/src/py/tests/unit/test_bridge_config.py
+++ b/src/py/tests/unit/test_bridge_config.py
@@ -1,0 +1,182 @@
+"""Tests for ``litestar_vite.utils.read_bridge_config`` (litestar-vite-c1t.1).
+
+The bridge config (``.litestar.json``) is the single source of truth for URL
+fields consumed by both the loader and the Vite-mode proxy middleware. This
+helper resolves and parses that file with mtime-based caching.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from litestar_vite.utils import read_bridge_config
+
+
+# ===== Fixtures and helpers =====
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    """Reset the per-process cache between tests to keep cases independent."""
+    read_bridge_config.cache_clear()
+
+
+def _write_bridge(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload))
+    return path
+
+
+# ===== File-presence and shape =====
+
+
+def test_read_bridge_config_returns_dict_when_file_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = _write_bridge(
+        tmp_path / ".litestar.json",
+        {"appUrl": "http://localhost:8000", "host": "127.0.0.1", "port": 5173},
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    result = read_bridge_config()
+
+    assert isinstance(result, dict)
+    assert result["appUrl"] == "http://localhost:8000"
+    assert result["host"] == "127.0.0.1"
+    assert result["port"] == 5173
+
+
+def test_read_bridge_config_returns_none_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "does-not-exist.json"))
+
+    assert read_bridge_config() is None
+
+
+def test_read_bridge_config_returns_none_when_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = tmp_path / ".litestar.json"
+    bridge.write_text("not json{")
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    assert read_bridge_config() is None
+
+
+def test_read_bridge_config_returns_none_when_not_object(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = _write_bridge(tmp_path / ".litestar.json", [1, 2, 3])
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    assert read_bridge_config() is None
+
+
+# ===== Path resolution order =====
+
+
+def test_read_bridge_config_resolution_explicit_arg_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_a = _write_bridge(tmp_path / "a.json", {"appUrl": "http://a", "host": "a", "port": 1})
+    file_b = _write_bridge(tmp_path / "b.json", {"appUrl": "http://b", "host": "b", "port": 2})
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(file_a))
+
+    result = read_bridge_config(file_b)
+
+    assert result is not None
+    assert result["appUrl"] == "http://b"
+
+
+def test_read_bridge_config_resolution_env_var_then_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("LITESTAR_VITE_CONFIG_PATH", raising=False)
+    _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://cwd", "host": "h", "port": 3})
+    monkeypatch.chdir(tmp_path)
+
+    result = read_bridge_config()
+
+    assert result is not None
+    assert result["appUrl"] == "http://cwd"
+
+
+# ===== Caching behavior =====
+
+
+def test_read_bridge_config_cache_hit_skips_file_io(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cache hit must avoid re-parsing JSON (NFR2).
+
+    The mtime-revalidation strategy (DP1 option (a)) still performs a single
+    ``Path.stat()`` per call to detect changes — but no read or decode should
+    occur when the mtime is unchanged.
+    """
+    import msgspec
+
+    bridge = _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://cached", "host": "h", "port": 4})
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    decode_count = 0
+    real_decode = msgspec.json.decode
+
+    def counting_decode(*args: object, **kwargs: object) -> object:
+        nonlocal decode_count
+        decode_count += 1
+        return real_decode(*args, **kwargs)
+
+    monkeypatch.setattr(msgspec.json, "decode", counting_decode)
+
+    first = read_bridge_config()
+    second = read_bridge_config()
+
+    assert first == second
+    assert second is not None
+    assert second["appUrl"] == "http://cached"
+    assert decode_count == 1
+
+
+def test_read_bridge_config_cache_invalidated_on_mtime_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge = _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://before", "host": "h", "port": 5})
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    first = read_bridge_config()
+    assert first is not None
+    assert first["appUrl"] == "http://before"
+
+    _write_bridge(bridge, {"appUrl": "http://after", "host": "h", "port": 5})
+    # Ensure mtime advances even on coarse-resolution filesystems.
+    future = time.time() + 5
+    os.utime(bridge, (future, future))
+
+    second = read_bridge_config()
+
+    assert second is not None
+    assert second["appUrl"] == "http://after"
+
+
+def test_read_bridge_config_cache_clear(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bridge = _write_bridge(tmp_path / ".litestar.json", {"appUrl": "http://one", "host": "h", "port": 6})
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    first = read_bridge_config()
+    assert first is not None
+    assert first["appUrl"] == "http://one"
+
+    _write_bridge(bridge, {"appUrl": "http://two", "host": "h", "port": 6})
+    read_bridge_config.cache_clear()
+    # Force mtime backwards so only cache_clear (not mtime detection) accounts for the re-read.
+    os.utime(bridge, (0, 0))
+
+    second = read_bridge_config()
+    assert second is not None
+    assert second["appUrl"] == "http://two"

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -145,13 +145,21 @@ def test_extract_proxy_response_filters_headers() -> None:
     assert body == b"ok"
 
 
-def test_build_hmr_target_url_includes_query(tmp_path: Path) -> None:
+def test_build_hmr_target_url_includes_query(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hotfile-only fallback: bridge cleared so legacy hotfile semantics apply."""
+    from litestar_vite.utils import read_bridge_config
+
+    read_bridge_config.cache_clear()
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "no-bridge.json"))
     hotfile = tmp_path / "hot"
     hotfile.write_text("http://localhost:5173")
     scope = {"path": "/vite-hmr", "query_string": b"token=1"}
 
     target = build_hmr_target_url(hotfile, scope, "/vite-hmr", "/static/")
     assert target == "ws://localhost:5173/vite-hmr?token=1"
+    read_bridge_config.cache_clear()
 
 
 def test_extract_headers_and_subprotocols() -> None:
@@ -785,3 +793,83 @@ def test_get_litestar_route_prefixes_excludes_websocket_only_routes() -> None:
     assert "/{path:path}" not in prefixes, (
         f"WebSocket-only '/{{path:path}}' must not appear in HTTP route prefixes; got {prefixes}"
     )
+
+
+# ===== Bridge-config preference for HMR target (litestar-vite-c1t) =====
+
+
+def _write_bridge_for_hmr(tmp_path: Path, payload: object) -> Path:
+    import json
+
+    bridge = tmp_path / ".litestar.json"
+    bridge.write_text(json.dumps(payload))
+    return bridge
+
+
+def test_build_hmr_target_url_prefers_bridge_host_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bridge ``host:port`` beats hotfile contents for the HMR WS target.
+
+    In ``proxyMode='vite'`` the hotfile points at the bridge URL (post-JS-C4),
+    so HMR would otherwise upgrade against Litestar itself. The bridge config
+    carries the real Vite host:port; prefer it for the WS target base.
+    """
+    from litestar_vite.utils import read_bridge_config
+
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://litestar-bridge:8000")
+    bridge = _write_bridge_for_hmr(
+        tmp_path, {"appUrl": "http://litestar-bridge:8000", "host": "127.0.0.1", "port": 5173}
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+    scope = {"path": "/vite-hmr", "query_string": b"token=1"}
+
+    target = build_hmr_target_url(hotfile, scope, "/vite-hmr", "/static/")
+
+    assert target == "ws://127.0.0.1:5173/vite-hmr?token=1"
+    read_bridge_config.cache_clear()
+
+
+def test_build_hmr_target_url_falls_back_to_hotfile_when_bridge_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from litestar_vite.utils import read_bridge_config
+
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
+    scope = {"path": "/vite-hmr", "query_string": b""}
+
+    target = build_hmr_target_url(hotfile, scope, "/vite-hmr", "/static/")
+
+    assert target == "ws://localhost:5173/vite-hmr"
+    read_bridge_config.cache_clear()
+
+
+def test_create_hmr_target_getter_sibling_overrides_bridge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``<hotfile>.hmr`` sibling continues to win for the HMR clientPort override.
+
+    The sibling carries Vite's HMR-specific target (often a different port than
+    the dev server's HTTP port), so it must take precedence even when bridge
+    config is present.
+    """
+    from litestar_vite.utils import read_bridge_config
+
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+    (tmp_path / "hot.hmr").write_text("http://127.0.0.1:24678")
+    bridge = _write_bridge_for_hmr(
+        tmp_path, {"appUrl": "http://bridge", "host": "127.0.0.1", "port": 5173}
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    getter = create_hmr_target_getter(hotfile, [None])
+
+    assert getter() == "http://127.0.0.1:24678"
+    read_bridge_config.cache_clear()

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -145,9 +145,7 @@ def test_extract_proxy_response_filters_headers() -> None:
     assert body == b"ok"
 
 
-def test_build_hmr_target_url_includes_query(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_build_hmr_target_url_includes_query(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Hotfile-only fallback: bridge cleared so legacy hotfile semantics apply."""
     from litestar_vite.utils import read_bridge_config
 
@@ -806,29 +804,27 @@ def _write_bridge_for_hmr(tmp_path: Path, payload: object) -> Path:
     return bridge
 
 
-def test_build_hmr_target_url_prefers_bridge_host_port(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Bridge ``host:port`` beats hotfile contents for the HMR WS target.
+def test_build_hmr_target_url_preserves_resolved_hotfile_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Vite HMR handler preserves the resolved hotfile target.
 
-    In ``proxyMode='vite'`` the hotfile points at the bridge URL (post-JS-C4),
-    so HMR would otherwise upgrade against Litestar itself. The bridge config
-    carries the real Vite host:port; prefer it for the WS target base.
+    The resolved hotfile URL already carries HTTPS, IPv6 brackets, wildcard
+    normalization, and any HMR clientPort override. Rebuilding from bridge
+    ``host``+``port`` loses those details.
     """
     from litestar_vite.utils import read_bridge_config
 
     read_bridge_config.cache_clear()
     hotfile = tmp_path / "hot"
-    hotfile.write_text("http://litestar-bridge:8000")
+    hotfile.write_text("https://[::1]:32001")
     bridge = _write_bridge_for_hmr(
-        tmp_path, {"appUrl": "http://litestar-bridge:8000", "host": "127.0.0.1", "port": 5173}
+        tmp_path, {"appUrl": "https://litestar-bridge:8443", "host": "::", "port": 5173, "proxyMode": "vite"}
     )
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
     scope = {"path": "/vite-hmr", "query_string": b"token=1"}
 
     target = build_hmr_target_url(hotfile, scope, "/vite-hmr", "/static/")
 
-    assert target == "ws://127.0.0.1:5173/vite-hmr?token=1"
+    assert target == "wss://[::1]:32001/vite-hmr?token=1"
     read_bridge_config.cache_clear()
 
 
@@ -849,9 +845,7 @@ def test_build_hmr_target_url_falls_back_to_hotfile_when_bridge_missing(
     read_bridge_config.cache_clear()
 
 
-def test_create_hmr_target_getter_sibling_overrides_bridge(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_create_hmr_target_getter_sibling_overrides_bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """``<hotfile>.hmr`` sibling continues to win for the HMR clientPort override.
 
     The sibling carries Vite's HMR-specific target (often a different port than
@@ -864,12 +858,30 @@ def test_create_hmr_target_getter_sibling_overrides_bridge(
     hotfile = tmp_path / "hot"
     hotfile.write_text("http://localhost:5173")
     (tmp_path / "hot.hmr").write_text("http://127.0.0.1:24678")
-    bridge = _write_bridge_for_hmr(
-        tmp_path, {"appUrl": "http://bridge", "host": "127.0.0.1", "port": 5173}
-    )
+    bridge = _write_bridge_for_hmr(tmp_path, {"appUrl": "http://bridge", "host": "127.0.0.1", "port": 5173})
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
     getter = create_hmr_target_getter(hotfile, [None])
 
     assert getter() == "http://127.0.0.1:24678"
+    read_bridge_config.cache_clear()
+
+
+def test_create_hmr_target_getter_uses_hotfile_when_sibling_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Framework HMR fallback must keep the hotfile target outside Vite proxy mode."""
+    from litestar_vite.utils import read_bridge_config
+
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("https://framework-dev-server:4321")
+    bridge = _write_bridge_for_hmr(
+        tmp_path, {"appUrl": "http://litestar-bridge:8000", "host": "127.0.0.1", "port": 5173, "proxyMode": "proxy"}
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    getter = create_hmr_target_getter(hotfile, [None])
+
+    assert getter() == "https://framework-dev-server:4321"
     read_bridge_config.cache_clear()

--- a/src/py/tests/unit/test_proxy_middleware.py
+++ b/src/py/tests/unit/test_proxy_middleware.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Any
 
@@ -5,6 +6,7 @@ import pytest
 from litestar.types import HTTPRequestEvent, Receive, Scope, Send
 
 from litestar_vite.plugin import ViteProxyMiddleware
+from litestar_vite.utils import read_bridge_config
 
 
 class _Recorder:
@@ -232,3 +234,139 @@ def test_should_proxy_rejects_path_traversal(hotfile: Path) -> None:
     # Normal paths with dots should still work
     assert middleware._should_proxy("/static/file.name.js", scope)
     assert middleware._should_proxy("/node_modules/.vite/deps/vue.js", scope)
+
+
+# ===== Bridge-config target precedence (litestar-vite-c1t) =====
+
+
+def _write_bridge(tmp_path: Path, payload: object) -> Path:
+    bridge = tmp_path / ".litestar.json"
+    bridge.write_text(json.dumps(payload))
+    return bridge
+
+
+@pytest.fixture(autouse=False)
+def _clear_bridge_cache() -> None:
+    read_bridge_config.cache_clear()
+
+
+def test_proxy_target_uses_bridge_host_port_over_hotfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bridge ``host``+``port`` beats hotfile contents for the proxy upstream.
+
+    This is the dual-consumer-conflict resolution test on the proxy side: in
+    ``proxyMode='vite'`` the JS plugin's C4 fix writes the bridge URL into the
+    hotfile, which would make the proxy self-loop without this preference.
+    """
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://litestar-bridge:8000")
+    bridge = _write_bridge(
+        tmp_path,
+        {"appUrl": "http://litestar-bridge:8000", "host": "127.0.0.1", "port": 5173},
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    async def noop(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
+    target = middleware._get_target_base_url()
+
+    assert target == "http://127.0.0.1:5173"
+    read_bridge_config.cache_clear()
+
+
+def test_proxy_target_falls_back_to_hotfile_when_bridge_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://127.0.0.1:9999")
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
+
+    async def noop(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
+    target = middleware._get_target_base_url()
+
+    assert target == "http://127.0.0.1:9999"
+    read_bridge_config.cache_clear()
+
+
+def test_proxy_target_falls_back_to_hotfile_when_bridge_lacks_host_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bridge present but missing/wrong-typed host or port → hotfile fallback."""
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://127.0.0.1:9999")
+    bridge = _write_bridge(tmp_path, {"appUrl": "http://anywhere", "host": "127.0.0.1", "port": "not-an-int"})
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    async def noop(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
+    target = middleware._get_target_base_url()
+
+    assert target == "http://127.0.0.1:9999"
+    read_bridge_config.cache_clear()
+
+
+def test_proxy_target_returns_none_when_neither_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    read_bridge_config.cache_clear()
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
+
+    async def noop(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(noop, hotfile_path=tmp_path / "no-hot")
+    target = middleware._get_target_base_url()
+
+    assert target is None
+    read_bridge_config.cache_clear()
+
+
+def test_proxy_target_cache_invariant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second call to _get_target_base_url must not re-read the bridge file.
+
+    The middleware-level ``_cache_initialized`` flag ensures the bridge lookup
+    happens at most once per middleware instance lifetime — matching the
+    existing hotfile semantics.
+    """
+    import litestar_vite.plugin._proxy as proxy_module
+
+    read_bridge_config.cache_clear()
+    bridge = _write_bridge(
+        tmp_path, {"appUrl": "http://bridge", "host": "127.0.0.1", "port": 5173}
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    call_count = 0
+    real_read = proxy_module.read_bridge_config
+
+    def counting_read(*args: object, **kwargs: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        return real_read(*args, **kwargs)
+
+    monkeypatch.setattr(proxy_module, "read_bridge_config", counting_read)
+
+    async def noop(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(noop, hotfile_path=tmp_path / "hot")
+
+    middleware._get_target_base_url()
+    middleware._get_target_base_url()
+    middleware._get_target_base_url()
+
+    assert call_count == 1
+    read_bridge_config.cache_clear()

--- a/src/py/tests/unit/test_proxy_middleware.py
+++ b/src/py/tests/unit/test_proxy_middleware.py
@@ -250,21 +250,21 @@ def _clear_bridge_cache() -> None:
     read_bridge_config.cache_clear()
 
 
-def test_proxy_target_uses_bridge_host_port_over_hotfile(
+def test_proxy_target_preserves_resolved_vite_hotfile_url_when_bridge_exists(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Bridge ``host``+``port`` beats hotfile contents for the proxy upstream.
+    """The hotfile is the resolved upstream URL even when bridge config exists.
 
-    This is the dual-consumer-conflict resolution test on the proxy side: in
-    ``proxyMode='vite'`` the JS plugin's C4 fix writes the bridge URL into the
-    hotfile, which would make the proxy self-loop without this preference.
+    ``proxyMode='vite'`` still needs the loader to anchor browser-facing asset
+    URLs on bridge ``appUrl``, but the proxy target itself must remain the actual
+    Vite URL written by the JS side. Rebuilding from bridge ``host``+``port``
+    drops HTTPS and IPv6/wildcard normalization.
     """
     read_bridge_config.cache_clear()
     hotfile = tmp_path / "hot"
-    hotfile.write_text("http://litestar-bridge:8000")
+    hotfile.write_text("https://[::1]:5173")
     bridge = _write_bridge(
-        tmp_path,
-        {"appUrl": "http://litestar-bridge:8000", "host": "127.0.0.1", "port": 5173},
+        tmp_path, {"appUrl": "https://litestar-bridge:8443", "host": "::", "port": 5173, "proxyMode": "vite"}
     )
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
@@ -274,7 +274,29 @@ def test_proxy_target_uses_bridge_host_port_over_hotfile(
     middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
     target = middleware._get_target_base_url()
 
-    assert target == "http://127.0.0.1:5173"
+    assert target == "https://[::1]:5173"
+    read_bridge_config.cache_clear()
+
+
+def test_proxy_target_preserves_hotfile_for_framework_proxy_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Framework/external proxy modes must not route asset requests to bridge host:port."""
+    read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://framework-dev-server:4321")
+    bridge = _write_bridge(
+        tmp_path, {"appUrl": "http://litestar-bridge:8000", "host": "127.0.0.1", "port": 5173, "proxyMode": "proxy"}
+    )
+    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
+
+    async def noop(scope: Scope, receive: Receive, send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
+    target = middleware._get_target_base_url()
+
+    assert target == "http://framework-dev-server:4321"
     read_bridge_config.cache_clear()
 
 
@@ -299,7 +321,7 @@ def test_proxy_target_falls_back_to_hotfile_when_bridge_missing(
 def test_proxy_target_falls_back_to_hotfile_when_bridge_lacks_host_port(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Bridge present but missing/wrong-typed host or port → hotfile fallback."""
+    """Bridge metadata never changes the hotfile target."""
     read_bridge_config.cache_clear()
     hotfile = tmp_path / "hot"
     hotfile.write_text("http://127.0.0.1:9999")
@@ -316,9 +338,7 @@ def test_proxy_target_falls_back_to_hotfile_when_bridge_lacks_host_port(
     read_bridge_config.cache_clear()
 
 
-def test_proxy_target_returns_none_when_neither_present(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_proxy_target_returns_none_when_neither_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     read_bridge_config.cache_clear()
     monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(tmp_path / "missing.json"))
 
@@ -332,35 +352,28 @@ def test_proxy_target_returns_none_when_neither_present(
     read_bridge_config.cache_clear()
 
 
-def test_proxy_target_cache_invariant(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Second call to _get_target_base_url must not re-read the bridge file.
+def test_proxy_target_cache_invariant(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Second call to _get_target_base_url must not re-read the hotfile.
 
-    The middleware-level ``_cache_initialized`` flag ensures the bridge lookup
-    happens at most once per middleware instance lifetime — matching the
-    existing hotfile semantics. The hotfile must exist (readiness signal) for
-    the bridge branch to be reached at all.
+    The middleware-level ``_cache_initialized`` flag ensures target resolution
+    happens at most once per middleware instance lifetime. The hotfile is the
+    upstream target source and readiness signal.
     """
     import litestar_vite.plugin._proxy as proxy_module
 
     read_bridge_config.cache_clear()
     hotfile = tmp_path / "hot"
     hotfile.write_text("http://bridge")
-    bridge = _write_bridge(
-        tmp_path, {"appUrl": "http://bridge", "host": "127.0.0.1", "port": 5173}
-    )
-    monkeypatch.setenv("LITESTAR_VITE_CONFIG_PATH", str(bridge))
 
     call_count = 0
-    real_read = proxy_module.read_bridge_config
+    real_read = proxy_module.read_hotfile_url
 
-    def counting_read(*args: object, **kwargs: object) -> object:
+    def counting_read(hotfile_path: Path) -> str:
         nonlocal call_count
         call_count += 1
-        return real_read(*args, **kwargs)
+        return real_read(hotfile_path)
 
-    monkeypatch.setattr(proxy_module, "read_bridge_config", counting_read)
+    monkeypatch.setattr(proxy_module, "read_hotfile_url", counting_read)
 
     async def noop(scope: Scope, receive: Receive, send: Send) -> None:
         return None

--- a/src/py/tests/unit/test_proxy_middleware.py
+++ b/src/py/tests/unit/test_proxy_middleware.py
@@ -339,11 +339,14 @@ def test_proxy_target_cache_invariant(
 
     The middleware-level ``_cache_initialized`` flag ensures the bridge lookup
     happens at most once per middleware instance lifetime — matching the
-    existing hotfile semantics.
+    existing hotfile semantics. The hotfile must exist (readiness signal) for
+    the bridge branch to be reached at all.
     """
     import litestar_vite.plugin._proxy as proxy_module
 
     read_bridge_config.cache_clear()
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://bridge")
     bridge = _write_bridge(
         tmp_path, {"appUrl": "http://bridge", "host": "127.0.0.1", "port": 5173}
     )
@@ -362,7 +365,7 @@ def test_proxy_target_cache_invariant(
     async def noop(scope: Scope, receive: Receive, send: Send) -> None:
         return None
 
-    middleware = ViteProxyMiddleware(noop, hotfile_path=tmp_path / "hot")
+    middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
 
     middleware._get_target_base_url()
     middleware._get_target_base_url()

--- a/src/py/tests/unit/test_utils.py
+++ b/src/py/tests/unit/test_utils.py
@@ -43,7 +43,13 @@ def test_check_h2_available_import_error(monkeypatch: pytest.MonkeyPatch) -> Non
         return orig_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    assert utils._check_h2_available() is False
+    try:
+        assert utils._check_h2_available() is False
+    finally:
+        # Reset the module-level cache so subsequent tests don't observe the
+        # monkeypatched outcome (would otherwise leak into integration tests
+        # that try to construct a real HTTP/2 client when h2 is missing).
+        utils._h2_available = None
 
 
 def test_check_h2_available_success(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,7 +68,10 @@ def test_check_h2_available_success(monkeypatch: pytest.MonkeyPatch) -> None:
         return orig_import(name, globals, locals, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    assert utils._check_h2_available() is True
+    try:
+        assert utils._check_h2_available() is True
+    finally:
+        utils._h2_available = None
 
 
 def test_infer_port_from_argv(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1044,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.23.1"
+version = "0.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- keep the Vite hotfile as the resolved upstream target even when server.origin is bridge appUrl
- remove Python proxy/HMR reconstruction of http://{bridge.host}:{bridge.port}, preserving framework/external targets plus TLS and IPv6 normalization
- parse bridge config through Litestar serialization helpers
- bump litestar-vite / npm package version to 0.23.2

## Root Cause
The previous bridge-target change made .litestar.json host/port win too broadly. That broke framework/proxy and external dev server modes, and it also dropped details from the frontend-resolved Vite URL such as https, IPv6 brackets, wildcard normalization, and HMR port handling.

## Validation
- uv run pytest src/py/tests/unit src/py/tests/integration -x
- npm test
- npm run lint
- ./node_modules/.bin/tsc --noEmit --project src/js/tsconfig.json
- uv run ruff check src/py/
- make mypy
- uv run pyright
- uv run slotscheck -m litestar_vite
- uv run pytest src/py/tests/unit/test_bridge_config.py src/py/tests/unit/test_proxy_middleware.py src/py/tests/unit/test_proxy_helpers.py src/py/tests/unit/test_asset_loader.py src/py/tests/integration/test_bridge_contract.py -q
- npm run build-plugin
- uv run pytest src/py/tests/e2e/test_dev_mode.py -k "vite_client_proxies or html_anchors" --timeout=120

Note: the full dev-mode e2e matrix was also attempted after rebuilding dist/js, but it exceeded the interactive timeout across unrelated examples. The focused bridge-source regression e2e passed.