### PR TITLE
fix(cli): honor RuntimeConfig.executor for local typegen binary on bun/deno

### DIFF
--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -973,20 +973,54 @@ def _get_local_binary_cmd(root_dir: Path, binary: str) -> "list[str] | None":
     return None
 
 
+def _is_direct_js_cli(candidate: Path) -> bool:
+    """Return True when ``candidate`` can be executed directly by a JS runtime."""
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        resolved = candidate
+
+    if resolved.suffix.lower() in {".js", ".mjs", ".cjs"}:
+        return True
+
+    try:
+        with candidate.open(encoding="utf-8", errors="ignore") as fp:
+            first_line = fp.readline()
+    except (OSError, UnicodeDecodeError):
+        return False
+
+    return first_line.startswith("#!") and any(runtime in first_line for runtime in ("node", "bun", "deno"))
+
+
+def _get_local_js_cli_cmd(root_dir: Path, binary: str) -> "list[str] | None":
+    """Resolve a local binary only when it points at a direct JS CLI file."""
+    bin_dir = root_dir / "node_modules" / ".bin"
+    for candidate in (bin_dir / binary, bin_dir / f"{binary}.js", bin_dir / f"{binary}.mjs", bin_dir / f"{binary}.cjs"):
+        if candidate.exists() and _is_direct_js_cli(candidate):
+            return [str(candidate)]
+    return None
+
+
 def _resolve_js_cli(root_dir: Path, executor: "str | None", binary: str) -> "list[str]":
     """Resolve a JS CLI command, honoring the configured executor.
 
     Prefers a locally installed ``node_modules/.bin/<binary>``. When the
-    resolved binary carries a ``#!/usr/bin/env node`` shebang and the
-    executor is ``bun`` or ``deno``, the runtime is prepended explicitly
-    so the shebang does not leak a hard ``node`` dependency into bun- or
-    deno-only environments (e.g., slim CI images that ship only ``bun``).
+    resolved binary is a direct JS CLI and the executor is ``bun`` or
+    ``deno``, the runtime is prepended explicitly so the shebang does not
+    leak a hard ``node`` dependency into bun- or deno-only environments
+    (e.g., slim CI images that ship only ``bun``).
+
+    Windows ``.cmd``/``.exe`` shims and POSIX shell shims are intentionally
+    not passed into Bun/Deno; those fall back to the runtime's package runner.
     For ``npm``/``yarn``/``pnpm``/``node`` the bare path is returned and
     the shebang governs, matching prior behavior.
 
     Falls back to ``_get_package_executor_cmd`` (``npx`` / ``bunx`` /
     ``deno run`` / ``yarn dlx`` / ``pnpm dlx``) when the local binary
     is missing.
+
+    Returns:
+        A command list suitable for subprocess.run.
     """
     local = _get_local_binary_cmd(root_dir, binary)
     if local is None:
@@ -994,9 +1028,15 @@ def _resolve_js_cli(root_dir: Path, executor: "str | None", binary: str) -> "lis
 
     match executor:
         case "bun":
-            return ["bun", "run", *local]
+            js_local = _get_local_js_cli_cmd(root_dir, binary)
+            return ["bun", "run", *js_local] if js_local is not None else _get_package_executor_cmd(executor, binary)
         case "deno":
-            return ["deno", "run", "-A", *local]
+            js_local = _get_local_js_cli_cmd(root_dir, binary)
+            return (
+                ["deno", "run", "-A", *js_local]
+                if js_local is not None
+                else _get_package_executor_cmd(executor, binary)
+            )
         case _:
             return local
 

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -973,6 +973,34 @@ def _get_local_binary_cmd(root_dir: Path, binary: str) -> "list[str] | None":
     return None
 
 
+def _resolve_js_cli(root_dir: Path, executor: "str | None", binary: str) -> "list[str]":
+    """Resolve a JS CLI command, honoring the configured executor.
+
+    Prefers a locally installed ``node_modules/.bin/<binary>``. When the
+    resolved binary carries a ``#!/usr/bin/env node`` shebang and the
+    executor is ``bun`` or ``deno``, the runtime is prepended explicitly
+    so the shebang does not leak a hard ``node`` dependency into bun- or
+    deno-only environments (e.g., slim CI images that ship only ``bun``).
+    For ``npm``/``yarn``/``pnpm``/``node`` the bare path is returned and
+    the shebang governs, matching prior behavior.
+
+    Falls back to ``_get_package_executor_cmd`` (``npx`` / ``bunx`` /
+    ``deno run`` / ``yarn dlx`` / ``pnpm dlx``) when the local binary
+    is missing.
+    """
+    local = _get_local_binary_cmd(root_dir, binary)
+    if local is None:
+        return _get_package_executor_cmd(executor, binary)
+
+    match executor:
+        case "bun":
+            return ["bun", "run", *local]
+        case "deno":
+            return ["deno", "run", "-A", *local]
+        case _:
+            return local
+
+
 def _run_extra_commands(config: Any, verbose: bool) -> bool:
     """Run additional code-generation commands configured in TypeGenConfig.
 
@@ -1010,7 +1038,7 @@ def _run_extra_commands(config: Any, verbose: bool) -> bool:
 
         # Resolve the binary through the project's JS executor,
         # same pattern as _invoke_typegen_cli.
-        resolved = _get_local_binary_cmd(root_dir, binary) or _get_package_executor_cmd(executor, binary)
+        resolved = _resolve_js_cli(root_dir, executor, binary)
         full_cmd = [*resolved, *args]
         display = " ".join(full_cmd)
 
@@ -1050,9 +1078,7 @@ def _invoke_typegen_cli(config: Any, verbose: bool) -> None:
     executor = config.runtime.executor
 
     # Build the command to run the unified TypeScript CLI
-    pkg_cmd = _get_local_binary_cmd(root_dir, "litestar-vite-typegen") or _get_package_executor_cmd(
-        executor, "litestar-vite-typegen"
-    )
+    pkg_cmd = _resolve_js_cli(root_dir, executor, "litestar-vite-typegen")
     cmd = [*pkg_cmd]
 
     if verbose:

--- a/src/py/tests/unit/test_cli.py
+++ b/src/py/tests/unit/test_cli.py
@@ -21,6 +21,7 @@ from litestar_vite.cli import (
     _parse_storage_options,
     _print_recommended_config,
     _prompt_for_options,
+    _resolve_js_cli,
     _run_extra_commands,
     _run_vite_build,
     _select_framework_template,
@@ -529,6 +530,51 @@ def test_cli_get_package_executor_cmd_variants() -> None:
     assert _get_package_executor_cmd(None, "tool") == ["npx", "tool"]
 
 
+def _make_local_bin(root_dir: Path, name: str) -> Path:
+    local_bin = root_dir / "node_modules" / ".bin" / name
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("#!/usr/bin/env node\n")
+    return local_bin
+
+
+def test_cli_resolve_js_cli_no_local_bin_falls_back_to_executor(tmp_path: Path) -> None:
+    assert _resolve_js_cli(tmp_path, "bun", "litestar-vite-typegen") == ["bunx", "litestar-vite-typegen"]
+    assert _resolve_js_cli(tmp_path, "deno", "litestar-vite-typegen") == [
+        "deno",
+        "run",
+        "-A",
+        "npm:litestar-vite-typegen",
+    ]
+    assert _resolve_js_cli(tmp_path, "pnpm", "litestar-vite-typegen") == ["pnpm", "dlx", "litestar-vite-typegen"]
+    assert _resolve_js_cli(tmp_path, None, "litestar-vite-typegen") == ["npx", "litestar-vite-typegen"]
+
+
+def test_cli_resolve_js_cli_bun_wraps_local_bin(tmp_path: Path) -> None:
+    """Regression test: bun executor must invoke local node-shebanged binary via `bun run`.
+
+    Without this wrap, the kernel reads `#!/usr/bin/env node` from the script
+    and fails with `/usr/bin/env: 'node': No such file or directory` on hosts
+    that ship only bun (e.g., slim CI images).
+    """
+    local_bin = _make_local_bin(tmp_path, "litestar-vite-typegen")
+
+    assert _resolve_js_cli(tmp_path, "bun", "litestar-vite-typegen") == ["bun", "run", str(local_bin)]
+
+
+def test_cli_resolve_js_cli_deno_wraps_local_bin(tmp_path: Path) -> None:
+    local_bin = _make_local_bin(tmp_path, "litestar-vite-typegen")
+
+    assert _resolve_js_cli(tmp_path, "deno", "litestar-vite-typegen") == ["deno", "run", "-A", str(local_bin)]
+
+
+def test_cli_resolve_js_cli_node_executors_use_bare_local_bin(tmp_path: Path) -> None:
+    """node/npm/yarn/pnpm imply node-on-PATH, so the shebang governs (no wrap)."""
+    local_bin = _make_local_bin(tmp_path, "tool")
+
+    for executor in ("node", "yarn", "pnpm", None):
+        assert _resolve_js_cli(tmp_path, executor, "tool") == [str(local_bin)]
+
+
 def test_cli_invoke_typegen_cli_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config = ViteConfig(paths=PathConfig(root=tmp_path))
     monkeypatch.setattr("litestar_vite.cli.subprocess.run", Mock(return_value=Mock(returncode=1)))
@@ -563,6 +609,47 @@ def test_cli_invoke_typegen_cli_prefers_local_bin_for_pnpm(tmp_path: Path, monke
     assert run.call_args.args[0] == [str(local_bin), "--verbose"]
     assert run.call_args.kwargs["cwd"] == tmp_path
     assert run.call_args.kwargs["check"] is False
+
+
+def test_cli_invoke_typegen_cli_wraps_local_bin_with_bun_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for bun-only environments: local bin must be invoked via `bun run`.
+
+    See https://github.com/litestar-org/litestar-vite/issues/...
+    Previously, the CLI returned the bare path of node_modules/.bin/litestar-vite-typegen
+    and let the OS resolve `#!/usr/bin/env node` — which fails on hosts without node.
+    """
+    config = ViteConfig(paths=PathConfig(root=tmp_path), runtime=RuntimeConfig(executor="bun"))
+
+    local_bin = tmp_path / "node_modules" / ".bin" / "litestar-vite-typegen"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("#!/usr/bin/env node\n")
+
+    run = Mock(return_value=Mock(returncode=0))
+    monkeypatch.setattr("litestar_vite.cli.subprocess.run", run)
+
+    _invoke_typegen_cli(config, verbose=False)
+
+    assert run.call_args.args[0] == ["bun", "run", str(local_bin)]
+    assert run.call_args.kwargs["cwd"] == tmp_path
+
+
+def test_cli_invoke_typegen_cli_wraps_local_bin_with_deno_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = ViteConfig(paths=PathConfig(root=tmp_path), runtime=RuntimeConfig(executor="deno"))
+
+    local_bin = tmp_path / "node_modules" / ".bin" / "litestar-vite-typegen"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("#!/usr/bin/env node\n")
+
+    run = Mock(return_value=Mock(returncode=0))
+    monkeypatch.setattr("litestar_vite.cli.subprocess.run", run)
+
+    _invoke_typegen_cli(config, verbose=True)
+
+    assert run.call_args.args[0] == ["deno", "run", "-A", str(local_bin), "--verbose"]
 
 
 def test_cli_run_extra_commands_executes_all(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -607,6 +694,27 @@ def test_cli_run_extra_commands_respects_executor(tmp_path: Path, monkeypatch: p
     _run_extra_commands(config, verbose=False)
 
     assert run.call_args.args[0] == ["pnpm", "dlx", "tsr", "generate"]
+
+
+def test_cli_run_extra_commands_wraps_local_bin_with_bun_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: extra_commands must also honor bun executor for local bins."""
+    config = ViteConfig(
+        paths=PathConfig(root=tmp_path),
+        runtime=RuntimeConfig(executor="bun"),
+        types=TypeGenConfig(extra_commands=[["tsr", "generate"]]),
+    )
+    local_bin = tmp_path / "node_modules" / ".bin" / "tsr"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("#!/usr/bin/env node\n")
+
+    run = Mock(return_value=Mock(returncode=0))
+    monkeypatch.setattr("litestar_vite.cli.subprocess.run", run)
+
+    _run_extra_commands(config, verbose=False)
+
+    assert run.call_args.args[0] == ["bun", "run", str(local_bin), "generate"]
 
 
 def test_cli_run_extra_commands_noop_when_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/py/tests/unit/test_cli.py
+++ b/src/py/tests/unit/test_cli.py
@@ -575,6 +575,47 @@ def test_cli_resolve_js_cli_node_executors_use_bare_local_bin(tmp_path: Path) ->
         assert _resolve_js_cli(tmp_path, executor, "tool") == [str(local_bin)]
 
 
+def test_cli_resolve_js_cli_bun_ignores_posix_shell_shim(tmp_path: Path) -> None:
+    """Bun should not be asked to run a shell shim as JavaScript."""
+    local_bin = tmp_path / "node_modules" / ".bin" / "tool"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text('#!/bin/sh\nexec node ../tool/bin.js "$@"\n')
+
+    assert _resolve_js_cli(tmp_path, "bun", "tool") == ["bunx", "tool"]
+
+
+def test_cli_resolve_js_cli_bun_ignores_windows_cmd_shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows .cmd shims still route through node, so Bun should use bunx instead."""
+    monkeypatch.setattr("litestar_vite.cli.os.name", "nt")
+    local_bin = tmp_path / "node_modules" / ".bin" / "tool.cmd"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("@ECHO off\r\nnode ..\\tool\\bin.js %*\r\n")
+
+    assert _resolve_js_cli(tmp_path, "bun", "tool") == ["bunx", "tool"]
+
+
+def test_cli_resolve_js_cli_deno_ignores_windows_cmd_shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deno cannot execute a Windows .cmd shim as a JavaScript module."""
+    monkeypatch.setattr("litestar_vite.cli.os.name", "nt")
+    local_bin = tmp_path / "node_modules" / ".bin" / "tool.cmd"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("@ECHO off\r\nnode ..\\tool\\bin.js %*\r\n")
+
+    assert _resolve_js_cli(tmp_path, "deno", "tool") == ["deno", "run", "-A", "npm:tool"]
+
+
+def test_cli_resolve_js_cli_node_executors_keep_windows_cmd_shim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Windows shim remains correct for Node-backed executors."""
+    monkeypatch.setattr("litestar_vite.cli.os.name", "nt")
+    local_bin = tmp_path / "node_modules" / ".bin" / "tool.cmd"
+    local_bin.parent.mkdir(parents=True, exist_ok=True)
+    local_bin.write_text("@ECHO off\r\nnode ..\\tool\\bin.js %*\r\n")
+
+    assert _resolve_js_cli(tmp_path, "pnpm", "tool") == [str(local_bin)]
+
+
 def test_cli_invoke_typegen_cli_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config = ViteConfig(paths=PathConfig(root=tmp_path))
     monkeypatch.setattr("litestar_vite.cli.subprocess.run", Mock(return_value=Mock(returncode=1)))


### PR DESCRIPTION
## Summary

- `litestar assets generate-types` now invokes the local `node_modules/.bin/litestar-vite-typegen` through the configured runtime (`bun run …` / `deno run -A …`) instead of relying on the `#!/usr/bin/env node` shebang.
- Same fix is applied to `TypeGenConfig.extra_commands`, which routed through the identical `_get_local_binary_cmd or _get_package_executor_cmd` pattern.
- `npm` / `yarn` / `pnpm` / `node` keep the bare-path behavior (those executors imply node-on-PATH, so the shebang is fine and we avoid churn for the common case).

## Root Cause

`_invoke_typegen_cli` and `_run_extra_commands` both resolved binaries with:

```python
pkg_cmd = _get_local_binary_cmd(root_dir, binary) or _get_package_executor_cmd(executor, binary)
```

`_get_local_binary_cmd` returns `[str(candidate)]` — a bare path, no interpreter prefix. When `subprocess.run(...)` executes it, the kernel parses `#!/usr/bin/env node` and looks up `node` on `PATH`. In bun-only environments (typical of slim CI images: `python:3.13-slim-bookworm` + `curl … bun.sh`) `node` is absent, so type generation fails with:

```
/usr/bin/env: 'node': No such file or directory
TypeScript type generation failed
```

The configured `RuntimeConfig.executor="bun"` was *only* consulted on the fallback path (no local binary present), which never triggers in a normal `bun install` / `npm install` workflow.

## Reproduction

In a project configured with `RuntimeConfig(executor="bun")` after `bun install`, on a host without `node` on `PATH`:

```bash
$ which node || echo "no node"
no node
$ which bun
/root/.bun/bin/bun
$ head -1 node_modules/.bin/litestar-vite-typegen
#!/usr/bin/env node
$ litestar assets generate-types
✓ Exported .litestar.json (updated)
…
/usr/bin/env: 'node': No such file or directory
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ TypeScript type generation failed                                            │
╰──────────────────────────────────────────────────────────────────────────────╯
```

The bug is exercised in unit tests by registering a fake binary in a temp `node_modules/.bin/` and asserting the resolved command starts with `bun run` (or `deno run -A`):

```python
def test_cli_resolve_js_cli_bun_wraps_local_bin(tmp_path: Path) -> None:
    local_bin = tmp_path / "node_modules" / ".bin" / "litestar-vite-typegen"
    local_bin.parent.mkdir(parents=True, exist_ok=True)
    local_bin.write_text("#!/usr/bin/env node\n")

    assert _resolve_js_cli(tmp_path, "bun", "litestar-vite-typegen") == [
        "bun", "run", str(local_bin),
    ]
```

## Implementation

New `_resolve_js_cli(root_dir, executor, binary) -> list[str]` helper centralizes the resolution:

| Executor | Local bin found | Local bin missing |
| --- | --- | --- |
| `bun` | `["bun", "run", <local>]` | `["bunx", <pkg>]` |
| `deno` | `["deno", "run", "-A", <local>]` | `["deno", "run", "-A", "npm:<pkg>"]` |
| `node` / `npm` / `yarn` / `pnpm` / `None` | `[<local>]` (shebang governs) | `["npx" / "yarn dlx" / "pnpm dlx", <pkg>]` |

Both call sites (`_invoke_typegen_cli` and `_run_extra_commands`) now use the helper. `bun run /path/to/script.js` is the canonical bun invocation for a node-shebanged script (works under bun ≥ 1.0).

The choice to leave `node` / `npm` / `yarn` / `pnpm` untouched is deliberate: those package managers all require Node to be installed, so the shebang resolves correctly and we avoid changing observable behavior for the majority of users (and avoid breaking existing tests like `test_cli_invoke_typegen_cli_prefers_local_bin_for_pnpm`).

## Affected Workflows

- `litestar assets generate-types` in CI/Docker images that ship only `bun` or `deno`.
- Any `TypeGenConfig.extra_commands` (e.g., `tsr generate`, `biome check`) in the same environments.
- Auto-typegen during `litestar run` in bun-only sandboxes.

## Validation

- `uv run pytest src/py/tests/unit/test_cli.py -v` — all 51 tests pass, including 7 new tests covering the regression contract.
- `uv run pytest src/py/tests --ignore=src/py/tests/e2e -n 2` — 1123 passed.
- `make lint` (pre-commit + mypy + pyright + slotscheck) — all clean (0 errors, 0 warnings).
- e2e suite was not re-run — touched paths are unit-tested and the e2e scenarios for `angular` / `nuxt` / `svelte-inertia` require pre-built example apps unrelated to this change.

## Notes

- No public API change.
- Backward-compatible for all existing `node` / `npm` / `yarn` / `pnpm` users.
- The npm-side `litestar-vite-plugin` shebang is unchanged; the fix lives entirely on the Python invocation side, so a new npm release is not required.
