### PR TITLE
fix(dev): normalize browser app urls

### DIFF
--- a/examples/svelte-inertia-jinja/resources/main.ts
+++ b/examples/svelte-inertia-jinja/resources/main.ts
@@ -18,6 +18,7 @@ createInertiaApp({
     }),
   },
   setup({ el, App, props }) {
+    if (!el) throw new Error("Inertia mount element not found")
     mount(App, {
       target: el,
       props,

--- a/examples/svelte-inertia/resources/main.ts
+++ b/examples/svelte-inertia/resources/main.ts
@@ -18,6 +18,7 @@ createInertiaApp({
     }),
   },
   setup({ el, App, props }) {
+    if (!el) throw new Error("Inertia mount element not found")
     mount(App, {
       target: el,
       props,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.23.2",
+      "version": "0.23.3",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.2",
+  "version": "0.23.3",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.23.2"
+version = "0.23.3"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -102,7 +102,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.23.2"
+current_version = "0.23.3"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/src/js/src/index.ts
+++ b/src/js/src/index.ts
@@ -10,6 +10,7 @@ import { checkBackendAvailability, type LitestarMeta, loadLitestarMeta } from ".
 import { type BridgeSchema, readBridgeConfig } from "./shared/bridge-schema.js"
 import { DEBOUNCE_MS } from "./shared/constants.js"
 import { createLogger } from "./shared/logger.js"
+import { resolveLitestarPort } from "./shared/network.js"
 import { resolveDefaultSdkClientPlugin } from "./shared/typegen-core.js"
 import { createLitestarTypeGenPlugin } from "./shared/typegen-plugin.js"
 import { buildInputOptions, resolveUserBuildInput } from "./shared/vite-compat.js"
@@ -392,6 +393,9 @@ function normalizeAppUrl(appUrl: string | undefined, _fallbackPort?: string): { 
   }
   try {
     const url = new URL(appUrl)
+    if (url.hostname === "0.0.0.0" || url.hostname === "[::]") {
+      url.hostname = "localhost"
+    }
 
     const rebuilt = url.origin + (url.pathname === "/" ? "" : url.pathname) + (url.search ?? "") + (url.hash ?? "")
 
@@ -423,7 +427,8 @@ function resolveLitestarPlugin(pluginConfig: ResolvedPluginConfig): Plugin {
       const runtimeAssetUrl = normalizeAssetUrl(env.ASSET_URL || pluginConfig.assetUrl)
       const buildAssetUrl = pluginConfig.deployAssetUrl ?? runtimeAssetUrl
       const serverConfig = command === "serve" ? (resolveDevelopmentEnvironmentServerConfig(pluginConfig.detectTls) ?? resolveEnvironmentServerConfig(env)) : undefined
-      const effectiveAppUrl = env.APP_URL || pythonDefaults?.appUrl || undefined
+      const effectiveAppUrl = normalizeAppUrl(env.APP_URL || pythonDefaults?.appUrl || undefined).url ?? undefined
+      const proxyHmrClientPort = pythonDefaults?.proxyMode === "vite" ? resolveLitestarPort(pythonDefaults.litestarPort, effectiveAppUrl, process.env) : null
 
       const withProxyErrorSilencer = (proxyConfig: Record<string, any> | undefined) => {
         if (!proxyConfig) return undefined
@@ -456,7 +461,7 @@ function resolveLitestarPlugin(pluginConfig: ResolvedPluginConfig): Plugin {
       }
       const explicitServerOrigin = typeof userConfig.server?.origin === "string" && userConfig.server.origin.length > 0 ? userConfig.server.origin : undefined
       const shouldForceDirectServerOrigin = explicitServerOrigin !== undefined || pythonDefaults?.proxyMode === "direct"
-      const proxyOriginDefault = !explicitServerOrigin && pythonDefaults?.proxyMode === "vite" && pythonDefaults.appUrl ? pythonDefaults.appUrl : undefined
+      const proxyOriginDefault = !explicitServerOrigin && pythonDefaults?.proxyMode === "vite" ? effectiveAppUrl : undefined
       const devBase = pluginConfig.assetUrl.startsWith("/") ? pluginConfig.assetUrl : pluginConfig.assetUrl.replace(/\/+$/, "")
 
       ensureCommandShouldRunInEnvironment(command, env, mode)
@@ -482,6 +487,7 @@ function resolveLitestarPlugin(pluginConfig: ResolvedPluginConfig): Plugin {
               ? false
               : {
                   path: "vite-hmr",
+                  ...(proxyHmrClientPort ? { clientPort: proxyHmrClientPort } : {}),
                   ...(serverConfig?.hmr ?? {}),
                   ...(userConfig.server?.hmr === true ? {} : userConfig.server?.hmr),
                 },
@@ -1399,8 +1405,8 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig, userC
     host = "[::1]"
   }
 
-  const configHmrClientPort = typeof config.server.hmr === "object" ? config.server.hmr.clientPort : null
-  const port = configHmrClientPort ?? address.port
+  const userHmrClientPort = typeof userConfig.server?.hmr === "object" ? userConfig.server.hmr.clientPort : null
+  const port = userHmrClientPort ?? address.port
 
   return `${protocol}://${host}:${port}`
 }

--- a/src/js/tests/index.test.ts
+++ b/src/js/tests/index.test.ts
@@ -300,6 +300,42 @@ describe("litestar-vite-plugin", () => {
     }
   })
 
+  it("normalizes bind-all bridge appUrl before using it as server.origin", () => {
+    const configPath = createRuntimeConfig({
+      proxyMode: "vite",
+      appUrl: "http://0.0.0.0:5006",
+    })
+
+    try {
+      const plugin = litestar({ input: "resources/js/app.ts" })[0]
+      const config = plugin.config({}, { command: "serve", mode: "development" })
+
+      expect(config.server?.origin).toBe("http://localhost:5006")
+    } finally {
+      cleanupRuntimeConfig(configPath)
+    }
+  })
+
+  it("routes default HMR client connections through the Litestar port in proxy mode", () => {
+    const configPath = createRuntimeConfig({
+      proxyMode: "vite",
+      appUrl: "http://localhost:5006",
+      litestarPort: 5006,
+    })
+
+    try {
+      const plugin = litestar({ input: "resources/js/app.ts" })[0]
+      const config = plugin.config({}, { command: "serve", mode: "development" })
+
+      expect(config.server?.hmr).toMatchObject({
+        path: "vite-hmr",
+        clientPort: 5006,
+      })
+    } finally {
+      cleanupRuntimeConfig(configPath)
+    }
+  })
+
   it("leaves server.origin undefined in proxy mode when bridge appUrl is null", () => {
     const configPath = createRuntimeConfig({
       proxyMode: "vite",
@@ -446,6 +482,7 @@ describe("litestar-vite-plugin", () => {
     const configPath = createRuntimeConfig({
       proxyMode: "vite",
       appUrl: "http://localhost:5006",
+      litestarPort: 5006,
     })
 
     try {
@@ -462,7 +499,7 @@ describe("litestar-vite-plugin", () => {
           mode: "development",
           command: "serve",
           base: "/static/",
-          server: { https: false, hmr: {}, origin: config.server?.origin },
+          server: { https: false, hmr: config.server?.hmr, origin: config.server?.origin },
           logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
         },
         httpServer: {
@@ -559,6 +596,33 @@ describe("litestar-vite-plugin", () => {
       })
       expect(config.server?.proxy?.["/schema"]).toMatchObject({
         target: "http://127.0.0.1:8001",
+        changeOrigin: true,
+        ws: true,
+      })
+    } finally {
+      cleanupRuntimeConfig(configPath)
+    }
+  })
+
+  it("normalizes bind-all bridge appUrl before using it as default proxy target", () => {
+    const configPath = createRuntimeConfig({
+      proxyMode: "vite",
+      appUrl: "http://0.0.0.0:8001",
+    })
+
+    try {
+      delete process.env.APP_URL
+
+      const plugin = litestar({ input: "resources/js/app.ts" })[0]
+      const config = plugin.config({}, { command: "serve", mode: "development" })
+
+      expect(config.server?.proxy?.["/api"]).toMatchObject({
+        target: "http://localhost:8001",
+        changeOrigin: true,
+        ws: true,
+      })
+      expect(config.server?.proxy?.["/schema"]).toMatchObject({
+        target: "http://localhost:8001",
         changeOrigin: true,
         ws: true,
       })

--- a/src/py/litestar_vite/plugin/__init__.py
+++ b/src/py/litestar_vite/plugin/__init__.py
@@ -36,6 +36,7 @@ from litestar_vite.plugin._process import ViteProcess
 from litestar_vite.plugin._proxy import (
     SSRProxyMiddleware,
     ViteProxyMiddleware,
+    create_disabled_vite_hmr_handlers,
     create_ssr_http_proxy_handler,
     create_ssr_proxy_controller,
     create_ssr_websocket_handler,
@@ -499,6 +500,13 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
         else:
             self._configure_vite_proxy(app_config, hotfile_path)
 
+    def _resolve_hmr_path(self) -> "str | None":
+        """Return the local HMR websocket path for the configured asset URL."""
+        asset_url = self._config.asset_url
+        if not asset_url.startswith("/"):
+            return None
+        return f"{asset_url.rstrip('/')}/vite-hmr"
+
     def _configure_vite_proxy(self, app_config: "AppConfig", hotfile_path: Path) -> None:
         """Configure Vite proxy mode (allow list).
 
@@ -520,10 +528,17 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
                 plugin=self,
             ),
         )
-        hmr_path = f"{self._config.asset_url.rstrip('/')}/vite-hmr"
-        app_config.route_handlers.append(
-            create_vite_hmr_handler(hotfile_path=hotfile_path, hmr_path=hmr_path, asset_url=self._config.asset_url)
-        )
+        hmr_path = self._resolve_hmr_path()
+        if hmr_path is not None:
+            app_config.route_handlers.append(
+                create_vite_hmr_handler(hotfile_path=hotfile_path, hmr_path=hmr_path, asset_url=self._config.asset_url)
+            )
+
+    def _configure_disabled_hmr_handler(self, app_config: "AppConfig") -> None:
+        """Register a clean-close websocket sink for stale Vite HMR clients."""
+        hmr_path = self._resolve_hmr_path()
+        if hmr_path is not None:
+            app_config.route_handlers.extend(create_disabled_vite_hmr_handlers(hmr_path=hmr_path))
 
     def _configure_ssr_proxy(self, app_config: "AppConfig", hotfile_path: Path) -> None:
         """Configure SSR proxy mode for framework dev servers.
@@ -579,10 +594,11 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
                 plugin=self,
             ),
         )
-        hmr_path = f"{self._config.asset_url.rstrip('/')}/vite-hmr"
-        app_config.route_handlers.append(
-            create_vite_hmr_handler(hotfile_path=hotfile_path, hmr_path=hmr_path, asset_url=self._config.asset_url)
-        )
+        hmr_path = self._resolve_hmr_path()
+        if hmr_path is not None:
+            app_config.route_handlers.append(
+                create_vite_hmr_handler(hotfile_path=hotfile_path, hmr_path=hmr_path, asset_url=self._config.asset_url)
+            )
 
     def on_app_init(self, app_config: "AppConfig") -> "AppConfig":
         """Configure the Litestar application for Vite.
@@ -637,8 +653,13 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
         if self._config.set_static_folders and not skip_static:
             self._configure_static_files(app_config)
 
-        if self._config.is_dev_mode and self._config.proxy_mode is not None and not is_non_serving_assets_cli():
+        dev_proxy_configured = (
+            self._config.is_dev_mode and self._config.proxy_mode is not None and not is_non_serving_assets_cli()
+        )
+        if dev_proxy_configured:
             self._configure_dev_proxy(app_config)
+        elif self._config.set_static_folders:
+            self._configure_disabled_hmr_handler(app_config)
 
         use_spa_handler = self._config.spa_handler and (
             self._config.registers_html_catchall or self._config.wants_html_proxy
@@ -907,6 +928,7 @@ __all__ = (
     "VitePlugin",
     "ViteProcess",
     "ViteProxyMiddleware",
+    "create_disabled_vite_hmr_handlers",
     "create_ssr_http_proxy_handler",
     "create_ssr_proxy_controller",
     "create_ssr_websocket_handler",

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -577,6 +577,38 @@ def create_vite_hmr_handler(hotfile_path: Path, hmr_path: str = "/static/vite-hm
     return vite_hmr_proxy
 
 
+def create_disabled_vite_hmr_handlers(hmr_path: str = "/static/vite-hmr") -> list[Any]:
+    """Create route handlers for stale Vite HMR clients.
+
+    Production mode does not register the real HMR proxy, but browser tabs that
+    loaded the dev client before a restart can keep reconnecting to the old HMR
+    endpoint. Registering this explicit websocket route prevents those requests
+    from matching the HTTP-only static files route and surfacing as a Litestar
+    routing ``KeyError``. A matching HTTP 404 route preserves the previous
+    production response for accidental HTTP requests to the same path.
+
+    Args:
+        hmr_path: The path to register the stale HMR WebSocket handler at.
+
+    Returns:
+        Route handlers for HTTP and WebSocket traffic on the HMR path.
+    """
+    from litestar import WebSocket, get, websocket
+    from litestar.exceptions import NotFoundException
+
+    @get(path=hmr_path, opt={"exclude_from_auth": True}, include_in_schema=False)
+    async def disabled_vite_hmr_http() -> None:
+        msg = "Vite HMR is disabled"
+        raise NotFoundException(msg)
+
+    @websocket(path=hmr_path, opt={"exclude_from_auth": True})
+    async def disabled_vite_hmr(socket: "WebSocket[Any, Any, Any]") -> None:
+        await socket.accept()
+        await socket.close(code=1001, reason="Vite HMR is disabled")
+
+    return [disabled_vite_hmr_http, disabled_vite_hmr]
+
+
 def check_http2_support(enable: bool) -> bool:
     """Check if HTTP/2 support is available.
 

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -238,6 +238,50 @@ def _path_for_bridge(path: Path, root_dir: Path) -> str:
         return os.path.relpath(resolved_path, resolved_root).replace("\\", "/")
 
 
+def _normalize_browser_host(host: str) -> str:
+    """Return a host safe to emit into browser-facing URLs."""
+    normalized = host.strip()
+    if normalized in {"0.0.0.0", "::", "[::]"}:  # noqa: S104
+        return "localhost"
+    if ":" in normalized and not normalized.startswith("["):
+        return f"[{normalized}]"
+    return normalized
+
+
+def _normalize_browser_url(url: str) -> str:
+    """Normalize bind-only hosts in URLs meant for browser navigation."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return url
+
+    if not parsed.scheme or not parsed.netloc or parsed.hostname is None:
+        return url
+
+    host = _normalize_browser_host(parsed.hostname)
+    if host == parsed.hostname:
+        return url
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return url
+
+    userinfo = ""
+    if parsed.username:
+        userinfo = parsed.username
+        if parsed.password:
+            userinfo = f"{userinfo}:{parsed.password}"
+        userinfo = f"{userinfo}@"
+
+    netloc = f"{userinfo}{host}"
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+
 def _derive_bridge_app_url() -> str | None:
     """Derive the canonical backend URL for the JS bridge config.
 
@@ -246,13 +290,13 @@ def _derive_bridge_app_url() -> str | None:
         when no backend address is available.
     """
     if explicit := os.environ.get("APP_URL"):
-        return explicit
+        return _normalize_browser_url(explicit)
 
     host = os.environ.get("LITESTAR_HOST")
     port = os.environ.get("LITESTAR_PORT") or os.environ.get("PORT")
     if not host and not port:
         return None
-    return f"http://{host or '127.0.0.1'}:{port or '8000'}"
+    return f"http://{_normalize_browser_host(host or '127.0.0.1')}:{port or '8000'}"
 
 
 _DEFAULT_PORT_BY_SCHEME = {"http": 80, "https": 443}
@@ -418,7 +462,7 @@ def set_environment(config: "ViteConfig", asset_url_override: str | None = None)
     backend_port = os.environ.get("LITESTAR_PORT") or os.environ.get("PORT") or infer_port_from_argv() or "8000"
     os.environ["LITESTAR_HOST"] = backend_host
     os.environ["LITESTAR_PORT"] = str(backend_port)
-    os.environ.setdefault("APP_URL", f"http://{backend_host}:{backend_port}")
+    os.environ.setdefault("APP_URL", f"http://{_normalize_browser_host(backend_host)}:{backend_port}")
 
     os.environ.setdefault("VITE_PROTOCOL", config.protocol)
     if config.proxy_mode is not None:

--- a/src/py/litestar_vite/templates/svelte-inertia/resources/main.ts.j2
+++ b/src/py/litestar_vite/templates/svelte-inertia/resources/main.ts.j2
@@ -18,6 +18,7 @@ createInertiaApp({
     }),
   },
   setup({ el, App, props }) {
+    if (!el) throw new Error("Inertia mount element not found");
     mount(App, {
       target: el,
       props,

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -11,8 +11,10 @@ from unittest.mock import Mock, patch
 import pytest
 from litestar import Litestar, get
 from litestar.config.app import AppConfig
+from litestar.exceptions import WebSocketDisconnect
 from litestar.middleware import DefineMiddleware
 from litestar.template.config import TemplateConfig
+from litestar.testing import TestClient
 
 from litestar_vite.config import PathConfig, RuntimeConfig, ViteConfig
 from litestar_vite.plugin import ProxyHeadersMiddleware, StaticFilesConfig, VitePlugin, ViteProcess, ViteProxyMiddleware
@@ -226,6 +228,45 @@ def test_vite_plugin_app_init_static_directories_configuration(tmp_path: Path) -
     assert result is app_config
     # Should configure multiple static directories in dev mode
     assert len(app_config.route_handlers) > 0
+
+
+def test_vite_plugin_production_stale_hmr_websocket_closes_cleanly(tmp_path: Path) -> None:
+    """Stale dev clients reconnecting to HMR in production must not hit Litestar's static HTTP route.
+
+    This reproduces issue #254: ``/static/{file_path:path}`` handles HTTP requests,
+    but a browser tab with an old Vite HMR client may still make a websocket
+    request to ``/static/vite-hmr`` after the app restarts with ``dev_mode=False``.
+    """
+
+    @get("/", sync_to_thread=False)
+    def index() -> str:
+        return "ok"
+
+    bundle_dir = tmp_path / "static"
+    bundle_dir.mkdir()
+
+    app = Litestar(
+        route_handlers=[index],
+        plugins=[
+            VitePlugin(
+                config=ViteConfig(
+                    mode="template",
+                    paths=PathConfig(bundle_dir=bundle_dir, asset_url="/static/"),
+                    runtime=RuntimeConfig(dev_mode=False),
+                )
+            )
+        ],
+        debug=True,
+    )
+
+    with TestClient(app=app) as client:
+        assert client.get("/static/vite-hmr").status_code == 404
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            with client.websocket_connect("/static/vite-hmr") as websocket:
+                websocket.receive_text()
+
+    assert exc_info.value.code == 1001
 
 
 def test_vite_plugin_app_init_no_proxy_when_proxy_mode_none(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/py/tests/unit/test_runtime_config.py
+++ b/src/py/tests/unit/test_runtime_config.py
@@ -34,6 +34,18 @@ def test_bridge_app_url_explicit_app_url_env(tmp_path: Path, monkeypatch: pytest
     assert data["appUrl"] == "https://api.example.com"
 
 
+def test_bridge_app_url_normalizes_bind_all_explicit_app_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APP_URL", "http://0.0.0.0:9001")
+
+    cfg = ViteConfig()
+    cfg.paths.root = tmp_path
+
+    path_str = write_runtime_config_file(cfg)
+    data = decode_json(Path(path_str).read_text())
+
+    assert data["appUrl"] == "http://localhost:9001"
+
+
 def test_bridge_app_url_falls_back_to_litestar_host_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("APP_URL", "")
     monkeypatch.setenv("LITESTAR_HOST", "0.0.0.0")
@@ -46,7 +58,7 @@ def test_bridge_app_url_falls_back_to_litestar_host_port(tmp_path: Path, monkeyp
     path_str = write_runtime_config_file(cfg)
     data = decode_json(Path(path_str).read_text())
 
-    assert data["appUrl"] == "http://0.0.0.0:9001"
+    assert data["appUrl"] == "http://localhost:9001"
 
 
 def test_bridge_app_url_falls_back_to_port_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/py/tests/unit/test_utils.py
+++ b/src/py/tests/unit/test_utils.py
@@ -119,12 +119,14 @@ def test_set_environment_sets_vars(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     monkeypatch.delenv("ASSET_URL", raising=False)
     monkeypatch.delenv("VITE_HOST", raising=False)
     monkeypatch.delenv("VITE_PORT", raising=False)
-    monkeypatch.delenv("LITESTAR_HOST", raising=False)
-    monkeypatch.delenv("LITESTAR_PORT", raising=False)
+    monkeypatch.setenv("LITESTAR_HOST", "0.0.0.0")
+    monkeypatch.setenv("LITESTAR_PORT", "8000")
+    monkeypatch.delenv("APP_URL", raising=False)
 
     utils.set_environment(config, asset_url_override="https://cdn.example.com/")
 
     assert os.environ["ASSET_URL"] == "https://cdn.example.com/"
+    assert os.environ["APP_URL"] == "http://localhost:8000"
     assert os.environ["VITE_HOST"] == "0.0.0.0"
     assert os.environ["VITE_PORT"] == "9999"
     assert os.environ["LITESTAR_VITE_CONFIG_PATH"].endswith(".litestar.json")

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1044,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.23.2"
+version = "0.23.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Normalize bind-all bridge app URLs (`0.0.0.0` / `[::]`) to localhost before emitting browser-facing `APP_URL` and `.litestar.json` `appUrl`.
- Normalize older bridge `appUrl` values in the JS plugin before using them for `server.origin` or default backend proxy targets.
- Route core Vite HMR client connections through the Litestar port in proxy mode while keeping hotfiles pointed at the actual Vite upstream.
- Add a production/no-proxy sink for stale `/static/vite-hmr` websocket attempts so old browser HMR clients close cleanly instead of crashing Litestar routing.
- Add Svelte Inertia mount null guards in the examples and scaffold template after full validation exposed production asset-build TypeScript failures.
- Include the `0.23.3` patch version bump.

## Root Cause

PR #252 split loader and proxy hotfile responsibilities, but apps that start with `LITESTAR_HOST=0.0.0.0` could write that bind address into `.litestar.json.appUrl`. The JS plugin then treated it as browser-facing configuration, so rendered HTML could leak absolute `0.0.0.0` asset URLs and Vite HMR still had a direct-port fallback path.

A second production-only issue remained after assets were otherwise rendering correctly: stale dev-mode browser clients can keep reconnecting to `/static/vite-hmr`. In production there is no websocket route for that path, and when static files own `/static/{file_path:path}`, Litestar can route the websocket attempt into an HTTP-only branch and raise `KeyError: 'websocket'`.

## Issue Relationship

- Fixes the stale HMR websocket crash reported in #254.
- This is related to the production HTMX/Jinja-style traceback where `/static/vite-hmr` appears on every page visit.
- This is not the same issue as the separate Inertia raw-HTML/AppHandler/runtime `resources/index.html` packaging report. I did not find a matching open/closed GitHub issue for that separate Inertia packaging problem while reviewing with `gh`.

## Implementation

- Browser-facing app URL normalization now treats bind-all hosts as local browser hosts.
- Dev proxy HMR remains enabled only when the proxy is configured.
- Production/static-folder mode registers a disabled HMR handler at the local asset HMR path:
  - HTTP `GET /static/vite-hmr` still behaves like a normal missing static asset.
  - Websocket `/static/vite-hmr` accepts and closes cleanly with code `1001`.
- Added a regression test that reproduces the stale-HMR websocket path with static folders enabled and no dev proxy.
- Added Svelte Inertia `el` null guards in both examples and the generated template so production asset builds pass TypeScript checks.
