### PR TITLE
fix(inertia): always send HTML content-type for bootstrap response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.23.3",
+      "version": "0.23.4",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.3",
+  "version": "0.23.4",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.23.3"
+version = "0.23.4"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -102,7 +102,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.23.3"
+current_version = "0.23.4"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -2,8 +2,6 @@ import contextlib
 import itertools
 from collections.abc import AsyncGenerator, Iterable, Mapping
 from dataclasses import dataclass
-from mimetypes import guess_type
-from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import quote, urlparse
 
@@ -316,8 +314,8 @@ class InertiaResponse(Response[T]):
                 ``Set-Cookie`` header.
             encoding: Content encoding
             headers: A string keyed dictionary of response headers. Header keys are insensitive.
-            media_type: A string or member of the :class:`MediaType <.enums.MediaType>` enum. If not set, try to infer
-                the media type based on the template name. If this fails, fall back to ``text/plain``.
+            media_type: A string or member of the :class:`MediaType <.enums.MediaType>` enum. If not set, Inertia JSON
+                responses use ``application/json`` and HTML bootstrap responses use ``text/html``.
             status_code: A value for the response HTTP status code.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             encrypt_history: Enable browser history encryption for this response (v2 feature).
@@ -659,22 +657,16 @@ class InertiaResponse(Response[T]):
         return vite_plugin.config.inertia_compatible
 
     def _determine_media_type(self, media_type: "MediaType | str | None") -> "MediaType | str":
-        """Determine the media type for the response.
+        """Determine the media type for HTML bootstrap responses.
 
         Args:
             media_type: The provided media type or None.
 
         Returns:
-            The determined media type.
+            The provided media type, or HTML when unset.
         """
         if media_type:
             return media_type
-        if self.template_name:
-            suffixes = PurePath(self.template_name).suffixes
-            for suffix in suffixes:
-                if type_ := guess_type(f"name{suffix}")[0]:
-                    return type_
-            return MediaType.TEXT
         return MediaType.HTML
 
     async def resolve_async_props(self, request: "Request[Any, Any, Any]") -> None:

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -864,13 +864,6 @@ class InertiaResponse(Response[T]):
                 status_code=self.status_code or status_code,
             )
 
-        # Bootstrap branch: body is always HTML, rendered by _render_spa or
-        # _render_template. Honour an explicit `self.media_type` if the user
-        # set one on the response, but ignore the route's `media_type` kwarg —
-        # Litestar's create_response_handler (used after the handler wrapping
-        # added in #249) forwards the route's declared media_type, which
-        # defaults to MediaType.JSON for @get and would otherwise be applied
-        # to an HTML body.
         resolved_media_type = self._determine_media_type(self.media_type)
 
         if vite_plugin.config.wants_spa_config:

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -864,7 +864,14 @@ class InertiaResponse(Response[T]):
                 status_code=self.status_code or status_code,
             )
 
-        resolved_media_type = self._determine_media_type(media_type or MediaType.HTML)
+        # Bootstrap branch: body is always HTML, rendered by _render_spa or
+        # _render_template. Honour an explicit `self.media_type` if the user
+        # set one on the response, but ignore the route's `media_type` kwarg —
+        # Litestar's create_response_handler (used after the handler wrapping
+        # added in #249) forwards the route's declared media_type, which
+        # defaults to MediaType.JSON for @get and would otherwise be applied
+        # to an HTML body.
+        resolved_media_type = self._determine_media_type(self.media_type)
 
         if vite_plugin.config.wants_spa_config:
             body = self._render_spa(request, page_props, vite_plugin)

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -1104,3 +1104,24 @@ async def test_always_prop_included_in_partial(
         assert data["props"]["auth"] == {"user": "Alice"}
         # Lazy prop should be included (was requested)
         assert data["props"]["analytics"] == {"views": 100}
+
+
+def test_determine_media_type_falls_back_to_html_when_unset() -> None:
+    """``_determine_media_type`` returns HTML when the response has no media_type.
+
+    The bootstrap branch in ``to_asgi_response`` calls
+    ``_determine_media_type(self.media_type)``. When the user did not set one,
+    ``self.media_type`` is ``None`` and the helper must fall back to HTML —
+    the route's declared ``media_type`` (forwarded via
+    ``create_response_handler`` after #249) must not leak in.
+    """
+    from litestar.enums import MediaType
+
+    resp: InertiaResponse[dict[str, Any]] = InertiaResponse(content={})
+    assert resp._determine_media_type(resp.media_type) == MediaType.HTML  # pyright: ignore[reportPrivateUsage]
+
+
+def test_determine_media_type_honours_explicit_response_media_type() -> None:
+    """Explicit ``media_type`` set on ``InertiaResponse`` is preserved."""
+    resp: InertiaResponse[dict[str, Any]] = InertiaResponse(content={}, media_type="application/xhtml+xml")
+    assert resp._determine_media_type(resp.media_type) == "application/xhtml+xml"  # pyright: ignore[reportPrivateUsage]

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from litestar import Request, get
+from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import ImproperlyConfiguredException, NotAuthorizedException
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.stores.memory import MemoryStore
@@ -964,6 +965,36 @@ async def test_html_bootstrap_response_uses_text_html_content_type(
         route_handlers=[handler],
         plugins=[inertia_plugin, vite_plugin],
         template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html"), (
+            f"expected text/html bootstrap, got {response.headers['content-type']!r}"
+        )
+        assert response.text.startswith("<!DOCTYPE html>")
+
+
+async def test_html_bootstrap_response_uses_text_html_content_type_for_custom_template_suffix(
+    tmp_path: Path,
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+) -> None:
+    (tmp_path / "app.jinja2").write_text(
+        '<!DOCTYPE html><html><body><div id="app" data-page="{{ inertia | escape }}"></div></body></html>'
+    )
+
+    @get("/", component="Home")
+    async def handler() -> Any:
+        from litestar_vite.inertia.response import InertiaResponse
+
+        return InertiaResponse(content={"thing": "value"}, template_name="app.jinja2")
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=TemplateConfig(engine=JinjaTemplateEngine(directory=tmp_path)),
         middleware=[ServerSideSessionConfig().middleware],
         stores={"sessions": MemoryStore()},
     ) as client:

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -977,9 +977,7 @@ async def test_html_bootstrap_response_uses_text_html_content_type(
 
 
 async def test_html_bootstrap_response_uses_text_html_content_type_for_custom_template_suffix(
-    tmp_path: Path,
-    inertia_plugin: InertiaPlugin,
-    vite_plugin: VitePlugin,
+    tmp_path: Path, inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin
 ) -> None:
     (tmp_path / "app.jinja2").write_text(
         '<!DOCTYPE html><html><body><div id="app" data-page="{{ inertia | escape }}"></div></body></html>'

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -942,6 +942,92 @@ async def test_inertia_response_uses_x_inertia_vary_header(
         assert html_response.headers["Vary"] == "X-Inertia"
 
 
+async def test_html_bootstrap_response_uses_text_html_content_type(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """The HTML bootstrap branch must send ``Content-Type: text/html``.
+
+    Regression for the 0.23.x bug: ``create_response_handler`` (used after the
+    handler-wrapping change in #249) forwards the route's declared
+    ``media_type`` — ``MediaType.JSON`` for ``@get`` by default — into
+    ``InertiaResponse.to_asgi_response``. The bootstrap branch renders HTML
+    unconditionally and must ignore that leaked default.
+    """
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {"thing": "value"}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html"), (
+            f"expected text/html bootstrap, got {response.headers['content-type']!r}"
+        )
+        assert response.text.startswith("<!DOCTYPE html>")
+
+
+async def test_inertia_partial_response_uses_application_json_content_type(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """The Inertia partial branch (X-Inertia: true) must remain JSON."""
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {"thing": "value"}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/json"
+        assert response.json()["component"] == "Home"
+
+
+async def test_explicit_response_media_type_is_respected_in_bootstrap(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """An explicit ``media_type`` set on the ``InertiaResponse`` object wins.
+
+    The bootstrap branch ignores the route's ``media_type`` kwarg, but a value
+    set directly on the response object must still flow through
+    ``_determine_media_type``.
+    """
+    from litestar_vite.inertia.response import InertiaResponse
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> InertiaResponse[dict[str, Any]]:
+        return InertiaResponse(content={"thing": "value"}, media_type="application/xhtml+xml")
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/xhtml+xml")
+
+
 async def test_hybrid_ssr_replaces_shell_root_and_injects_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that hybrid SSR replaces the root element instead of nesting it."""
     from litestar_vite.config import InertiaConfig, InertiaSSRConfig, PathConfig, RuntimeConfig, SPAConfig, ViteConfig

--- a/uv.lock
+++ b/uv.lock
@@ -1044,7 +1044,7 @@ wheels = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.23.3"
+version = "0.23.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
The handler wrapper added in #249 routes Inertia responses through Litestar's create_response_handler, which forwards the route's declared media_type (MediaType.JSON by default for @get) into InertiaResponse.to_asgi_response. The HTML bootstrap branch then resolved that JSON value via `_determine_media_type(media_type or MediaType.HTML)`, sending the response as HTML body + JSON Content-Type. Browsers refused to boot the Inertia SPA from a JSON-typed document.

The bootstrap branch always renders HTML (via _render_spa or _render_template) — a non-HTML media_type was always wrong here. Pass `self.media_type` only, so an explicit override on the response object still wins but the route's declared default cannot leak in.

Adds regression coverage:
- bootstrap returns text/html
- Inertia partial still returns application/json
- explicit response.media_type is honored
- _determine_media_type unit tests for the helper itself