### PR TITLE
fix(inertia): strip resolved keys from deferredProps on partial reload

### DIFF
--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -388,7 +388,7 @@ class InertiaResponse(Response[T]):
             "csrf_input": f'<input type="hidden" name="_csrf_token" value="{csrf_token}" />',
         }
 
-    def _build_page_props(  # noqa: PLR0915
+    def _build_page_props(  # noqa: PLR0915, C901
         self,
         request: "Request[UserT, AuthT, StateT]",
         partial_data: "set[str] | None",
@@ -458,6 +458,14 @@ class InertiaResponse(Response[T]):
             else:
                 shared_props["content"] = route_content
 
+        # v2.2+ protocol: drop keys this partial reload just resolved.
+        # Echoing them back makes @inertiajs/core treat the response as
+        # "still has deferred work" and re-fire loadDeferredProps forever.
+        # partial_except keys are NOT resolved by this response, so they
+        # remain legitimately deferred — no symmetric filter needed.
+        if partial_data:
+            for key in partial_data:
+                _discard_deferred_prop_key(deferred_props_map, key)
         deferred_props = deferred_props_map or None
         # Extract once props tracked during get_shared_props (already rendered)
         once_props_from_shared = [key for key in shared_props.pop("_once_props", []) if key not in reset_keys]

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -458,11 +458,7 @@ class InertiaResponse(Response[T]):
             else:
                 shared_props["content"] = route_content
 
-        # v2.2+ protocol: drop keys this partial reload just resolved.
-        # Echoing them back makes @inertiajs/core treat the response as
-        # "still has deferred work" and re-fire loadDeferredProps forever.
-        # partial_except keys are NOT resolved by this response, so they
-        # remain legitimately deferred — no symmetric filter needed.
+        # Drop keys this partial reload just resolved, or the client loops on loadDeferredProps.
         if partial_data:
             for key in partial_data:
                 _discard_deferred_prop_key(deferred_props_map, key)

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -2509,3 +2509,124 @@ def test_inertia_deferred_props_full_cycle() -> None:
         data_partial = response_partial.json()
         assert data_partial["props"]["deferred"] == "slow_result"
         assert "immediate" not in data_partial["props"]
+        # The resolved key must not be re-advertised as still-deferred,
+        # or the @inertiajs/core v3 client loops on loadDeferredProps.
+        assert "deferred" not in data_partial.get("deferredProps", {}).get("default", []), (
+            "Server echoed the resolved deferred key back in `deferredProps`; "
+            "this causes the Inertia v3 client to re-fire `loadDeferredProps` in an infinite loop."
+        )
+
+
+def test_deferred_props_partial_reload_strips_resolved_keys_from_metadata() -> None:
+    """A partial reload for a deferred key must not echo it back in `deferredProps`."""
+
+    @get("/", component="Home")
+    async def handler() -> dict[str, Any]:
+        return {"fast": "loads immediately", "slow": defer("slow", lambda: "computed")}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[InertiaPlugin(config=InertiaConfig()), VitePlugin()],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        partial = client.get(
+            "/",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_DATA.value: "slow",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Home",
+            },
+        )
+        body = partial.json()
+        assert body["props"]["slow"] == "computed"
+        # With the only deferred key resolved, `deferredProps` must drop out entirely.
+        assert body.get("deferredProps") in (None, {}), body.get("deferredProps")
+
+
+def test_deferred_props_partial_reload_preserves_unrequested_metadata() -> None:
+    """When only one of two deferred props is requested, the unrequested one
+    must remain in `deferredProps` so the client can fetch it later.
+    """
+
+    @get("/", component="Home")
+    async def handler() -> dict[str, Any]:
+        return {"first": defer("first", lambda: "value-1"), "second": defer("second", lambda: "value-2")}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[InertiaPlugin(config=InertiaConfig()), VitePlugin()],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        partial = client.get(
+            "/",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_DATA.value: "first",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Home",
+            },
+        )
+        body = partial.json()
+        assert body["props"]["first"] == "value-1"
+        assert "first" not in body["deferredProps"].get("default", [])
+        assert "second" in body["deferredProps"]["default"]
+
+
+def test_deferred_props_grouped_partial_reload_strips_only_requested_group() -> None:
+    """When deferred props live in distinct groups, a partial reload for one
+    group's keys must strip those keys from their group only; other groups
+    stay intact and an emptied group is removed entirely.
+    """
+
+    @get("/", component="Home")
+    async def handler() -> dict[str, Any]:
+        return {
+            "stats": defer("stats", lambda: {"hits": 1}, group="metrics"),
+            "perms": defer("perms", lambda: ["read"], group="security"),
+        }
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[InertiaPlugin(config=InertiaConfig()), VitePlugin()],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        partial = client.get(
+            "/",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_DATA.value: "stats",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Home",
+            },
+        )
+        body = partial.json()
+        assert body["props"]["stats"] == {"hits": 1}
+        assert "metrics" not in body.get("deferredProps", {}), (
+            "An emptied group must be removed from `deferredProps` entirely."
+        )
+        assert body["deferredProps"]["security"] == ["perms"]
+
+
+def test_deferred_props_initial_response_still_advertises_all_keys() -> None:
+    """The fix must NOT affect the initial response — every deferred key must
+    still be advertised so the client knows to fetch them. Regression guard
+    against over-correcting #236 / PR #241.
+    """
+
+    @get("/", component="Home")
+    async def handler() -> dict[str, Any]:
+        return {"a": defer("a", lambda: 1), "b": defer("b", lambda: 2, group="other")}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[InertiaPlugin(config=InertiaConfig()), VitePlugin()],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        initial = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        body = initial.json()
+        assert "a" not in body["props"]
+        assert "b" not in body["props"]
+        assert body["deferredProps"]["default"] == ["a"]
+        assert body["deferredProps"]["other"] == ["b"]


### PR DESCRIPTION
# Summary 


`InertiaResponse._build_page_props` unconditionally emits every `defer()` key in `deferredProps`, including on the partial-reload response that is actively resolving that key. The `@inertiajs/core` v3 client sees a non-empty `deferredProps` and unconditionally schedules another `loadDeferredProps` fetch, producing an **infinite request loop**.

Laravel's adapter strips resolved keys from `deferredProps` on partial reloads. We did not. This is a protocol-compliance bug.

## Root cause

`src/py/litestar_vite/inertia/response.py::InertiaResponse._build_page_props` (line 461):

```python
deferred_props = deferred_props_map or None    # ← always echoes resolved keys
```

`deferred_props_map` is populated from `extract_deferred_props(...)` **before** `lazy_render` resolves the deferred values. There was no subsequent filter against `partial_data`, so resolved keys were reported as still-deferred in the response.

PR #241 (which closed #236) correctly restored the missing metadata for the *initial* response but did not differentiate "initial" from "partial reload that resolved the deferred key".

## Client behaviour (for context)

`@inertiajs/core@3.1.1`:

- `index.js:1045` — every page `set()` with non-empty `deferredProps` schedules `pendingDeferredProps`.
- `index.js:1104` — `loadDeferredProps` fires after each swap when component+url match.
- `index.js:3346` — `loadDeferredProps` re-issues a partial reload per group.

"Drop resolved keys" filtering exists at `index.js:561` (prefetch cache) and `:1581` (popstate), but **not** in the regular partial-reload response handler. The protocol assumes the server has already filtered.

## Fix

After `lazy_render` resolves the requested keys, strip them from `deferred_props_map` before emission. Reuses the existing `_discard_deferred_prop_key` helper (response.py:887), which already handles "remove key from every group" and "drop the group if it becomes empty".

```python
# v2.2+ protocol: drop keys this partial reload just resolved.
# Echoing them back makes @inertiajs/core treat the response as
# "still has deferred work" and re-fire loadDeferredProps forever.
# partial_except keys are NOT resolved by this response, so they
# remain legitimately deferred — no symmetric filter needed.
if partial_data:
    for key in partial_data:
        _discard_deferred_prop_key(deferred_props_map, key)
deferred_props = deferred_props_map or None
```

- Initial responses have `partial_data is None` → the filter is skipped → #236 / PR #241 behaviour preserved.
- `partial_except` keys are excluded from this reload (not resolved), so they remain legitimately deferred — no symmetric filter needed.
- SSR pre-pass (`_prefetch_ssr`) also calls `_build_page_props`, so it picks up the fix automatically.
- No public API changes, no client-side changes, no migration.

## Tests

Five new assertions in `src/py/tests/unit/inertia/test_response.py`:

| Test                                                                     | What it locks in                                                              |
| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| `test_inertia_deferred_props_full_cycle` (extended)                      | Cheap "this would have caught the bug" guard on the existing full-cycle test. |
| `test_deferred_props_partial_reload_strips_resolved_keys_from_metadata`  | The bug itself — single-key partial reload drops `deferredProps` entirely.    |
| `test_deferred_props_partial_reload_preserves_unrequested_metadata`      | Unrequested deferred props stay advertised.                                   |
| `test_deferred_props_grouped_partial_reload_strips_only_requested_group` | Group-correctness; emptied groups removed entirely.                           |
| `test_deferred_props_initial_response_still_advertises_all_keys`         | Non-regression guard against over-correcting #236 / PR #241.                  |