### PR TITLE
feat: prepare for Litestar 3 deprecations and fix Inertia integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Litestar Vite connects the Litestar backend to a Vite toolchain. It supports SPA
 
 ## Features
 
-- One-port dev: proxies Vite HTTP + WS/HMR through Litestar by default; switch to two-port with `VITE_PROXY_MODE=direct`.
+- One-port dev: proxies Vite HTTP + WS/HMR through Litestar on a single ASGI port by default.
 - Framework-mode support: use `mode="framework"` (alias `mode="ssr"`) for Astro, Nuxt, and SvelteKit. Litestar proxies everything except your API routes.
 - Production assets: reads the Vite manifest from `public/manifest.json` (configurable) and serves under `asset_url`.
 - Type-safe frontends: optional OpenAPI/routes export plus `@hey-api/openapi-ts` via the Vite plugin.

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -4,7 +4,7 @@ Litestar Vite connects the Litestar backend to a Vite toolchain. It supports SPA
 
 ## Features
 
-- One-port dev: proxies Vite HTTP + WS/HMR through Litestar by default; switch to two-port with `VITE_PROXY_MODE=direct`.
+- One-port dev: proxies Vite HTTP + WS/HMR through Litestar on a single ASGI port by default.
 - Framework-mode support: use `mode="framework"` (alias `mode="ssr"`) for Astro, Nuxt, and SvelteKit. Litestar proxies everything except your API routes.
 - Production assets: reads the Vite manifest from `public/manifest.json` (configurable) and serves under `asset_url`.
 - Type-safe frontends: optional OpenAPI/routes export plus `@hey-api/openapi-ts` via the Vite plugin.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ nitpick_ignore = [
     (PY_CLASS, "EmptyType"),
     (PY_CLASS, "ModelT"),
     (PY_CLASS, "T"),
-    (PY_CLASS, "litestar.contrib.jinja.T"),
+    (PY_CLASS, "litestar.plugins.jinja.T"),
     (PY_CLASS, "config.app.AppConfig"),
     (PY_OBJ, "litestar.template.config.EngineType"),
     (PY_CLASS, "litestar.template.config.EngineType"),

--- a/docs/frameworks/inertia/configuration.rst
+++ b/docs/frameworks/inertia/configuration.rst
@@ -35,6 +35,19 @@ Or with custom configuration:
        ),
    ))
 
+Vite Plugin Boundary
+--------------------
+
+Use ``litestar-vite-plugin`` as the default Vite plugin for Litestar-backed Inertia apps. It owns
+the Litestar bridge file, dev/prod asset resolution, proxy routing, type generation, CSRF helper
+wiring, and the ``resolvePageComponent()`` helper used by generated entries.
+
+Do not add ``@inertiajs/vite`` to generated Litestar scaffolds by default. Applications can
+experiment with ``@inertiajs/vite`` for its page shorthand or upstream SSR automation, but it must
+not replace the Litestar bridge/proxy/typegen responsibilities. If both plugins are combined,
+``litestar-vite-plugin`` should remain the bridge owner and ``@inertiajs/vite`` should be treated
+as application-owned integration code.
+
 InertiaConfig Reference
 -----------------------
 

--- a/docs/frameworks/inertia/deferred-props.rst
+++ b/docs/frameworks/inertia/deferred-props.rst
@@ -44,10 +44,11 @@ Group related props to fetch them together:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
    from litestar_vite.inertia import defer
 
    @get("/users/{id}", component="Users/Show")
-   async def show_user(id: int) -> dict[str, Any]:
+   async def show_user(id: FromPath[int]) -> dict[str, Any]:
        return {
            "user": get_user(id),                                       # Immediate
 

--- a/docs/frameworks/inertia/infinite-scroll.rst
+++ b/docs/frameworks/inertia/infinite-scroll.rst
@@ -21,10 +21,11 @@ Mark list props as mergeable and provide scroll metadata:
 .. code-block:: python
 
    from litestar import get
+   from litestar.params import FromQuery
    from litestar_vite.inertia import merge, scroll_props, InertiaResponse
 
    @get("/posts", component="Posts")
-   async def list_posts(page: int = 1) -> InertiaResponse:
+   async def list_posts(page: FromQuery[int] = 1) -> InertiaResponse:
        posts = await Post.paginate(page=page, per_page=20)
        return InertiaResponse(
            {"posts": merge("posts", posts.items, match_on="id")},
@@ -44,10 +45,11 @@ the route. Litestar-Vite will extract items and scroll props for you:
 
 .. code-block:: python
 
+   from litestar.params import FromQuery
    from litestar.pagination import OffsetPagination
 
    @get("/posts", component="Posts", infinite_scroll=True, key="posts")
-   async def list_posts(offset: int = 0, limit: int = 20) -> OffsetPagination[Post]:
+   async def list_posts(offset: FromQuery[int] = 0, limit: FromQuery[int] = 20) -> OffsetPagination[Post]:
        posts, total = await Post.paginate(offset=offset, limit=limit)
        return OffsetPagination(items=posts, total=total, limit=limit, offset=offset)
 

--- a/docs/frameworks/inertia/load-when-visible.rst
+++ b/docs/frameworks/inertia/load-when-visible.rst
@@ -21,10 +21,11 @@ Backend Usage
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
    from litestar_vite.inertia import optional
 
    @get("/posts/{post_id}", component="Posts/Show")
-   async def show_post(post_id: int) -> dict[str, Any]:
+   async def show_post(post_id: FromPath[int]) -> dict[str, Any]:
        return {
            "post": await Post.get(post_id),
            "comments": optional("comments", lambda: Comment.for_post(post_id)),

--- a/docs/frameworks/inertia/merging-props.rst
+++ b/docs/frameworks/inertia/merging-props.rst
@@ -17,10 +17,11 @@ Use ``merge()`` to append or prepend data instead of replacing:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromQuery
    from litestar_vite.inertia import merge
 
    @get("/posts", component="Posts")
-   async def list_posts(page: int = 1) -> dict[str, Any]:
+   async def list_posts(page: FromQuery[int] = 1) -> dict[str, Any]:
        posts = await Post.paginate(page=page, per_page=20)
        return {
            "posts": merge("posts", posts.items),  # Append to existing
@@ -67,10 +68,11 @@ Backend
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromQuery
    from litestar_vite.inertia import merge, scroll_props
 
    @get("/posts", component="Posts")
-   async def list_posts(page: int = 1) -> dict[str, Any]:
+   async def list_posts(page: FromQuery[int] = 1) -> dict[str, Any]:
        posts = await Post.paginate(page=page, per_page=20)
        return {
            "posts": merge("posts", posts.items),
@@ -170,10 +172,13 @@ Return pagination objects directly - items and scroll props are extracted:
 .. code-block:: python
 
    from litestar import get
+   from litestar.params import FromQuery
    from litestar.pagination import OffsetPagination
 
    @get("/posts", component="Posts", infinite_scroll=True)
-   async def list_posts(offset: int = 0, limit: int = 20) -> OffsetPagination[Post]:
+   async def list_posts(
+       offset: FromQuery[int] = 0, limit: FromQuery[int] = 20
+   ) -> OffsetPagination[Post]:
        posts, total = await Post.paginate(offset, limit)
        return OffsetPagination(items=posts, offset=offset, limit=limit, total=total)
 
@@ -195,10 +200,11 @@ The pagination container is automatically unwrapped:
 .. code-block:: python
 
    from litestar import get
+   from litestar.params import FromQuery
    from litestar.pagination import OffsetPagination
 
    @get("/posts", component="Posts", infinite_scroll=True, key="posts")
-   async def list_posts(offset: int = 0) -> OffsetPagination[Post]:
+   async def list_posts(offset: FromQuery[int] = 0) -> OffsetPagination[Post]:
        ...  # Props will have "posts" instead of "items"
 
 Protocol Response

--- a/docs/frameworks/inertia/pages.rst
+++ b/docs/frameworks/inertia/pages.rst
@@ -54,9 +54,10 @@ The dictionary returned from your handler becomes the page props:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
 
    @get("/users/{user_id:int}", component="Users/Show")
-   async def show_user(user_id: int) -> dict[str, Any]:
+   async def show_user(user_id: FromPath[int]) -> dict[str, Any]:
        user = await User.get(user_id)
        return {
            "user": {
@@ -134,15 +135,16 @@ Use path separators for nested page organization:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
 
    @get("/users", component="Users/Index")
    async def list_users() -> dict[str, Any]: ...
 
    @get("/users/{id}", component="Users/Show")
-   async def show_user(id: int) -> dict[str, Any]: ...
+   async def show_user(id: FromPath[int]) -> dict[str, Any]: ...
 
    @get("/users/{id}/edit", component="Users/Edit")
-   async def edit_user(id: int) -> dict[str, Any]: ...
+   async def edit_user(id: FromPath[int]) -> dict[str, Any]: ...
 
 See Also
 --------

--- a/docs/frameworks/inertia/partial-reloads.rst
+++ b/docs/frameworks/inertia/partial-reloads.rst
@@ -97,10 +97,11 @@ Optional props are only included when explicitly requested:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
    from litestar_vite.inertia import optional
 
    @get("/posts/{post_id}", component="Posts/Show")
-   async def show_post(post_id: int) -> dict[str, Any]:
+   async def show_post(post_id: FromPath[int]) -> dict[str, Any]:
        return {
            "post": await Post.get(post_id),
            "comments": optional("comments", lambda: Comment.for_post(post_id)),

--- a/docs/frameworks/inertia/responses.rst
+++ b/docs/frameworks/inertia/responses.rst
@@ -105,10 +105,11 @@ Return pagination objects directly - they're automatically unwrapped:
 .. code-block:: python
 
    from litestar import get
+   from litestar.params import FromQuery
    from litestar.pagination import OffsetPagination
 
    @get("/users", component="Users")
-   async def list_users(offset: int = 0, limit: int = 20) -> OffsetPagination[User]:
+   async def list_users(offset: FromQuery[int] = 0, limit: FromQuery[int] = 20) -> OffsetPagination[User]:
        users, total = await User.paginate(offset, limit)
        return OffsetPagination(
            items=users,

--- a/docs/frameworks/inertia/routing.rst
+++ b/docs/frameworks/inertia/routing.rst
@@ -235,9 +235,10 @@ litestar-vite uses kebab-case for route names by default (converted from Python 
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
 
    @get("/users/{user_id}", component="UserProfile")
-   async def user_profile(user_id: int) -> dict[str, Any]:
+   async def user_profile(user_id: FromPath[int]) -> dict[str, Any]:
        ...  # Route name: "user-profile"
 
    @get("/users", component="Users")
@@ -251,9 +252,10 @@ This differs from Laravel's dot notation (``users.show``), but you can customize
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
 
    @get("/users/{user_id}", component="UserProfile", name="users.show")
-   async def user_profile(user_id: int) -> dict[str, Any]:
+   async def user_profile(user_id: FromPath[int]) -> dict[str, Any]:
        ...  # Route name: "users.show" (custom)
 
 See Also

--- a/docs/frameworks/inertia/templates.rst
+++ b/docs/frameworks/inertia/templates.rst
@@ -19,7 +19,7 @@ It's rendered on initial page loads with page data embedded.
 
 Key features:
 
-- ``<title inertia>`` - Enables dynamic title updates via Inertia's ``<Head>`` component
+- ``<title data-inertia>`` - Enables dynamic title updates via Inertia's ``<Head>`` component
 - ``<script type="application/json" id="app_page" data-page="app">`` - Script-element bootstrap payload for the current default transport
 - ``{{ inertia | safe }}`` - JSON-encoded page payload (use ``| safe`` to prevent escaping)
 - ``{{ vite_hmr() }}`` and ``{{ vite() }}`` - Vite asset injection
@@ -107,11 +107,11 @@ Use this attribute form only when you set ``use_script_element=False``.
 Dynamic Titles
 --------------
 
-Add the ``inertia`` attribute to ``<title>`` for dynamic title support:
+Add the ``data-inertia`` attribute to ``<title>`` for dynamic title support:
 
 .. code-block:: html
 
-   <title inertia>Default Title</title>
+   <title data-inertia>Default Title</title>
 
 Then update titles from your components using Inertia's ``<Head>`` component:
 

--- a/docs/frameworks/inertia/typed-page-props.rst
+++ b/docs/frameworks/inertia/typed-page-props.rst
@@ -124,12 +124,13 @@ Use path separators for component organization:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
 
    @get("/users", component="Users/Index")
    async def list_users() -> dict[str, Any]: ...
 
    @get("/users/{id}", component="Users/Show")
-   async def show_user(id: int) -> dict[str, Any]: ...
+   async def show_user(id: FromPath[int]) -> dict[str, Any]: ...
 
 Access via:
 
@@ -197,9 +198,10 @@ Optional props are marked with ``?``:
    from typing import Any
 
    from litestar import get
+   from litestar.params import FromPath
 
    @get("/users/{id}", component="Users/Show")
-   async def show_user(id: int) -> dict[str, Any]:
+   async def show_user(id: FromPath[int]) -> dict[str, Any]:
        user = await User.get_or_none(id)
        return {
            "user": user,  # Can be None

--- a/docs/reference/inertia/ssr.rst
+++ b/docs/reference/inertia/ssr.rst
@@ -13,10 +13,55 @@ This SSR path is distinct from framework proxy mode:
 - Inertia SSR: ``InertiaConfig(ssr=True)``
 - Meta-framework proxy mode: ``ViteConfig(mode="framework")`` or alias ``mode="ssr"``
 
+The SSR server is a Node ``/render`` endpoint. Litestar posts the page object to
+``InertiaSSRConfig.url`` and uses the returned ``head`` and ``body`` fields when building the
+initial HTML response. This request is required when SSR is enabled; failures to contact the
+configured endpoint are errors, not a silent fallback to client-side rendering.
+
 Typical file layout:
 
 - Browser entry: ``resources/main.tsx`` or ``resources/main.ts``
 - Node SSR entry: ``resources/ssr.tsx`` or ``resources/ssr.ts``
+
+Process management
+------------------
+
+``InertiaSSRConfig.command`` can start the Node ``/render`` server during Litestar lifespan:
+
+.. code-block:: python
+
+   from litestar_vite import InertiaConfig, InertiaSSRConfig
+
+   InertiaConfig(
+       ssr=InertiaSSRConfig(
+           command=["npm", "run", "start:ssr"],
+           auto_start=True,
+           health_check=True,
+       )
+   )
+
+When ``command`` is set and ``auto_start`` is true, litestar-vite starts the process on
+application startup and stops it on shutdown. Set ``auto_start=False`` when another process
+manager owns the SSR server. With ``health_check=True``, startup polls the configured SSR URL up
+to ``health_check_timeout`` seconds and logs a warning if the endpoint does not become reachable.
+
+Plugin boundary
+---------------
+
+Generated Litestar scaffolds do not install ``@inertiajs/vite`` by default. The default frontend
+bridge remains ``litestar-vite-plugin`` because it owns Litestar-specific behavior:
+
+- writing and reading the ``.litestar.json`` bridge contract;
+- dev/prod asset resolution and proxy integration;
+- route and schema type generation;
+- CSRF helper wiring for generated Inertia entries;
+- the ``resolvePageComponent()`` wrapper used by the templates.
+
+The upstream ``@inertiajs/vite`` plugin may be useful if an application wants to experiment with
+its page shorthand or Laravel-centered SSR automation, but it must not replace the
+``litestar-vite-plugin`` bridge/proxy/typegen responsibilities. If both plugins are combined,
+keep ``litestar-vite-plugin`` as the bridge owner and treat ``@inertiajs/vite`` as application
+owned integration code.
 
 When you use the default script-element bootstrap transport:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ All examples must implement the same "Library" backend with these endpoints:
 
 ```python
 from litestar import Controller, get
+from litestar.params import FromPath
 from msgspec import Struct
 
 class Book(Struct):
@@ -63,7 +64,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         # Return book or raise NotFoundException
         ...
 ```

--- a/examples/angular-cli/app.py
+++ b/examples/angular-cli/app.py
@@ -100,10 +100,10 @@ class LibraryController(Controller):
 
 # VitePlugin for development proxy, type generation, and production static serving
 # - Dev: Auto-starts Angular CLI (ng serve) and proxies to port 4200
-# - Prod: mode="external" auto-serves bundle_dir as static files
+# - Prod: framework mode auto-serves bundle_dir as static files
 vite = VitePlugin(
     config=ViteConfig(
-        mode="external",
+        mode="framework",
         dev_mode=DEV_MODE,
         paths=PathConfig(root=here, bundle_dir=dist_dir),
         types=TypeGenConfig(),

--- a/examples/angular-cli/app.py
+++ b/examples/angular-cli/app.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import ExternalDevServer, PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -88,7 +89,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/angular/app.py
+++ b/examples/angular/app.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -84,7 +85,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/astro/app.py
+++ b/examples/astro/app.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -87,7 +88,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/htmx-no-jinja/app.py
+++ b/examples/htmx-no-jinja/app.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, Response, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -128,7 +129,7 @@ class LibraryController(Controller):
         return Response(content=_index_html(_get_summary(), BOOKS), media_type="text/html")
 
     @get("/fragments/book/{book_id:int}")
-    async def book_fragment(self, book_id: int) -> Response[str]:
+    async def book_fragment(self, book_id: FromPath[int]) -> Response[str]:
         """Return a book card fragment for HTMX swaps.
 
         Returns:
@@ -145,7 +146,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/jinja-htmx/app.py
+++ b/examples/jinja-htmx/app.py
@@ -5,8 +5,9 @@ from pathlib import Path
 
 # [docs-start:htmx-imports]
 from litestar import Controller, Litestar, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
 from litestar_htmx import HTMXPlugin, HTMXRequest
@@ -77,7 +78,7 @@ class LibraryController(Controller):
 
     # [docs-start:htmx-fragment]
     @get("/fragments/book/{book_id:int}")
-    async def book_fragment(self, book_id: int) -> Template:
+    async def book_fragment(self, book_id: FromPath[int]) -> Template:
         """Return a book card fragment for HTMX swaps.
 
         Returns:
@@ -103,7 +104,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/nuxt/app.py
+++ b/examples/nuxt/app.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -95,7 +96,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/react-inertia-jinja/app.py
+++ b/examples/react-inertia-jinja/app.py
@@ -8,9 +8,10 @@ import os
 from pathlib import Path
 
 from litestar import Controller, Litestar, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template import TemplateConfig
 from msgspec import Struct
 
@@ -91,7 +92,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/react-inertia-jinja/index.html
+++ b/examples/react-inertia-jinja/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>react-inertia</title>
+    <title data-inertia>react-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/react-inertia-jinja/index.html
+++ b/examples/react-inertia-jinja/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>react-inertia</title>
+    <title>react-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/react-inertia-jinja/templates/index.html
+++ b/examples/react-inertia-jinja/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>react-inertia</title>
+    <title data-inertia>react-inertia</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.tsx') }}
   </head>

--- a/examples/react-inertia-jinja/templates/index.html
+++ b/examples/react-inertia-jinja/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>react-inertia</title>
+    <title>react-inertia</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.tsx') }}
   </head>

--- a/examples/react-inertia/app.py
+++ b/examples/react-inertia/app.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import InertiaConfig, PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -89,7 +90,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/react-inertia/index.html
+++ b/examples/react-inertia/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>react-inertia</title>
+    <title data-inertia>react-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/react-inertia/index.html
+++ b/examples/react-inertia/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>react-inertia</title>
+    <title>react-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/react-inertia/resources/index.html
+++ b/examples/react-inertia/resources/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>react-inertia</title>
+    <title data-inertia>react-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/react-inertia/resources/index.html
+++ b/examples/react-inertia/resources/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>react-inertia</title>
+    <title>react-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/react-router/app.py
+++ b/examples/react-router/app.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -71,7 +72,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/react-tanstack/app.py
+++ b/examples/react-tanstack/app.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -85,7 +86,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/react/app.py
+++ b/examples/react/app.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -84,7 +85,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/svelte-inertia-jinja/app.py
+++ b/examples/svelte-inertia-jinja/app.py
@@ -10,9 +10,10 @@ import os
 from pathlib import Path
 
 from litestar import Controller, Litestar, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template import TemplateConfig
 from msgspec import Struct
 
@@ -93,7 +94,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/svelte-inertia-jinja/templates/index.html
+++ b/examples/svelte-inertia-jinja/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>svelte-inertia-jinja</title>
+    <title data-inertia>svelte-inertia-jinja</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.ts') }}
   </head>

--- a/examples/svelte-inertia-jinja/templates/index.html
+++ b/examples/svelte-inertia-jinja/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>svelte-inertia-jinja</title>
+    <title>svelte-inertia-jinja</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.ts') }}
   </head>

--- a/examples/svelte-inertia/app.py
+++ b/examples/svelte-inertia/app.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import InertiaConfig, PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -94,7 +95,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/svelte-inertia/index.html
+++ b/examples/svelte-inertia/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>svelte-inertia</title>
+    <title>svelte-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/svelte-inertia/index.html
+++ b/examples/svelte-inertia/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>svelte-inertia</title>
+    <title data-inertia>svelte-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/svelte/app.py
+++ b/examples/svelte/app.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -87,7 +88,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/sveltekit/app.py
+++ b/examples/sveltekit/app.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -100,7 +101,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/examples/vue-inertia-jinja-ssr/app.py
+++ b/examples/vue-inertia-jinja-ssr/app.py
@@ -20,9 +20,10 @@ import os
 from pathlib import Path
 
 from litestar import Controller, Litestar, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template import TemplateConfig
 from msgspec import Struct
 
@@ -111,7 +112,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/vue-inertia-jinja-ssr/templates/index.html
+++ b/examples/vue-inertia-jinja-ssr/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>vue-inertia-jinja-ssr</title>
+    <title>vue-inertia-jinja-ssr</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.ts') }}
   </head>

--- a/examples/vue-inertia-jinja-ssr/templates/index.html
+++ b/examples/vue-inertia-jinja-ssr/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>vue-inertia-jinja-ssr</title>
+    <title data-inertia>vue-inertia-jinja-ssr</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.ts') }}
   </head>

--- a/examples/vue-inertia-jinja/app.py
+++ b/examples/vue-inertia-jinja/app.py
@@ -8,9 +8,10 @@ import os
 from pathlib import Path
 
 from litestar import Controller, Litestar, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template import TemplateConfig
 from msgspec import Struct
 
@@ -96,7 +97,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/vue-inertia-jinja/templates/index.html
+++ b/examples/vue-inertia-jinja/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>vue-inertia</title>
+    <title data-inertia>vue-inertia</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.ts') }}
   </head>

--- a/examples/vue-inertia-jinja/templates/index.html
+++ b/examples/vue-inertia-jinja/templates/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>vue-inertia</title>
+    <title>vue-inertia</title>
     {{ vite_hmr() }}
     {{ vite('resources/main.ts') }}
   </head>

--- a/examples/vue-inertia-ssr/app.py
+++ b/examples/vue-inertia-ssr/app.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import InertiaConfig, PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -103,7 +104,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/vue-inertia-ssr/index.html
+++ b/examples/vue-inertia-ssr/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>vue-inertia-ssr</title>
+    <title data-inertia>vue-inertia-ssr</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/vue-inertia-ssr/index.html
+++ b/examples/vue-inertia-ssr/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>vue-inertia-ssr</title>
+    <title>vue-inertia-ssr</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/vue-inertia/app.py
+++ b/examples/vue-inertia/app.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
 from litestar.middleware.session.client_side import CookieBackendConfig
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import InertiaConfig, PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -94,7 +95,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         return _get_book(book_id)
 
 

--- a/examples/vue-inertia/resources/index.html
+++ b/examples/vue-inertia/resources/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>vue-inertia</title>
+    <title>vue-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/vue-inertia/resources/index.html
+++ b/examples/vue-inertia/resources/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>vue-inertia</title>
+    <title data-inertia>vue-inertia</title>
   </head>
   <body>
     <div id="app"></div>

--- a/examples/vue/app.py
+++ b/examples/vue/app.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from litestar import Controller, Litestar, get
 from litestar.exceptions import NotFoundException
+from litestar.params import FromPath
 from msgspec import Struct
 
 from litestar_vite import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig, VitePlugin
@@ -87,7 +88,7 @@ class LibraryController(Controller):
         return BOOKS
 
     @get("/api/books/{book_id:int}")
-    async def book_detail(self, book_id: int) -> Book:
+    async def book_detail(self, book_id: FromPath[int]) -> Book:
         """Return a single book by id.
 
         Returns:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15,7 +15,7 @@
 | Node | >=22.12.0 |
 | Vite peer | ^7.0.0 \|\| ^8.0.0 |
 
-Python dependencies: litestar>=2.7.0, httpx>=0.24.1, websockets>=12.0, typing_extensions
+Python dependencies: litestar>=2.22.0, httpx>=0.24.1, websockets>=12.0, typing_extensions
 Optional extras: jinja (jinja2), nodeenv (nodeenv), http2 (h2>=4.0.0)
 
 npm dependencies: picocolors ^1.1.1, vite-plugin-full-reload ^1.2.0

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -461,7 +461,7 @@ Any type with an `items` attribute satisfies it; built-in support covers
 Source: `litestar_vite.plugin`
 
 ```python
-class VitePlugin(InitPluginProtocol, CLIPlugin):
+class VitePlugin(InitPlugin, CLIPlugin):
     def __init__(
         self,
         config: ViteConfig | None = None,
@@ -518,7 +518,7 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
 Source: `litestar_vite.inertia.plugin`
 
 ```python
-class InertiaPlugin(InitPluginProtocol):
+class InertiaPlugin(InitPlugin):
     def __init__(self, config: InertiaConfig) -> None: ...
 
     @asynccontextmanager
@@ -1279,7 +1279,7 @@ app = Litestar(
 
 ```python
 from litestar import Litestar
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 from litestar_vite import VitePlugin, ViteConfig
 

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ Litestar Vite connects the Litestar backend to a Vite toolchain. It supports SPA
 
 ## Core Concepts
 
-**VitePlugin** (`litestar_vite.plugin.VitePlugin`): Main Litestar plugin implementing `InitPluginProtocol` and `CLIPlugin`. Handles static file serving, Jinja2 template callable registration, Vite dev server process management, dev proxy middleware, and SPA handler initialization.
+**VitePlugin** (`litestar_vite.plugin.VitePlugin`): Main Litestar plugin implementing `InitPlugin` and `CLIPlugin`. Handles static file serving, Jinja2 template callable registration, Vite dev server process management, dev proxy middleware, and SPA handler initialization.
 
 **ViteConfig** (`litestar_vite.config.ViteConfig`): Root configuration dataclass. Key fields: `mode` (spa/template/htmx/hybrid/inertia/framework/ssr/ssg/external, auto-detected if unset), `dev_mode` (bool), `paths` (PathConfig), `runtime` (RuntimeConfig), `types` (TypeGenConfig|bool), `inertia` (InertiaConfig|bool), `spa` (SPAConfig|bool), `deploy` (DeployConfig|bool), `static_props` (dict written to `.litestar.json`), `guards` (Sequence[Guard] for the SPA catch-all), `exclude_static_from_auth` (bool), `spa_path` (str), `include_root_spa_paths` (bool).
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ Litestar Vite connects the Litestar backend to a Vite toolchain. It supports SPA
 - Package: `litestar-vite`
 - Version: 0.23.5
 - Python: >=3.10
-- Key dependencies: `litestar>=2.7.0`, `httpx>=0.24.1`, `websockets>=12.0`, `typing_extensions`
+- Key dependencies: `litestar>=2.22.0`, `httpx>=0.24.1`, `websockets>=12.0`, `typing_extensions`
 - Optional extras: `jinja` (Jinja2 templates), `nodeenv` (auto-detected Node), `http2` (h2 for proxy)
 
 ## npm Package

--- a/package-lock.json
+++ b/package-lock.json
@@ -686,9 +686,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
-      "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.68.0.tgz",
+      "integrity": "sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==",
       "cpu": [
         "arm"
       ],
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
-      "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.68.0.tgz",
+      "integrity": "sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==",
       "cpu": [
         "arm64"
       ],
@@ -1053,9 +1053,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
-      "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.68.0.tgz",
+      "integrity": "sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==",
       "cpu": [
         "arm64"
       ],
@@ -1070,9 +1070,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
-      "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.68.0.tgz",
+      "integrity": "sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==",
       "cpu": [
         "x64"
       ],
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
-      "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.68.0.tgz",
+      "integrity": "sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==",
       "cpu": [
         "x64"
       ],
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
-      "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.68.0.tgz",
+      "integrity": "sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==",
       "cpu": [
         "arm"
       ],
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
-      "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.68.0.tgz",
+      "integrity": "sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==",
       "cpu": [
         "arm"
       ],
@@ -1138,9 +1138,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
-      "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.68.0.tgz",
+      "integrity": "sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==",
       "cpu": [
         "arm64"
       ],
@@ -1155,9 +1155,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
-      "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.68.0.tgz",
+      "integrity": "sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==",
       "cpu": [
         "arm64"
       ],
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
-      "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.68.0.tgz",
+      "integrity": "sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==",
       "cpu": [
         "ppc64"
       ],
@@ -1189,9 +1189,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
-      "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.68.0.tgz",
+      "integrity": "sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==",
       "cpu": [
         "riscv64"
       ],
@@ -1206,9 +1206,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
-      "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.68.0.tgz",
+      "integrity": "sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==",
       "cpu": [
         "riscv64"
       ],
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
-      "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.68.0.tgz",
+      "integrity": "sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==",
       "cpu": [
         "s390x"
       ],
@@ -1240,9 +1240,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
-      "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.68.0.tgz",
+      "integrity": "sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==",
       "cpu": [
         "x64"
       ],
@@ -1257,9 +1257,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
-      "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.68.0.tgz",
+      "integrity": "sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==",
       "cpu": [
         "x64"
       ],
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
-      "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.68.0.tgz",
+      "integrity": "sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==",
       "cpu": [
         "arm64"
       ],
@@ -1291,9 +1291,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
-      "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.68.0.tgz",
+      "integrity": "sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==",
       "cpu": [
         "arm64"
       ],
@@ -1308,9 +1308,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
-      "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.68.0.tgz",
+      "integrity": "sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==",
       "cpu": [
         "ia32"
       ],
@@ -1325,9 +1325,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
-      "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.68.0.tgz",
+      "integrity": "sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==",
       "cpu": [
         "x64"
       ],
@@ -1353,9 +1353,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1370,9 +1370,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1387,9 +1387,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1404,9 +1404,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1421,9 +1421,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1438,9 +1438,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1455,9 +1455,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1489,9 +1489,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1506,9 +1506,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1523,9 +1523,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1593,9 +1593,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1617,9 +1617,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.0.tgz",
+      "integrity": "sha512-dnxczajOqt0gesZlN5pGQ1s1imQVrsmCw5G2Ci4oM+0WvNz3pyRnlWrT7McoZIb8VlFwCawdmbWRmxRn7HI+VQ==",
       "cpu": [
         "arm"
       ],
@@ -1631,9 +1631,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.0.tgz",
+      "integrity": "sha512-Bp3JpGP00Vu3f238ivRrjf7z3xSzVPXqCmaJYA9t2c+c8vKYvOzmXF7LkkeUalTEGd6cZcSWe+PFIP3Vy48fRg==",
       "cpu": [
         "arm64"
       ],
@@ -1645,9 +1645,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.0.tgz",
+      "integrity": "sha512-zaYIpr670mUmmZ1tVzUFplbQbG7h3Gugx3L5FoqhsC2m/YnLlR1a7zVLmXNPy+iY1tFPEbNG+HHBXZGyId0G5w==",
       "cpu": [
         "arm64"
       ],
@@ -1659,9 +1659,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.0.tgz",
+      "integrity": "sha512-+P49fvkv2dSoeevUW+lgZ/I2JHSsJCK1Lyjj7Cu6E4UHG4tS9XIefzIjo5qhgELjAclnen1rLzK2PMKJdo+Dyg==",
       "cpu": [
         "x64"
       ],
@@ -1673,9 +1673,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.0.tgz",
+      "integrity": "sha512-l3FAAOyKJXH2ea6KNFN+MMgC/rnE94YGLXs2ehYqDcCoHt1DpvgWX75BhUJxN38XojP7Ul+4H8PRn7EdyqSDrw==",
       "cpu": [
         "arm64"
       ],
@@ -1687,9 +1687,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.0.tgz",
+      "integrity": "sha512-VokPN3TSctKj65cyCNPaUh4vMFA8awxOot/0sp+4J7ZlNRKQEhXhawqPwajoi8H5ZFt61i0ugZJuTKXBjGJ17Q==",
       "cpu": [
         "x64"
       ],
@@ -1701,9 +1701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.0.tgz",
+      "integrity": "sha512-DxH0P3wxm+Yzs/p3zrk9dw1rURu8p0Nv5+MRK/L7OtnLNg5rLZraSBFZ8iUXOd9f2BlhJyEpIZUH/emjq4UJ4g==",
       "cpu": [
         "arm"
       ],
@@ -1715,9 +1715,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.0.tgz",
+      "integrity": "sha512-T6ZvMNe84kAz6TBWHC7hGAoEtzP1LWYw/AqayGWEF6uISt3Abk/st06LqRD9THd7Xz3NxzurUpzAuEAUbZf+nw==",
       "cpu": [
         "arm"
       ],
@@ -1729,9 +1729,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.0.tgz",
+      "integrity": "sha512-q/4hzvQkDs8b4jIBab1pnLiiM0ayTZsN2amBFPDzuyZxjEd4wDwx0UJFYM3cOZzSf5Kw8fnWSprJzIBMkcR44Q==",
       "cpu": [
         "arm64"
       ],
@@ -1743,9 +1743,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.0.tgz",
+      "integrity": "sha512-vvYWX3akdEAY6km+9wAqFDnk6pQsbJKVnj7xawcvs/+fdlYBGp+U+Qq/lLfpIxYIZvZLHMAKD9HLdacSx/r3dw==",
       "cpu": [
         "arm64"
       ],
@@ -1757,9 +1757,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.0.tgz",
+      "integrity": "sha512-DePa5cqOxDP/Zp0VOXpeWaGew5iIv5DXp9NYbzkX5PFQyWVX9184WCTh3hvr/7lhXo8ZVlbFLkz8+o/q1dU6gA==",
       "cpu": [
         "loong64"
       ],
@@ -1771,9 +1771,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.0.tgz",
+      "integrity": "sha512-LV8aWMB8UChglMCEzs7RkN0GsH29RJaLLqwm9fCIjlqwxQTiWAqNcc7wjBkH31hV0PU/yVxGYvrYsgfea2qw6g==",
       "cpu": [
         "loong64"
       ],
@@ -1785,9 +1785,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QoNSnwQtaeNu5grdBbsL0tt1uyl5EnS8DA8Mr3nluMXbhdQNyhN+G4tBax7VCdxLKj8YJ0/4OO9Ho84jMnJtKA==",
       "cpu": [
         "ppc64"
       ],
@@ -1799,9 +1799,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.0.tgz",
+      "integrity": "sha512-/zZp5MKapIIApE8trN8qLGNSiRN9TUoaUZ1cmVu4XnVdd5LQLOXTtyi+vtfUbNnT3iyjzpPqYeKXmvJ+gJGYWw==",
       "cpu": [
         "ppc64"
       ],
@@ -1813,9 +1813,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.0.tgz",
+      "integrity": "sha512-RbrzcD3aJ1k3UbtMRRBNwojdVVyXjuVAFTfn/xPa6EEl6GE9Sm/akPgFTb9aAC9pMKGJ6CtWxaGrqWcabH+ySg==",
       "cpu": [
         "riscv64"
       ],
@@ -1827,9 +1827,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.0.tgz",
+      "integrity": "sha512-ZF+onDsBso8PJf1XaG9lB+O9RnBpKGnY6OrzC4CSHrtC1jb6jWLTKK4bRqdoCXHd22gyr2hiYmEAm8Wns/BOCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1841,9 +1841,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.0.tgz",
+      "integrity": "sha512-Atk0aSIk5Zx2Wuh9dgRQgLP0Koc8hOeYpbWryMXyk8G8/HmPkwPPkMqIIDhrXHHYqfUzSJA/I7IWSBv8xSmRBA==",
       "cpu": [
         "s390x"
       ],
@@ -1855,9 +1855,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
       "cpu": [
         "x64"
       ],
@@ -1869,9 +1869,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.0.tgz",
+      "integrity": "sha512-mvFtE4A/t/7hRJ7X8Ozmu8FsIkAUat2nzl12pgU337BRmq87AQUJztwHz2Zv5/tjo9/C95E66CK03SI/ToEDJw==",
       "cpu": [
         "x64"
       ],
@@ -1883,9 +1883,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.0.tgz",
+      "integrity": "sha512-z9b9+aTxvt8n2rNltMPvyaUfB8NJ+CVyOrGK/MdIKHx7B+lXmZpm/XbRsU7Rpf3fRqJ2uS6mBJiJveCtq8LHDg==",
       "cpu": [
         "x64"
       ],
@@ -1897,9 +1897,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.0.tgz",
+      "integrity": "sha512-jXaXFqKMehsOc+g8R6oo33RRC6w07G9jDBxAE5eAKX7mOcCbZloYIPNhfG9Wl+P9O9IWHFO4OJgPi1Ml2qkt7w==",
       "cpu": [
         "arm64"
       ],
@@ -1911,9 +1911,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.0.tgz",
+      "integrity": "sha512-OXNWVFocS2IA4+QplhTZZ2a+8hPZR7T8KuozsNmJKK8y7cp83StHvGksfHzPG3wczWTczyWHVQuqeiTUbjiyBg==",
       "cpu": [
         "arm64"
       ],
@@ -1925,9 +1925,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.0.tgz",
+      "integrity": "sha512-AlAbNtBO637LxSldqV43z0FfXoGfl2TW1DgAg/bs7aQswFbDewz2SJm3BUhiGfbOVtW571xbc9p+REdxhyN/Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1939,9 +1939,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.0.tgz",
+      "integrity": "sha512-QRSrQXyJ1M4tjNXdR0/G/IgV6lzfQQJYBjlWIEYkY2Xs86DRl/iEpQ4blMDjJxSl7n19eDKKXMg0AmuBVYy8pQ==",
       "cpu": [
         "x64"
       ],
@@ -1953,9 +1953,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.0.tgz",
+      "integrity": "sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==",
       "cpu": [
         "x64"
       ],
@@ -2319,9 +2319,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2343,8 +2343,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2353,15 +2353,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2370,9 +2370,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2383,13 +2383,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2398,13 +2398,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2413,9 +2413,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2426,13 +2426,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -2782,9 +2782,9 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
-      "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.11.tgz",
+      "integrity": "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3551,9 +3551,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
-      "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.68.0.tgz",
+      "integrity": "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3566,25 +3566,25 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.67.0",
-        "@oxlint/binding-android-arm64": "1.67.0",
-        "@oxlint/binding-darwin-arm64": "1.67.0",
-        "@oxlint/binding-darwin-x64": "1.67.0",
-        "@oxlint/binding-freebsd-x64": "1.67.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.67.0",
-        "@oxlint/binding-linux-arm64-musl": "1.67.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.67.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-gnu": "1.67.0",
-        "@oxlint/binding-linux-x64-musl": "1.67.0",
-        "@oxlint/binding-openharmony-arm64": "1.67.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.67.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.67.0",
-        "@oxlint/binding-win32-x64-msvc": "1.67.0"
+        "@oxlint/binding-android-arm-eabi": "1.68.0",
+        "@oxlint/binding-android-arm64": "1.68.0",
+        "@oxlint/binding-darwin-arm64": "1.68.0",
+        "@oxlint/binding-darwin-x64": "1.68.0",
+        "@oxlint/binding-freebsd-x64": "1.68.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.68.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.68.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.68.0",
+        "@oxlint/binding-linux-arm64-musl": "1.68.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.68.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.68.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.68.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.68.0",
+        "@oxlint/binding-linux-x64-gnu": "1.68.0",
+        "@oxlint/binding-linux-x64-musl": "1.68.0",
+        "@oxlint/binding-openharmony-arm64": "1.68.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.68.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.68.0",
+        "@oxlint/binding-win32-x64-msvc": "1.68.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.22.1",
@@ -3699,13 +3699,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3715,31 +3715,31 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.0.tgz",
+      "integrity": "sha512-T9mWdbWfQtp0B5lv/HX+wrhYsmXRlcWnXXmJbXqKJhlRaoS6KMhq0gpyzW4UJfclcxrEdLnTgjT2NjruLONu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3749,40 +3749,33 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "@rollup/rollup-android-arm-eabi": "4.61.0",
+        "@rollup/rollup-android-arm64": "4.61.0",
+        "@rollup/rollup-darwin-arm64": "4.61.0",
+        "@rollup/rollup-darwin-x64": "4.61.0",
+        "@rollup/rollup-freebsd-arm64": "4.61.0",
+        "@rollup/rollup-freebsd-x64": "4.61.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
+        "@rollup/rollup-linux-arm64-musl": "4.61.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.0",
+        "@rollup/rollup-linux-loong64-musl": "4.61.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-gnu": "4.61.0",
+        "@rollup/rollup-linux-x64-musl": "4.61.0",
+        "@rollup/rollup-openbsd-x64": "4.61.0",
+        "@rollup/rollup-openharmony-arm64": "4.61.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.0",
+        "@rollup/rollup-win32-x64-gnu": "4.61.0",
+        "@rollup/rollup-win32-x64-msvc": "4.61.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.1",
@@ -4002,9 +3995,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.56.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.0.tgz",
-      "integrity": "sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg==",
+      "version": "5.56.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.1.tgz",
+      "integrity": "sha512-eArsJmvl3xZVuTYD852PzIEdg2wgDdIZ1NEsIPbzAukHwi284B18No4nK2rCO9AwsWUDza4Cjvmoa4HaojTl5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4169,17 +4162,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4270,9 +4263,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4389,20 +4382,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -4432,8 +4425,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -4462,13 +4455,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -4499,9 +4492,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.5",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litestar-vite-plugin",
-      "version": "0.23.5",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.23.5",
+  "version": "0.24.0",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Topic :: Database :: Database Engines/Servers",
 ]
 dependencies = [
-  "litestar>=2.7.0",
+  "litestar>=2.22.0",
   "httpx>=0.24.1",
   "websockets>=12.0",
   "typing_extensions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.23.5"
+version = "0.24.0"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -102,7 +102,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.23.5"
+current_version = "0.24.0"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/src/py/litestar_vite/_typing.py
+++ b/src/py/litestar_vite/_typing.py
@@ -1,0 +1,120 @@
+"""Type and optional-dependency shims used across litestar-vite."""
+
+from importlib import import_module
+from importlib.util import find_spec
+from typing import Any
+
+__all__ = (
+    "ADVANCED_ALCHEMY_INSTALLED",
+    "FSSPEC_INSTALLED",
+    "JINJA_INSTALLED",
+    "SQLSPEC_INSTALLED",
+    "AdvancedAlchemyDuplicateKeyError",
+    "AdvancedAlchemyForeignKeyError",
+    "AdvancedAlchemyIntegrityError",
+    "AdvancedAlchemyNotFoundError",
+    "AdvancedAlchemyRepositoryError",
+    "SQLSpecCheckViolationError",
+    "SQLSpecForeignKeyViolationError",
+    "SQLSpecIntegrityError",
+    "SQLSpecNotFoundError",
+    "SQLSpecNotNullViolationError",
+    "SQLSpecRepositoryError",
+    "SQLSpecUniqueViolationError",
+)
+
+
+def _module_installed(module_name: str) -> bool:
+    try:
+        return find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _get_exception_type(exception_module: Any, name: str) -> type[Exception] | None:
+    exception_type = getattr(exception_module, name, None)
+    if isinstance(exception_type, type) and issubclass(exception_type, Exception):
+        return exception_type
+    return None
+
+
+def _load_exception_types(module_name: str, names: tuple[str, ...]) -> tuple[type[Exception], ...] | None:
+    if not _module_installed(module_name):
+        return None
+    try:
+        exception_module = import_module(module_name)
+    except ImportError:
+        return None
+
+    exception_types = tuple(
+        exception_type for name in names if (exception_type := _get_exception_type(exception_module, name))
+    )
+    return exception_types if len(exception_types) == len(names) else None
+
+
+def _placeholder_exception_type(name: str, base: type[Exception] = Exception) -> type[Exception]:
+    return type(name, (base,), {"__module__": __name__})
+
+
+JINJA_INSTALLED = _module_installed("jinja2")
+FSSPEC_INSTALLED = _module_installed("fsspec")
+
+
+AdvancedAlchemyRepositoryError = _placeholder_exception_type("AdvancedAlchemyRepositoryError")
+AdvancedAlchemyNotFoundError = _placeholder_exception_type(
+    "AdvancedAlchemyNotFoundError", AdvancedAlchemyRepositoryError
+)
+AdvancedAlchemyIntegrityError = _placeholder_exception_type(
+    "AdvancedAlchemyIntegrityError", AdvancedAlchemyRepositoryError
+)
+AdvancedAlchemyDuplicateKeyError = _placeholder_exception_type(
+    "AdvancedAlchemyDuplicateKeyError", AdvancedAlchemyIntegrityError
+)
+AdvancedAlchemyForeignKeyError = _placeholder_exception_type(
+    "AdvancedAlchemyForeignKeyError", AdvancedAlchemyIntegrityError
+)
+
+
+_advanced_alchemy_exception_types = _load_exception_types(
+    "advanced_alchemy.exceptions",
+    ("RepositoryError", "NotFoundError", "IntegrityError", "DuplicateKeyError", "ForeignKeyError"),
+)
+ADVANCED_ALCHEMY_INSTALLED = _advanced_alchemy_exception_types is not None
+if _advanced_alchemy_exception_types is not None:
+    AdvancedAlchemyRepositoryError = _advanced_alchemy_exception_types[0]
+    AdvancedAlchemyNotFoundError = _advanced_alchemy_exception_types[1]
+    AdvancedAlchemyIntegrityError = _advanced_alchemy_exception_types[2]
+    AdvancedAlchemyDuplicateKeyError = _advanced_alchemy_exception_types[3]
+    AdvancedAlchemyForeignKeyError = _advanced_alchemy_exception_types[4]
+
+
+SQLSpecRepositoryError = _placeholder_exception_type("SQLSpecRepositoryError")
+SQLSpecNotFoundError = _placeholder_exception_type("SQLSpecNotFoundError", SQLSpecRepositoryError)
+SQLSpecIntegrityError = _placeholder_exception_type("SQLSpecIntegrityError", SQLSpecRepositoryError)
+SQLSpecUniqueViolationError = _placeholder_exception_type("SQLSpecUniqueViolationError", SQLSpecIntegrityError)
+SQLSpecForeignKeyViolationError = _placeholder_exception_type("SQLSpecForeignKeyViolationError", SQLSpecIntegrityError)
+SQLSpecCheckViolationError = _placeholder_exception_type("SQLSpecCheckViolationError", SQLSpecIntegrityError)
+SQLSpecNotNullViolationError = _placeholder_exception_type("SQLSpecNotNullViolationError", SQLSpecIntegrityError)
+
+
+_sqlspec_exception_types = _load_exception_types(
+    "sqlspec.exceptions",
+    (
+        "RepositoryError",
+        "NotFoundError",
+        "IntegrityError",
+        "UniqueViolationError",
+        "ForeignKeyViolationError",
+        "CheckViolationError",
+        "NotNullViolationError",
+    ),
+)
+SQLSPEC_INSTALLED = _sqlspec_exception_types is not None
+if _sqlspec_exception_types is not None:
+    SQLSpecRepositoryError = _sqlspec_exception_types[0]
+    SQLSpecNotFoundError = _sqlspec_exception_types[1]
+    SQLSpecIntegrityError = _sqlspec_exception_types[2]
+    SQLSpecUniqueViolationError = _sqlspec_exception_types[3]
+    SQLSpecForeignKeyViolationError = _sqlspec_exception_types[4]
+    SQLSpecCheckViolationError = _sqlspec_exception_types[5]
+    SQLSpecNotNullViolationError = _sqlspec_exception_types[6]

--- a/src/py/litestar_vite/config/_constants.py
+++ b/src/py/litestar_vite/config/_constants.py
@@ -1,7 +1,8 @@
 """Constants and utility functions for configuration."""
 
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from litestar_vite._typing import FSSPEC_INSTALLED, JINJA_INSTALLED
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -18,8 +19,6 @@ __all__ = (
 )
 
 TRUE_VALUES = {"True", "true", "1", "yes", "Y", "T"}
-JINJA_INSTALLED = bool(find_spec("jinja2"))
-FSSPEC_INSTALLED = bool(find_spec("fsspec"))
 
 
 @runtime_checkable

--- a/src/py/litestar_vite/inertia/exception_handler.py
+++ b/src/py/litestar_vite/inertia/exception_handler.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote, urlparse, urlunparse
 
@@ -16,11 +17,6 @@ from litestar.exceptions.responses import (
     create_debug_response,  # pyright: ignore[reportUnknownVariableType]
     create_exception_response,  # pyright: ignore[reportUnknownVariableType]
 )
-from litestar.repository.exceptions import (
-    ConflictError,  # pyright: ignore[reportUnknownVariableType,reportAttributeAccessIssue]
-    NotFoundError,  # pyright: ignore[reportUnknownVariableType,reportAttributeAccessIssue]
-    RepositoryError,  # pyright: ignore[reportUnknownVariableType,reportAttributeAccessIssue]
-)
 from litestar.response import Response
 from litestar.status_codes import (
     HTTP_400_BAD_REQUEST,
@@ -37,20 +33,13 @@ from litestar_vite.inertia.request import InertiaRequest
 from litestar_vite.inertia.response import InertiaBack, InertiaRedirect, InertiaResponse
 
 if TYPE_CHECKING:
-    from litestar.connection import Request
     from litestar.connection.base import AuthT, StateT, UserT
-    from litestar.response import Response
 
     from litestar_vite.inertia.plugin import InertiaPlugin
 
 
 FIELD_ERR_RE = re.compile(r"field `(.+)`$")
-
-
-class _HTTPConflictException(HTTPException):
-    """Request conflict with the current state of the target resource."""
-
-    status_code: int = HTTP_409_CONFLICT
+ExceptionHandler = Callable[[Request[Any, Any, Any], Exception], Response[Any]]
 
 
 def exception_to_http_response(request: "Request[UserT, AuthT, StateT]", exc: "Exception") -> "Response[Any]":
@@ -78,15 +67,10 @@ def exception_to_http_response(request: "Request[UserT, AuthT, StateT]", exc: "E
     if not inertia_enabled:
         if isinstance(exc, HTTPException):
             return cast("Response[Any]", create_exception_response(request, exc))
-        if isinstance(exc, NotFoundError):  # pyright: ignore[reportArgumentType]
-            http_exc = NotFoundException
-        elif isinstance(exc, (RepositoryError, ConflictError)):  # pyright: ignore[reportArgumentType]
-            http_exc = _HTTPConflictException  # type: ignore[assignment]
-        else:
-            http_exc = InternalServerException  # type: ignore[assignment]
-        if request.app.debug and http_exc not in {PermissionDeniedException, NotFoundError}:
+        if request.app.debug:
             return cast("Response[Any]", create_debug_response(request, exc))
-        return cast("Response[Any]", create_exception_response(request, http_exc(detail=str(exc.__cause__))))  # pyright: ignore[reportUnknownArgumentType]
+        detail = str(exc.__cause__) if exc.__cause__ is not None else str(exc)
+        return cast("Response[Any]", create_exception_response(request, InternalServerException(detail=detail)))
     return create_inertia_exception_response(request, exc)
 
 
@@ -176,3 +160,76 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
         return InertiaRedirect(request, redirect_to=inertia_plugin.config.redirect_404)
 
     return InertiaResponse[Any](media_type=preferred_type, content=content, status_code=status_code)
+
+
+def _register_exception_handlers(  # pyright: ignore[reportUnusedFunction]
+    exception_handlers: dict[type[Exception] | int, Any], default_handler: ExceptionHandler
+) -> None:
+    from litestar_vite._typing import (
+        ADVANCED_ALCHEMY_INSTALLED,
+        SQLSPEC_INSTALLED,
+        AdvancedAlchemyDuplicateKeyError,
+        AdvancedAlchemyForeignKeyError,
+        AdvancedAlchemyIntegrityError,
+        AdvancedAlchemyNotFoundError,
+        AdvancedAlchemyRepositoryError,
+        SQLSpecCheckViolationError,
+        SQLSpecForeignKeyViolationError,
+        SQLSpecIntegrityError,
+        SQLSpecNotFoundError,
+        SQLSpecNotNullViolationError,
+        SQLSpecRepositoryError,
+        SQLSpecUniqueViolationError,
+    )
+
+    if ADVANCED_ALCHEMY_INSTALLED:
+        exception_handlers[AdvancedAlchemyRepositoryError] = _make_exception_handler(
+            not_found_exceptions=(AdvancedAlchemyNotFoundError,),
+            conflict_exceptions=(
+                AdvancedAlchemyIntegrityError,
+                AdvancedAlchemyDuplicateKeyError,
+                AdvancedAlchemyForeignKeyError,
+            ),
+            default_handler=default_handler,
+        )
+
+    if SQLSPEC_INSTALLED:
+        exception_handlers[SQLSpecRepositoryError] = _make_exception_handler(
+            not_found_exceptions=(SQLSpecNotFoundError,),
+            conflict_exceptions=(
+                SQLSpecIntegrityError,
+                SQLSpecUniqueViolationError,
+                SQLSpecForeignKeyViolationError,
+                SQLSpecCheckViolationError,
+                SQLSpecNotNullViolationError,
+            ),
+            default_handler=default_handler,
+        )
+
+
+def _make_exception_handler(
+    *,
+    not_found_exceptions: tuple[type[Exception], ...],
+    conflict_exceptions: tuple[type[Exception], ...],
+    default_handler: ExceptionHandler,
+) -> ExceptionHandler:
+    def exception_handler(request: Request[Any, Any, Any], exc: Exception) -> Response[Any]:
+        detail = _exception_detail(exc)
+        if isinstance(exc, not_found_exceptions):
+            http_exc: HTTPException = NotFoundException(detail=detail or "Not Found")
+        elif isinstance(exc, conflict_exceptions):
+            http_exc = HTTPException(detail=detail, status_code=HTTP_409_CONFLICT)
+        else:
+            http_exc = InternalServerException(detail=detail)
+        return default_handler(request, http_exc)
+
+    return exception_handler
+
+
+def _exception_detail(exc: Exception) -> str:
+    detail = getattr(exc, "detail", None)
+    if detail:
+        return str(detail)
+    if exc.__cause__ is not None:
+        return str(exc.__cause__)
+    return str(exc)

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -221,10 +221,11 @@ def optional(key: str, callback: "Callable[..., T | Coroutine[Any, Any, T]]") ->
 
     Example::
 
+        from litestar.params import FromPath
         from litestar_vite.inertia import optional, InertiaResponse
 
         @get("/posts/{post_id}", component="Posts/Show")
-        async def show_post(post_id: int) -> InertiaResponse:
+        async def show_post(post_id: FromPath[int]) -> InertiaResponse:
             post = await Post.get(post_id)
             return InertiaResponse({
                 "post": post,
@@ -494,10 +495,11 @@ def scroll_props(
 
     Example::
 
+        from litestar.params import FromQuery
         from litestar_vite.inertia import scroll_props, InertiaResponse
 
         @get("/posts", component="Posts")
-        async def list_posts(page: int = 1) -> InertiaResponse:
+        async def list_posts(page: FromQuery[int] = 1) -> InertiaResponse:
             posts = await Post.paginate(page=page, per_page=20)
             return InertiaResponse(
                 {"posts": merge("posts", posts.items)},

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1,6 +1,6 @@
 import inspect
 from collections import defaultdict
-from collections.abc import Callable, Coroutine, Iterable, Mapping
+from collections.abc import Callable, Coroutine, Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeGuard, TypeVar, cast, overload
 
@@ -527,7 +527,7 @@ def is_merge_prop(value: "Any") -> "TypeGuard[MergeProp[Any, Any]]":
     return isinstance(value, MergeProp)
 
 
-def extract_merge_props(props: "dict[str, Any]") -> "tuple[list[str], list[str], list[str], list[str]]":
+def extract_merge_props(props: "Mapping[str, Any]") -> "tuple[list[str], list[str], list[str], list[str]]":
     """Extract merge props metadata for the Inertia v2 protocol.
 
     This extracts all MergeProp instances from the props dict and categorizes them
@@ -564,7 +564,7 @@ def extract_merge_props(props: "dict[str, Any]") -> "tuple[list[str], list[str],
     deep_merge_list: "list[str]" = []
     match_on_paths: "list[str]" = []
 
-    for key, value in props.items():
+    for key, value in _iter_mapping_prop_paths(props):
         if is_merge_prop(value):
             match value.strategy:
                 case "append":
@@ -580,6 +580,21 @@ def extract_merge_props(props: "dict[str, Any]") -> "tuple[list[str], list[str],
                 match_on_paths.extend(f"{key}.{match_key}" for match_key in value.match_on)
 
     return merge_list, prepend_list, deep_merge_list, match_on_paths
+
+
+def unwrap_merge_props(value: "T") -> "T":
+    """Return ``value`` with any nested MergeProp wrappers replaced by their payloads."""
+    if is_merge_prop(value):
+        return cast("T", unwrap_merge_props(value.value))
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        return cast("T", {key: unwrap_merge_props(item) for key, item in cast("Mapping[str, Any]", value).items()})
+    if isinstance(value, list):
+        return cast("T", [unwrap_merge_props(item) for item in cast("Iterable[Any]", value)])
+    if isinstance(value, tuple):
+        return cast("T", tuple(unwrap_merge_props(item) for item in cast("Iterable[Any]", value)))
+    return value
 
 
 class StaticProp(Generic[PropKeyT, StaticT]):
@@ -952,7 +967,7 @@ def extract_deferred_props(props: "Mapping[str, Any]") -> "dict[str, list[str]]"
     """
     groups: "dict[str, list[str]]" = {}
 
-    for key, value in props.items():
+    for key, value in _iter_mapping_prop_paths(props):
         if is_deferred_prop(value):
             # Exclude once props from deferred metadata
             if value.is_once:
@@ -963,17 +978,6 @@ def extract_deferred_props(props: "Mapping[str, Any]") -> "dict[str, list[str]]"
             groups[group].append(key)
 
     return groups
-
-
-def _should_track_once_prop(
-    key: str, partial_data: "set[str] | None" = None, partial_except: "set[str] | None" = None
-) -> bool:
-    """Return whether once-prop metadata should stay in scope for this response."""
-    if partial_except:
-        return key not in partial_except
-    if partial_data:
-        return key in partial_data
-    return True
 
 
 def extract_once_props(
@@ -1004,20 +1008,16 @@ def extract_once_props(
 
         The result is ["settings", "stats"].
     """
-    once_keys: "list[str]" = []
-
-    for key, value in props.items():
-        if (is_once_prop(value) or (is_deferred_prop(value) and value.is_once)) and _should_track_once_prop(
-            key, partial_data, partial_except
-        ):
-            once_keys.append(key)
-
-    return once_keys
+    return [key for key, _ in _extract_once_prop_entries(props, partial_data, partial_except)]
 
 
-def build_once_props_metadata(keys: "Iterable[str]") -> "dict[str, dict[str, str | int | None]]":
+def build_once_props_metadata(keys: "Iterable[str | _OncePropEntry]") -> "dict[str, dict[str, str | int | None]]":
     """Build stable once-prop metadata for the Inertia page object."""
-    return {key: {"prop": key} for key in keys}
+    metadata: "dict[str, dict[str, str | int | None]]" = {}
+    for item in keys:
+        key, prop = item if isinstance(item, tuple) else (item, item)
+        metadata[key] = {"prop": prop}
+    return metadata
 
 
 def should_render(  # noqa: PLR0911
@@ -1056,34 +1056,34 @@ def should_render(  # noqa: PLR0911
     # OptionalProp: Only render when explicitly requested
     if is_optional_prop(value):
         if partial_data:
-            return value.key in partial_data
+            return _matches_partial_data(value, partial_data, key)
         # Never included in initial loads or standard partial reloads
         return False
 
     # OnceProp: Respect partial reload filters and omit on full visits when cached client-side
     if is_once_prop(value):
         if partial_except:
-            return value.key not in partial_except
+            return not _matches_partial_except(value, partial_except, key)
         if partial_data:
-            return value.key in partial_data
+            return _matches_partial_data(value, partial_data, key)
         if except_once_props:
-            return value.key not in except_once_props
+            return not _matches_partial_except(value, except_once_props, key)
         return True
 
     # LazyProp (StaticProp/DeferredProp): Only render on partial reload
     if is_lazy_prop(value):
         if partial_except:
-            return value.key not in partial_except
+            return not _matches_partial_except(value, partial_except, key)
         if partial_data:
-            return value.key in partial_data
+            return _matches_partial_data(value, partial_data, key)
         return False
 
     # Regular values: Apply standard filtering
     if key is not None:
         if partial_except:
-            return key not in partial_except
+            return not _matches_partial_except(value, partial_except, key)
         if partial_data:
-            return key in partial_data
+            return _matches_partial_data(value, partial_data, key)
 
     return True
 
@@ -1135,6 +1135,7 @@ def lazy_render(  # noqa: PLR0911
     partial_data: "set[str] | None" = None,
     partial_except: "set[str] | None" = None,
     except_once_props: "set[str] | None" = None,
+    _key: "str | None" = None,
 ) -> "T":
     """Filter deferred properties from the value based on partial data.
 
@@ -1155,14 +1156,19 @@ def lazy_render(  # noqa: PLR0911
     if isinstance(value, str):
         return cast("T", value)
     if isinstance(value, Mapping):
-        return cast(
-            "T",
-            {
-                k: lazy_render(v, partial_data, partial_except, except_once_props)
-                for k, v in cast("Mapping[str, Any]", value).items()
-                if should_render(v, partial_data, partial_except, except_once_props, key=k)
-            },
-        )
+        rendered: "dict[str, Any]" = {}
+        for k, v in cast("Mapping[str, Any]", value).items():
+            child_key = _join_prop_path((str(k),)) if _key is None else f"{_key}.{k}"
+            if isinstance(v, Mapping):
+                child: Any = lazy_render(
+                    cast("Mapping[str, Any]", v), partial_data, partial_except, except_once_props, _key=child_key
+                )
+                if should_render(v, partial_data, partial_except, except_once_props, key=child_key) or child:
+                    rendered[k] = child
+                continue
+            if should_render(v, partial_data, partial_except, except_once_props, key=child_key):
+                rendered[k] = lazy_render(v, partial_data, partial_except, except_once_props, _key=child_key)
+        return cast("T", rendered)
 
     if isinstance(value, list):
         return cast(
@@ -1185,13 +1191,13 @@ def lazy_render(  # noqa: PLR0911
         )
 
     # Handle special prop types that need rendering
-    if is_lazy_prop(value) and should_render(value, partial_data, partial_except, except_once_props):
+    if is_lazy_prop(value) and should_render(value, partial_data, partial_except, except_once_props, key=_key):
         return cast("T", value.render())
 
-    if is_once_prop(value) and should_render(value, partial_data, partial_except, except_once_props):
+    if is_once_prop(value) and should_render(value, partial_data, partial_except, except_once_props, key=_key):
         return cast("T", value.render())
 
-    if is_optional_prop(value) and should_render(value, partial_data, partial_except, except_once_props):
+    if is_optional_prop(value) and should_render(value, partial_data, partial_except, except_once_props, key=_key):
         return cast("T", value.render())
 
     if is_always_prop(value):
@@ -1217,23 +1223,15 @@ def has_unresolved_async_props(  # noqa: PLR0911
     re-deferral when ``InertiaResponse.to_asgi_response`` re-enters after
     async resolution mutates the prop in place.
     """
-    if not should_render(value, partial_data, partial_except, except_once_props, key=_key):
-        return False
-    if is_optional_prop(value):
-        return not value._evaluated and inspect.iscoroutinefunction(value._callback)  # pyright: ignore[reportPrivateUsage]
-    if is_deferred_prop(value):
-        cb = value._value  # pyright: ignore[reportPrivateUsage]
-        return not value._evaluated and cb is not None and inspect.iscoroutinefunction(cb)  # pyright: ignore[reportPrivateUsage]
-    if is_once_prop(value):
-        cb = value._value  # pyright: ignore[reportPrivateUsage]
-        return not value._evaluated and callable(cb) and inspect.iscoroutinefunction(cb)  # pyright: ignore[reportPrivateUsage]
-    if isinstance(value, str):
-        return False
     if isinstance(value, Mapping):
         mapping = cast("Mapping[str, Any]", value)
         return any(
             has_unresolved_async_props(
-                v, partial_data=partial_data, partial_except=partial_except, except_once_props=except_once_props, _key=k
+                v,
+                partial_data=partial_data,
+                partial_except=partial_except,
+                except_once_props=except_once_props,
+                _key=_join_prop_path((str(k),)) if _key is None else f"{_key}.{k}",
             )
             for k, v in mapping.items()
         )
@@ -1245,6 +1243,16 @@ def has_unresolved_async_props(  # noqa: PLR0911
             )
             for v in sequence
         )
+    if not should_render(value, partial_data, partial_except, except_once_props, key=_key):
+        return False
+    if is_optional_prop(value):
+        return not value._evaluated and inspect.iscoroutinefunction(value._callback)  # pyright: ignore[reportPrivateUsage]
+    if is_deferred_prop(value):
+        cb = value._value  # pyright: ignore[reportPrivateUsage]
+        return not value._evaluated and cb is not None and inspect.iscoroutinefunction(cb)  # pyright: ignore[reportPrivateUsage]
+    if is_once_prop(value):
+        cb = value._value  # pyright: ignore[reportPrivateUsage]
+        return not value._evaluated and callable(cb) and inspect.iscoroutinefunction(cb)  # pyright: ignore[reportPrivateUsage]
     return False
 
 
@@ -1254,6 +1262,7 @@ async def resolve_async_props(
     partial_data: "set[str] | None" = None,
     partial_except: "set[str] | None" = None,
     except_once_props: "set[str] | None" = None,
+    _key: "str | None" = None,
 ) -> None:
     """Walk ``value`` and ``await`` async prop callbacks on the current loop.
 
@@ -1274,9 +1283,19 @@ async def resolve_async_props(
     if isinstance(value, Mapping):
         mapping = cast("Mapping[str, Any]", value)
         for k, v in mapping.items():
-            if not should_render(v, partial_data, partial_except, except_once_props, key=k):
+            child_key = _join_prop_path((str(k),)) if _key is None else f"{_key}.{k}"
+            if isinstance(v, Mapping):
+                await resolve_async_props(
+                    v,
+                    partial_data=partial_data,
+                    partial_except=partial_except,
+                    except_once_props=except_once_props,
+                    _key=child_key,
+                )
                 continue
-            await _resolve_one(v, partial_data, partial_except, except_once_props)
+            if not should_render(v, partial_data, partial_except, except_once_props, key=child_key):
+                continue
+            await _resolve_one(v, partial_data, partial_except, except_once_props, child_key)
         return
 
     if isinstance(value, (list, tuple)):
@@ -1284,25 +1303,10 @@ async def resolve_async_props(
         for v in sequence:
             if not should_render(v, partial_data, partial_except, except_once_props):
                 continue
-            await _resolve_one(v, partial_data, partial_except, except_once_props)
+            await _resolve_one(v, partial_data, partial_except, except_once_props, None)
         return
 
-    await _resolve_one(value, partial_data, partial_except, except_once_props)
-
-
-async def _resolve_one(
-    value: "Any",
-    partial_data: "set[str] | None",
-    partial_except: "set[str] | None",
-    except_once_props: "set[str] | None",
-) -> None:
-    if is_optional_prop(value) or is_deferred_prop(value) or is_once_prop(value):
-        await value.resolve_async()
-        return
-    if isinstance(value, (Mapping, list, tuple)):
-        await resolve_async_props(
-            value, partial_data=partial_data, partial_except=partial_except, except_once_props=except_once_props
-        )
+    await _resolve_one(value, partial_data, partial_except, except_once_props, _key)
 
 
 def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
@@ -1345,7 +1349,7 @@ def get_shared_props(
     props: "dict[str, Any]" = {}
     flash: "dict[str, list[str]]" = defaultdict(list)
     errors: "dict[str, Any]" = {}
-    once_props_keys: "list[str]" = []
+    once_props_entries: "list[_OncePropEntry]" = []
     error_bag = request.headers.get("X-Inertia-Error-Bag", None)
 
     try:
@@ -1353,18 +1357,23 @@ def get_shared_props(
         shared_props = cast("dict[str,Any]", request.session.pop("_shared", {}))
         inertia_plugin = cast("InertiaPlugin", request.app.plugins.get("InertiaPlugin"))
 
+        once_props_entries = _extract_once_prop_entries(shared_props, partial_data, partial_except)
+
         for key, value in shared_props.items():
-            # Track once props for protocol metadata
-            if (is_once_prop(value) or (is_deferred_prop(value) and value.is_once)) and _should_track_once_prop(
-                key, partial_data, partial_except
+            if not should_render(value, partial_data, partial_except, except_once_props, key=key) and not isinstance(
+                value, Mapping
             ):
-                once_props_keys.append(key)
-            if not should_render(value, partial_data, partial_except, except_once_props, key=key):
                 continue
             # Render all special prop types. Async callbacks must already be
             # pre-resolved by InertiaResponse's async pre-pass; render() raises
             # otherwise.
-            if is_special_prop(value):
+            if isinstance(value, Mapping):
+                rendered: Any = lazy_render(
+                    cast("Mapping[str, Any]", value), partial_data, partial_except, except_once_props, _key=key
+                )
+                if rendered or should_render(value, partial_data, partial_except, except_once_props, key=key):
+                    props[key] = rendered
+            elif is_special_prop(value):
                 props[key] = value.render()
             else:
                 props[key] = value
@@ -1392,7 +1401,7 @@ def get_shared_props(
     props["errors"] = {error_bag: errors} if error_bag is not None else errors
     props["csrf_token"] = value_or_default(ScopeState.from_scope(request.scope).csrf_token, "")
     # Store once props keys for later extraction (removed before serialization)
-    props["_once_props"] = once_props_keys
+    props["_once_props"] = once_props_entries
     return props
 
 
@@ -1652,6 +1661,101 @@ def pagination_to_dict(value: "Any") -> dict[str, Any]:
         result[camel_attr] = attr_value
 
     return result
+
+
+_OncePropEntry = tuple[str, str]
+
+
+def _join_prop_path(path: "tuple[str, ...]") -> str:
+    return ".".join(path)
+
+
+def _iter_mapping_prop_paths(value: "Mapping[str, Any]", path: "tuple[str, ...]" = ()) -> "Iterator[tuple[str, Any]]":
+    for key, item in value.items():
+        item_path = (*path, str(key))
+        yield _join_prop_path(item_path), item
+        if isinstance(item, Mapping):
+            yield from _iter_mapping_prop_paths(cast("Mapping[str, Any]", item), item_path)
+
+
+def _prop_key_candidates(value: "Any", key: "str | None") -> "tuple[str, ...]":
+    candidates: "list[str]" = []
+    if key:
+        candidates.append(key)
+        local_key = key.rsplit(".", maxsplit=1)[-1]
+        if local_key != key:
+            candidates.append(local_key)
+    prop_key = getattr(value, "key", None)
+    if isinstance(prop_key, str):
+        candidates.append(prop_key)
+    return tuple(dict.fromkeys(candidates))
+
+
+def _matches_partial_data(value: "Any", partial_data: "set[str]", key: "str | None") -> bool:
+    candidates = _prop_key_candidates(value, key)
+    if is_special_prop(value):
+        return any(candidate in partial_data for candidate in candidates)
+    return any(
+        candidate in partial_data or any(requested.startswith(f"{candidate}.") for requested in partial_data)
+        for candidate in candidates
+    )
+
+
+def _matches_partial_except(value: "Any", partial_except: "set[str]", key: "str | None") -> bool:
+    candidates = _prop_key_candidates(value, key)
+    return any(
+        candidate in partial_except or any(candidate.startswith(f"{excluded}.") for excluded in partial_except)
+        for candidate in candidates
+    )
+
+
+def _should_track_once_prop(
+    key: str,
+    partial_data: "set[str] | None" = None,
+    partial_except: "set[str] | None" = None,
+    prop_path: "str | None" = None,
+) -> bool:
+    """Return whether once-prop metadata should stay in scope for this response."""
+    candidates = tuple(dict.fromkeys((key, prop_path or key)))
+    if partial_except:
+        return not any(candidate in partial_except for candidate in candidates)
+    if partial_data:
+        return any(candidate in partial_data for candidate in candidates)
+    return True
+
+
+def _extract_once_prop_entries(
+    props: "Mapping[str, Any]", partial_data: "set[str] | None" = None, partial_except: "set[str] | None" = None
+) -> "list[_OncePropEntry]":
+    entries: "list[_OncePropEntry]" = []
+
+    for prop_path, value in _iter_mapping_prop_paths(props):
+        if is_once_prop(value) or (is_deferred_prop(value) and value.is_once):
+            key = str(value.key)
+            if _should_track_once_prop(key, partial_data, partial_except, prop_path):
+                entries.append((key, prop_path))
+
+    return entries
+
+
+async def _resolve_one(
+    value: "Any",
+    partial_data: "set[str] | None",
+    partial_except: "set[str] | None",
+    except_once_props: "set[str] | None",
+    key: "str | None",
+) -> None:
+    if is_optional_prop(value) or is_deferred_prop(value) or is_once_prop(value):
+        await value.resolve_async()
+        return
+    if isinstance(value, (Mapping, list, tuple)):
+        await resolve_async_props(
+            value,
+            partial_data=partial_data,
+            partial_except=partial_except,
+            except_once_props=except_once_props,
+            _key=key,
+        )
 
 
 def _has_offset_pagination_attrs(value: Any) -> bool:

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from litestar.handlers.http_handlers.base import HTTPRouteHandler
-from litestar.plugins import InitPluginProtocol
+from litestar.plugins import InitPlugin
 from litestar.response import Response
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from litestar_vite.config import InertiaConfig
 
 
-class InertiaPlugin(InitPluginProtocol):
+class InertiaPlugin(InitPlugin):
     """Inertia plugin.
 
     This plugin configures Litestar for Inertia.js support, including:
@@ -117,7 +117,10 @@ class InertiaPlugin(InitPluginProtocol):
         from litestar.security.session_auth.middleware import MiddlewareWrapper
         from litestar.utils.predicates import is_class_and_subclass
 
-        from litestar_vite.inertia.exception_handler import exception_to_http_response
+        from litestar_vite.inertia.exception_handler import (
+            _register_exception_handlers,  # pyright: ignore[reportPrivateUsage]
+            exception_to_http_response,
+        )
         from litestar_vite.inertia.helpers import DeferredProp, StaticProp
         from litestar_vite.inertia.middleware import InertiaMiddleware
         from litestar_vite.inertia.request import InertiaRequest
@@ -151,6 +154,8 @@ class InertiaPlugin(InitPluginProtocol):
             exception_handlers[ValidationException] = create_precognition_exception_handler(
                 fallback_handler=exception_to_http_response
             )
+
+        _register_exception_handlers(exception_handlers=exception_handlers, default_handler=exception_to_http_response)
 
         app_config.exception_handlers.update(exception_handlers)  # pyright: ignore[reportUnknownMemberType]
         app_config.request_class = InertiaRequest

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -20,15 +20,14 @@ from litestar.utils.scope.state import ScopeState
 from litestar_vite.html_transform import inject_head_html, replace_element_outer_html
 from litestar_vite.inertia._utils import get_headers
 from litestar_vite.inertia.helpers import (
+    _extract_once_prop_entries,  # pyright: ignore[reportPrivateUsage]
     build_once_props_metadata,
     extract_deferred_props,
     extract_merge_props,
-    extract_once_props,
     extract_pagination_scroll_props,
     get_raw_shared_props,
     get_shared_props,
     has_unresolved_async_props,
-    is_merge_prop,
     is_or_contains_lazy_prop,
     is_or_contains_special_prop,
     is_pagination_container,
@@ -36,6 +35,7 @@ from litestar_vite.inertia.helpers import (
     pagination_to_dict,
     resolve_async_props,
     should_render,
+    unwrap_merge_props,
 )
 from litestar_vite.inertia.plugin import InertiaPlugin
 from litestar_vite.inertia.request import InertiaDetails, InertiaRequest
@@ -49,234 +49,6 @@ if TYPE_CHECKING:
 
 
 T = TypeVar("T")
-
-
-@dataclass(frozen=True)
-class _InertiaSSRResult:
-    head: list[str]
-    body: str
-
-
-@dataclass(frozen=True)
-class _InertiaRequestInfo:
-    inertia_enabled: bool
-    is_inertia: bool
-    is_partial_render: bool
-    partial_keys: set[str]
-    partial_except_keys: set[str]
-    except_once_keys: set[str]
-    reset_keys: set[str]
-
-
-def _get_inertia_request_info(request: "Request[Any, Any, Any]") -> _InertiaRequestInfo:
-    """Return Inertia request state for both InertiaRequest and plain Request.
-
-    InertiaResponse is typically used together with InertiaMiddleware, which wraps
-    incoming requests in :class:`~litestar_vite.inertia.request.InertiaRequest`.
-
-    This helper preserves compatibility with plain :class:`litestar.Request` by
-    falling back to header parsing via :class:`~litestar_vite.inertia.request.InertiaDetails`.
-
-    Returns:
-        Aggregated Inertia-related request flags and partial-render metadata.
-    """
-    if isinstance(request, InertiaRequest):
-        is_inertia = request.is_inertia
-        return _InertiaRequestInfo(
-            inertia_enabled=bool(request.inertia_enabled or is_inertia),
-            is_inertia=is_inertia,
-            is_partial_render=request.is_partial_render,
-            partial_keys=request.partial_keys,
-            partial_except_keys=request.partial_except_keys,
-            except_once_keys=request.except_once_props_keys,
-            reset_keys=request.reset_keys,
-        )
-
-    details = InertiaDetails(request)
-    is_inertia = bool(details)
-    return _InertiaRequestInfo(
-        inertia_enabled=bool(details.route_component is not None or is_inertia),
-        is_inertia=is_inertia,
-        is_partial_render=details.is_partial_render,
-        partial_keys=set(details.partial_keys),
-        partial_except_keys=set(details.partial_except_keys),
-        except_once_keys=set(details.except_once_props_keys),
-        reset_keys=set(details.reset_keys),
-    )
-
-
-# Maximum allowed size for SSR response body + head combined (10 MiB).
-# This prevents a malicious or misconfigured SSR server from causing OOM.
-_SSR_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
-
-
-def _parse_inertia_ssr_payload(payload: Any, url: str) -> _InertiaSSRResult:
-    if not isinstance(payload, dict):
-        msg = f"Inertia SSR server at {url!r} returned unexpected payload type: {type(payload)!r}."
-        raise ImproperlyConfiguredException(msg)
-
-    payload_dict = cast("dict[str, Any]", payload)
-
-    body = payload_dict.get("body")
-    if not isinstance(body, str):
-        msg = f"Inertia SSR server at {url!r} returned invalid 'body' (expected string)."
-        raise ImproperlyConfiguredException(msg)
-
-    head_raw: Any = payload_dict.get("head", [])
-    if head_raw is None:
-        head_raw = []
-    if not isinstance(head_raw, list):
-        msg = f"Inertia SSR server at {url!r} returned invalid 'head' (expected list[str])."
-        raise ImproperlyConfiguredException(msg)
-
-    head_list = cast("list[Any]", head_raw)
-    if any(not isinstance(item, str) for item in head_list):
-        msg = f"Inertia SSR server at {url!r} returned invalid 'head' (expected list[str])."
-        raise ImproperlyConfiguredException(msg)
-
-    total_size = len(body) + sum(len(h) for h in head_list)
-    if total_size > _SSR_MAX_RESPONSE_BYTES:
-        msg = (
-            f"Inertia SSR response from {url!r} exceeds maximum allowed size "
-            f"({total_size:,} bytes > {_SSR_MAX_RESPONSE_BYTES:,} bytes). "
-            "This may indicate a misconfigured SSR server."
-        )
-        raise ImproperlyConfiguredException(msg)
-
-    return _InertiaSSRResult(head=cast("list[str]", head_list), body=body)
-
-
-async def _render_inertia_ssr(
-    page: dict[str, Any], url: str, timeout_seconds: float, client: "httpx.AsyncClient | None" = None
-) -> _InertiaSSRResult:
-    """Call the Inertia SSR server asynchronously and return head/body HTML.
-
-    Args:
-        page: The page object to send to the SSR server.
-        url: The SSR server URL (typically http://localhost:13714/render).
-        timeout_seconds: Request timeout in seconds.
-        client: Optional shared httpx.AsyncClient for connection pooling.
-            If None, creates a new client per request (slower).
-
-    Returns:
-        An _InertiaSSRResult with head and body HTML.
-    """
-    return await _do_ssr_request(page, url, timeout_seconds, client)
-
-
-@contextlib.asynccontextmanager
-async def _acquire_ssr_client(client: "httpx.AsyncClient | None") -> "AsyncGenerator[httpx.AsyncClient, None]":
-    """Yield ``client`` when provided, otherwise a short-lived fallback client.
-
-    Yields:
-        The shared client when supplied, or a fallback client whose lifecycle is
-        bound to the context.
-    """
-    if client is not None:
-        yield client
-    else:
-        async with httpx.AsyncClient() as fallback:
-            yield fallback
-
-
-async def _do_ssr_request(
-    page: dict[str, Any], url: str, timeout_seconds: float, client: "httpx.AsyncClient | None"
-) -> _InertiaSSRResult:
-    """Execute the SSR request with optional client reuse.
-
-    Args:
-        page: The page object to send to the SSR server.
-        url: The SSR server URL.
-        timeout_seconds: Request timeout in seconds.
-        client: Optional shared httpx.AsyncClient.
-
-    Raises:
-        ImproperlyConfiguredException: If the SSR server is unreachable,
-            returns an error status, or returns invalid payload.
-
-    Returns:
-        An _InertiaSSRResult with head and body HTML.
-    """
-    # Use Litestar's msgspec encoder so msgspec Structs and other custom types embedded
-    # in handler return values serialize the same way as the regular Inertia render path
-    # (response.render uses get_serializer too). httpx's default json= serializer falls
-    # back to stdlib json.dumps and rejects Struct instances.
-    body = encode_json(page, serializer=get_serializer(None))
-    headers = {"content-type": "application/json"}
-
-    try:
-        async with _acquire_ssr_client(client) as resolved_client:
-            response = await resolved_client.post(url, content=body, headers=headers, timeout=timeout_seconds)
-            response.raise_for_status()
-    except httpx.RequestError as exc:
-        msg = (
-            f"Inertia SSR is enabled but the SSR server is not reachable at {url!r}. "
-            "Start the SSR server (Node) or disable InertiaConfig.ssr."
-        )
-        raise ImproperlyConfiguredException(msg) from exc
-    except httpx.HTTPStatusError as exc:
-        msg = f"Inertia SSR server at {url!r} returned HTTP {exc.response.status_code}. Check the SSR server logs."
-        raise ImproperlyConfiguredException(msg) from exc
-
-    try:
-        payload = response.json()
-    except ValueError as exc:
-        msg = f"Inertia SSR server at {url!r} returned invalid JSON. Check the SSR server logs."
-        raise ImproperlyConfiguredException(msg) from exc
-
-    return _parse_inertia_ssr_payload(payload, url)
-
-
-def _get_redirect_url(request: "Request[Any, Any, Any]", url: str | None) -> str:
-    """Return a safe redirect URL, falling back to base_url when invalid.
-
-    Args:
-        request: The request object.
-        url: Candidate redirect URL.
-
-    Returns:
-        A safe redirect URL (same-origin absolute, or relative), otherwise the request base URL.
-    """
-    base_url = str(request.base_url)
-
-    if not url:
-        return base_url
-
-    parsed = urlparse(url)
-    base = urlparse(base_url)
-
-    if not parsed.scheme and not parsed.netloc:
-        return url
-
-    if parsed.scheme not in {"http", "https"}:
-        return base_url
-
-    if parsed.netloc != base.netloc:
-        return base_url
-
-    return url
-
-
-def _get_relative_url(request: "Request[Any, Any, Any]") -> str:
-    """Return the relative URL including query string for Inertia page props.
-
-    The Inertia.js protocol requires the ``url`` property to include query parameters
-    so that page state (e.g., filters, pagination) is preserved on refresh.
-
-    This matches the behavior of other Inertia adapters:
-    - Laravel: Uses ``fullUrl()`` minus scheme/host
-    - Rails: Uses ``request.fullpath``
-    - Django: Uses ``request.get_full_path()``
-
-    Args:
-        request: The request object.
-
-    Returns:
-        The path with query string if present, e.g., ``/reports?page=1&status=active``.
-    """
-    path = request.url.path
-    query = request.url.query
-    return f"{path}?{query}" if query else path
 
 
 class InertiaResponse(Response[T]):
@@ -388,7 +160,7 @@ class InertiaResponse(Response[T]):
             "csrf_input": f'<input type="hidden" name="_csrf_token" value="{csrf_token}" />',
         }
 
-    def _build_page_props(  # noqa: PLR0915, C901
+    def _build_page_props(  # noqa: PLR0915
         self,
         request: "Request[UserT, AuthT, StateT]",
         partial_data: "set[str] | None",
@@ -426,7 +198,7 @@ class InertiaResponse(Response[T]):
         route_handler = request.scope.get("route_handler")  # pyright: ignore[reportUnknownMemberType]
         content: Any = self.content
         route_content: Any | None = None
-        route_once_props: "list[str]" = []
+        route_once_props: "list[tuple[str, str]]" = []
 
         # v2.2+ protocol: Extract deferred props metadata before filtering.
         # Route props override shared props with the same key, so discard any
@@ -436,7 +208,7 @@ class InertiaResponse(Response[T]):
             for key in content_mapping:
                 _discard_deferred_prop_key(deferred_props_map, str(key))
             _merge_deferred_props(deferred_props_map, extract_deferred_props(content_mapping))
-            route_once_props = extract_once_props(
+            route_once_props = _extract_once_prop_entries(
                 content_mapping, partial_data=partial_data, partial_except=partial_except
             )
 
@@ -464,21 +236,20 @@ class InertiaResponse(Response[T]):
                 _discard_deferred_prop_key(deferred_props_map, key)
         deferred_props = deferred_props_map or None
         # Extract once props tracked during get_shared_props (already rendered)
-        once_props_from_shared = [key for key in shared_props.pop("_once_props", []) if key not in reset_keys]
-        route_once_props = [key for key in route_once_props if key not in reset_keys]
-        once_prop_keys = list(dict.fromkeys([*once_props_from_shared, *route_once_props]))
-        once_props = build_once_props_metadata(once_prop_keys) or None
+        once_props_from_shared = shared_props.pop("_once_props", [])
+        once_prop_entries = _dedupe_once_prop_entries(
+            [*once_props_from_shared, *route_once_props], reset_keys=reset_keys
+        )
+        once_props = build_once_props_metadata(once_prop_entries) or None
 
         merge_props_list, prepend_props_list, deep_merge_props_list, match_props_on = extract_merge_props(shared_props)
+        shared_props = unwrap_merge_props(shared_props)
 
         extracted_scroll_props: "ScrollPropsConfig | None" = self.scroll_props
         infinite_scroll_enabled = bool(route_handler and route_handler.opt.get("infinite_scroll", False))
 
         for key in tuple(shared_props):
             value = shared_props[key]
-            if is_merge_prop(value):
-                value = shared_props[key] = value.value
-
             if is_pagination_container(value):
                 _, scroll = extract_pagination_scroll_props(value)
                 if extracted_scroll_props is None and scroll is not None and infinite_scroll_enabled:
@@ -880,56 +651,6 @@ class InertiaResponse(Response[T]):
         )
 
 
-def _merge_deferred_props(target: "dict[str, list[str]]", source: "Mapping[str, list[str]]") -> None:
-    for group, keys in source.items():
-        group_keys = target.setdefault(group, [])
-        for key in keys:
-            if key not in group_keys:
-                group_keys.append(key)
-
-
-def _discard_deferred_prop_key(target: "dict[str, list[str]]", key: str) -> None:
-    for group in tuple(target):
-        group_keys = target[group]
-        if key in group_keys:
-            group_keys.remove(key)
-        if not group_keys:
-            del target[group]
-
-
-class _AsyncInertiaSSRResponse:
-    """ASGI response placeholder for SSR HTTP pre-fetch.
-
-    Async prop callbacks are not resolved here because ASGI dispatch happens
-    after Litestar's yield-based dependency cleanup. The handler wrapper must
-    resolve those callbacks before this object is created.
-    """
-
-    __slots__ = ("_app", "_kwargs", "_request", "_response")
-
-    def __init__(
-        self,
-        *,
-        response: "InertiaResponse[Any]",
-        app: "Litestar | None",
-        request: "Request[Any, Any, Any]",
-        kwargs: "dict[str, Any]",
-    ) -> None:
-        self._response = response
-        self._app = app
-        self._request = request
-        self._kwargs = kwargs
-
-    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
-        info = _get_inertia_request_info(self._request)
-        partial_data = info.partial_keys if info.is_partial_render and info.partial_keys else None
-        partial_except = info.partial_except_keys if info.is_partial_render and info.partial_except_keys else None
-        await self._response._prefetch_ssr(self._request, info, partial_data, partial_except)  # pyright: ignore[reportPrivateUsage]
-        self._response._async_prepass_done = True  # pyright: ignore[reportPrivateUsage]
-        asgi_response = self._response.to_asgi_response(self._app, self._request, **self._kwargs)
-        await asgi_response(scope, receive, send)
-
-
 class InertiaExternalRedirect(Response[Any]):
     """External redirect via Inertia protocol (409 + X-Inertia-Location).
 
@@ -979,14 +700,66 @@ class InertiaRedirect(Redirect):
             **kwargs: Additional keyword arguments passed to the Redirect constructor.
         """
         safe_url = _get_redirect_url(request, redirect_to)
-        super().__init__(  # pyright: ignore[reportUnknownMemberType]
-            path=safe_url,
-            status_code=HTTP_307_TEMPORARY_REDIRECT if request.method == "GET" else HTTP_303_SEE_OTHER,
-            **kwargs,
+        if _should_use_fragment_redirect(request, safe_url):
+            self._uses_inertia_fragment_redirect = True
+            Response.__init__(  # pyright: ignore[reportUnknownMemberType]
+                self,
+                content=b"",
+                status_code=HTTP_409_CONFLICT,
+                headers={"X-Inertia-Redirect": quote(safe_url, safe="/#%[]=:;$&()+,!?*@'~")},
+                **kwargs,
+            )
+        else:
+            self._uses_inertia_fragment_redirect = False
+            super().__init__(  # pyright: ignore[reportUnknownMemberType]
+                path=safe_url,
+                status_code=HTTP_307_TEMPORARY_REDIRECT if request.method == "GET" else HTTP_303_SEE_OTHER,
+                **kwargs,
+            )
+
+    def to_asgi_response(
+        self,
+        app: "Litestar | None",
+        request: "Request[Any, Any, Any]",
+        *,
+        background: "BackgroundTask | BackgroundTasks | None" = None,
+        cookies: "Iterable[Cookie] | None" = None,
+        encoded_headers: "Iterable[tuple[bytes, bytes]] | None" = None,
+        headers: "dict[str, str] | None" = None,
+        is_head_response: bool = False,
+        media_type: "MediaType | str | None" = None,
+        status_code: "int | None" = None,
+        type_encoders: "TypeEncodersMap | None" = None,
+    ) -> "ASGIResponse":
+        if self._uses_inertia_fragment_redirect:
+            return Response.to_asgi_response(  # pyright: ignore[reportUnknownMemberType]
+                self,
+                app=app,
+                request=request,
+                background=background,
+                cookies=cookies,
+                encoded_headers=encoded_headers,
+                headers=headers,
+                is_head_response=is_head_response,
+                media_type=media_type,
+                status_code=status_code,
+                type_encoders=type_encoders,
+            )
+        return super().to_asgi_response(  # pyright: ignore[reportUnknownMemberType]
+            app=app,
+            request=request,
+            background=background,
+            cookies=cookies,
+            encoded_headers=encoded_headers,
+            headers=headers,
+            is_head_response=is_head_response,
+            media_type=media_type,
+            status_code=status_code,
+            type_encoders=type_encoders,
         )
 
 
-class InertiaBack(Redirect):
+class InertiaBack(InertiaRedirect):
     """Redirect back to the previous page using the Referer header.
 
     This class safely validates the Referer header to prevent open redirect
@@ -1006,8 +779,301 @@ class InertiaBack(Redirect):
             **kwargs: Additional keyword arguments passed to the Redirect constructor.
         """
         safe_url = _get_redirect_url(request, request.headers.get("Referer"))
-        super().__init__(  # pyright: ignore[reportUnknownMemberType]
-            path=safe_url,
-            status_code=HTTP_307_TEMPORARY_REDIRECT if request.method == "GET" else HTTP_303_SEE_OTHER,
-            **kwargs,
+        super().__init__(request=request, redirect_to=safe_url, **kwargs)
+
+
+@dataclass(frozen=True)
+class _InertiaSSRResult:
+    head: list[str]
+    body: str
+
+
+@dataclass(frozen=True)
+class _InertiaRequestInfo:
+    inertia_enabled: bool
+    is_inertia: bool
+    is_partial_render: bool
+    partial_keys: set[str]
+    partial_except_keys: set[str]
+    except_once_keys: set[str]
+    reset_keys: set[str]
+
+
+def _get_inertia_request_info(request: "Request[Any, Any, Any]") -> _InertiaRequestInfo:
+    """Return Inertia request state for both InertiaRequest and plain Request.
+
+    InertiaResponse is typically used together with InertiaMiddleware, which wraps
+    incoming requests in :class:`~litestar_vite.inertia.request.InertiaRequest`.
+
+    This helper preserves compatibility with plain :class:`litestar.Request` by
+    falling back to header parsing via :class:`~litestar_vite.inertia.request.InertiaDetails`.
+
+    Returns:
+        Aggregated Inertia-related request flags and partial-render metadata.
+    """
+    if isinstance(request, InertiaRequest):
+        is_inertia = request.is_inertia
+        return _InertiaRequestInfo(
+            inertia_enabled=bool(request.inertia_enabled or is_inertia),
+            is_inertia=is_inertia,
+            is_partial_render=request.is_partial_render,
+            partial_keys=request.partial_keys,
+            partial_except_keys=request.partial_except_keys,
+            except_once_keys=request.except_once_props_keys,
+            reset_keys=request.reset_keys,
         )
+
+    details = InertiaDetails(request)
+    is_inertia = bool(details)
+    return _InertiaRequestInfo(
+        inertia_enabled=bool(details.route_component is not None or is_inertia),
+        is_inertia=is_inertia,
+        is_partial_render=details.is_partial_render,
+        partial_keys=set(details.partial_keys),
+        partial_except_keys=set(details.partial_except_keys),
+        except_once_keys=set(details.except_once_props_keys),
+        reset_keys=set(details.reset_keys),
+    )
+
+
+# Maximum allowed size for SSR response body + head combined (10 MiB).
+# This prevents a malicious or misconfigured SSR server from causing OOM.
+_SSR_MAX_RESPONSE_BYTES = 10 * 1024 * 1024
+
+
+def _parse_inertia_ssr_payload(payload: Any, url: str) -> _InertiaSSRResult:
+    if not isinstance(payload, dict):
+        msg = f"Inertia SSR server at {url!r} returned unexpected payload type: {type(payload)!r}."
+        raise ImproperlyConfiguredException(msg)
+
+    payload_dict = cast("dict[str, Any]", payload)
+
+    body = payload_dict.get("body")
+    if not isinstance(body, str):
+        msg = f"Inertia SSR server at {url!r} returned invalid 'body' (expected string)."
+        raise ImproperlyConfiguredException(msg)
+
+    head_raw: Any = payload_dict.get("head", [])
+    if head_raw is None:
+        head_raw = []
+    if not isinstance(head_raw, list):
+        msg = f"Inertia SSR server at {url!r} returned invalid 'head' (expected list[str])."
+        raise ImproperlyConfiguredException(msg)
+
+    head_list = cast("list[Any]", head_raw)
+    if any(not isinstance(item, str) for item in head_list):
+        msg = f"Inertia SSR server at {url!r} returned invalid 'head' (expected list[str])."
+        raise ImproperlyConfiguredException(msg)
+
+    total_size = len(body) + sum(len(h) for h in head_list)
+    if total_size > _SSR_MAX_RESPONSE_BYTES:
+        msg = (
+            f"Inertia SSR response from {url!r} exceeds maximum allowed size "
+            f"({total_size:,} bytes > {_SSR_MAX_RESPONSE_BYTES:,} bytes). "
+            "This may indicate a misconfigured SSR server."
+        )
+        raise ImproperlyConfiguredException(msg)
+
+    return _InertiaSSRResult(head=cast("list[str]", head_list), body=body)
+
+
+async def _render_inertia_ssr(
+    page: dict[str, Any], url: str, timeout_seconds: float, client: "httpx.AsyncClient | None" = None
+) -> _InertiaSSRResult:
+    """Call the Inertia SSR server asynchronously and return head/body HTML.
+
+    Args:
+        page: The page object to send to the SSR server.
+        url: The SSR server URL (typically http://localhost:13714/render).
+        timeout_seconds: Request timeout in seconds.
+        client: Optional shared httpx.AsyncClient for connection pooling.
+            If None, creates a new client per request (slower).
+
+    Returns:
+        An _InertiaSSRResult with head and body HTML.
+    """
+    return await _do_ssr_request(page, url, timeout_seconds, client)
+
+
+@contextlib.asynccontextmanager
+async def _acquire_ssr_client(client: "httpx.AsyncClient | None") -> "AsyncGenerator[httpx.AsyncClient, None]":
+    """Yield ``client`` when provided, otherwise a short-lived fallback client.
+
+    Yields:
+        The shared client when supplied, or a fallback client whose lifecycle is
+        bound to the context.
+    """
+    if client is not None:
+        yield client
+    else:
+        async with httpx.AsyncClient() as fallback:
+            yield fallback
+
+
+async def _do_ssr_request(
+    page: dict[str, Any], url: str, timeout_seconds: float, client: "httpx.AsyncClient | None"
+) -> _InertiaSSRResult:
+    """Execute the SSR request with optional client reuse.
+
+    Args:
+        page: The page object to send to the SSR server.
+        url: The SSR server URL.
+        timeout_seconds: Request timeout in seconds.
+        client: Optional shared httpx.AsyncClient.
+
+    Raises:
+        ImproperlyConfiguredException: If the SSR server is unreachable,
+            returns an error status, or returns invalid payload.
+
+    Returns:
+        An _InertiaSSRResult with head and body HTML.
+    """
+    # Use Litestar's msgspec encoder so msgspec Structs and other custom types embedded
+    # in handler return values serialize the same way as the regular Inertia render path
+    # (response.render uses get_serializer too). httpx's default json= serializer falls
+    # back to stdlib json.dumps and rejects Struct instances.
+    body = encode_json(page, serializer=get_serializer(None))
+    headers = {"content-type": "application/json"}
+
+    try:
+        async with _acquire_ssr_client(client) as resolved_client:
+            response = await resolved_client.post(url, content=body, headers=headers, timeout=timeout_seconds)
+            response.raise_for_status()
+    except httpx.RequestError as exc:
+        msg = (
+            f"Inertia SSR is enabled but the SSR server is not reachable at {url!r}. "
+            "Start the SSR server (Node) or disable InertiaConfig.ssr."
+        )
+        raise ImproperlyConfiguredException(msg) from exc
+    except httpx.HTTPStatusError as exc:
+        msg = f"Inertia SSR server at {url!r} returned HTTP {exc.response.status_code}. Check the SSR server logs."
+        raise ImproperlyConfiguredException(msg) from exc
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        msg = f"Inertia SSR server at {url!r} returned invalid JSON. Check the SSR server logs."
+        raise ImproperlyConfiguredException(msg) from exc
+
+    return _parse_inertia_ssr_payload(payload, url)
+
+
+def _get_redirect_url(request: "Request[Any, Any, Any]", url: str | None) -> str:
+    """Return a safe redirect URL, falling back to base_url when invalid.
+
+    Args:
+        request: The request object.
+        url: Candidate redirect URL.
+
+    Returns:
+        A safe redirect URL (same-origin absolute, or relative), otherwise the request base URL.
+    """
+    base_url = str(request.base_url)
+
+    if not url:
+        return base_url
+
+    parsed = urlparse(url)
+    base = urlparse(base_url)
+
+    if not parsed.scheme and not parsed.netloc:
+        return url
+
+    if parsed.scheme not in {"http", "https"}:
+        return base_url
+
+    if parsed.netloc != base.netloc:
+        return base_url
+
+    return url
+
+
+def _get_relative_url(request: "Request[Any, Any, Any]") -> str:
+    """Return the relative URL including query string for Inertia page props.
+
+    The Inertia.js protocol requires the ``url`` property to include query parameters
+    so that page state (e.g., filters, pagination) is preserved on refresh.
+
+    This matches the behavior of other Inertia adapters:
+    - Laravel: Uses ``fullUrl()`` minus scheme/host
+    - Rails: Uses ``request.fullpath``
+    - Django: Uses ``request.get_full_path()``
+
+    Args:
+        request: The request object.
+
+    Returns:
+        The path with query string if present, e.g., ``/reports?page=1&status=active``.
+    """
+    path = request.url.path
+    query = request.url.query
+    return f"{path}?{query}" if query else path
+
+
+def _should_use_fragment_redirect(request: "Request[Any, Any, Any]", url: str) -> bool:
+    return bool(InertiaDetails(request)) and bool(urlparse(url).fragment)
+
+
+def _merge_deferred_props(target: "dict[str, list[str]]", source: "Mapping[str, list[str]]") -> None:
+    for group, keys in source.items():
+        group_keys = target.setdefault(group, [])
+        for key in keys:
+            if key not in group_keys:
+                group_keys.append(key)
+
+
+def _discard_deferred_prop_key(target: "dict[str, list[str]]", key: str) -> None:
+    for group in tuple(target):
+        group_keys = target[group]
+        group_keys[:] = [
+            prop_key
+            for prop_key in group_keys
+            if prop_key != key and not prop_key.startswith(f"{key}.") and prop_key.rsplit(".", maxsplit=1)[-1] != key
+        ]
+        if not group_keys:
+            del target[group]
+
+
+def _dedupe_once_prop_entries(
+    entries: "Iterable[str | tuple[str, str]]", *, reset_keys: "set[str]"
+) -> "list[str | tuple[str, str]]":
+    filtered: "dict[str, str | tuple[str, str]]" = {}
+    for entry in entries:
+        key, prop_path = entry if isinstance(entry, tuple) else (entry, entry)
+        if key in reset_keys or prop_path in reset_keys:
+            continue
+        filtered.setdefault(key, entry)
+    return list(filtered.values())
+
+
+class _AsyncInertiaSSRResponse:
+    """ASGI response placeholder for SSR HTTP pre-fetch.
+
+    Async prop callbacks are not resolved here because ASGI dispatch happens
+    after Litestar's yield-based dependency cleanup. The handler wrapper must
+    resolve those callbacks before this object is created.
+    """
+
+    __slots__ = ("_app", "_kwargs", "_request", "_response")
+
+    def __init__(
+        self,
+        *,
+        response: "InertiaResponse[Any]",
+        app: "Litestar | None",
+        request: "Request[Any, Any, Any]",
+        kwargs: "dict[str, Any]",
+    ) -> None:
+        self._response = response
+        self._app = app
+        self._request = request
+        self._kwargs = kwargs
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        info = _get_inertia_request_info(self._request)
+        partial_data = info.partial_keys if info.is_partial_render and info.partial_keys else None
+        partial_except = info.partial_except_keys if info.is_partial_render and info.partial_except_keys else None
+        await self._response._prefetch_ssr(self._request, info, partial_data, partial_except)  # pyright: ignore[reportPrivateUsage]
+        self._response._async_prepass_done = True  # pyright: ignore[reportPrivateUsage]
+        asgi_response = self._response.to_asgi_response(self._app, self._request, **self._kwargs)
+        await asgi_response(scope, receive, send)

--- a/src/py/litestar_vite/inertia/types.py
+++ b/src/py/litestar_vite/inertia/types.py
@@ -312,7 +312,12 @@ class PageProps(Generic[T]):
         Returns:
             The Inertia protocol dictionary.
         """
-        return to_inertia_dict(self, required_fields={"component", "url", "version", "props"})
+        data = to_inertia_dict(self, required_fields={"component", "url", "version", "props"})
+        if data.get("encryptHistory") is False:
+            del data["encryptHistory"]
+        if data.get("clearHistory") is False:
+            del data["clearHistory"]
+        return data
 
 
 @dataclass

--- a/src/py/litestar_vite/plugin/__init__.py
+++ b/src/py/litestar_vite/plugin/__init__.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, cast
 import httpx
 from litestar.exceptions import NotFoundException
 from litestar.middleware import DefineMiddleware
-from litestar.plugins import CLIPlugin, InitPluginProtocol
+from litestar.plugins import CLIPlugin, InitPlugin
 from litestar.static_files import create_static_files_router  # pyright: ignore[reportUnknownVariableType]
 
 from litestar_vite.config import JINJA_INSTALLED, TRUE_VALUES, ExternalDevServer
@@ -118,7 +118,7 @@ def _user_has_root_http_handler(route_handlers: "Iterable[ControllerRouterHandle
     return any(_walk(item) for item in route_handlers or [])
 
 
-class VitePlugin(InitPluginProtocol, CLIPlugin):
+class VitePlugin(InitPlugin, CLIPlugin):
     """Vite plugin for Litestar.
 
     This plugin integrates Vite with Litestar, providing:
@@ -404,7 +404,7 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
         Args:
             app_config: The Litestar application configuration.
         """
-        from litestar.contrib.jinja import JinjaTemplateEngine
+        from litestar.plugins.jinja import JinjaTemplateEngine
 
         from litestar_vite.loader import render_asset_tag, render_hmr_client, render_routes, render_static_asset
 
@@ -440,7 +440,7 @@ class VitePlugin(InitPluginProtocol, CLIPlugin):
         template_config = app_config.template_config  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
         if template_config is None:
             return False
-        from litestar.contrib.jinja import JinjaTemplateEngine
+        from litestar.plugins.jinja import JinjaTemplateEngine
 
         return isinstance(template_config.engine_instance, JinjaTemplateEngine)  # pyright: ignore[reportUnknownMemberType]
 

--- a/src/py/litestar_vite/templates/react-inertia/index.html.j2
+++ b/src/py/litestar_vite/templates/react-inertia/index.html.j2
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>{{ project_name }}</title>
+    <title data-inertia>{{ project_name }}</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/py/litestar_vite/templates/react-inertia/index.html.j2
+++ b/src/py/litestar_vite/templates/react-inertia/index.html.j2
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>{{ project_name }}</title>
+    <title>{{ project_name }}</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/py/litestar_vite/templates/svelte-inertia/index.html.j2
+++ b/src/py/litestar_vite/templates/svelte-inertia/index.html.j2
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>{{ project_name }}</title>
+    <title data-inertia>{{ project_name }}</title>
     {{ "{{ vite_hmr() }}" }}
     {{ "{{ vite('{{ resource_dir }}/main.ts') }}" }}
   </head>

--- a/src/py/litestar_vite/templates/svelte-inertia/index.html.j2
+++ b/src/py/litestar_vite/templates/svelte-inertia/index.html.j2
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/static/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>{{ project_name }}</title>
+    <title>{{ project_name }}</title>
     {{ "{{ vite_hmr() }}" }}
     {{ "{{ vite('{{ resource_dir }}/main.ts') }}" }}
   </head>

--- a/src/py/litestar_vite/templates/vue-inertia/index.html.j2
+++ b/src/py/litestar_vite/templates/vue-inertia/index.html.j2
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title data-inertia>{{ project_name }}</title>
+    <title>{{ project_name }}</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/py/litestar_vite/templates/vue-inertia/index.html.j2
+++ b/src/py/litestar_vite/templates/vue-inertia/index.html.j2
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title inertia>{{ project_name }}</title>
+    <title data-inertia>{{ project_name }}</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/py/litestar_vite/typing.py
+++ b/src/py/litestar_vite/typing.py
@@ -1,0 +1,40 @@
+# ruff: noqa: A005
+"""Public typing and optional-dependency shims."""
+
+from litestar_vite._typing import (
+    ADVANCED_ALCHEMY_INSTALLED,
+    FSSPEC_INSTALLED,
+    JINJA_INSTALLED,
+    SQLSPEC_INSTALLED,
+    AdvancedAlchemyDuplicateKeyError,
+    AdvancedAlchemyForeignKeyError,
+    AdvancedAlchemyIntegrityError,
+    AdvancedAlchemyNotFoundError,
+    AdvancedAlchemyRepositoryError,
+    SQLSpecCheckViolationError,
+    SQLSpecForeignKeyViolationError,
+    SQLSpecIntegrityError,
+    SQLSpecNotFoundError,
+    SQLSpecNotNullViolationError,
+    SQLSpecRepositoryError,
+    SQLSpecUniqueViolationError,
+)
+
+__all__ = (
+    "ADVANCED_ALCHEMY_INSTALLED",
+    "FSSPEC_INSTALLED",
+    "JINJA_INSTALLED",
+    "SQLSPEC_INSTALLED",
+    "AdvancedAlchemyDuplicateKeyError",
+    "AdvancedAlchemyForeignKeyError",
+    "AdvancedAlchemyIntegrityError",
+    "AdvancedAlchemyNotFoundError",
+    "AdvancedAlchemyRepositoryError",
+    "SQLSpecCheckViolationError",
+    "SQLSpecForeignKeyViolationError",
+    "SQLSpecIntegrityError",
+    "SQLSpecNotFoundError",
+    "SQLSpecNotNullViolationError",
+    "SQLSpecRepositoryError",
+    "SQLSpecUniqueViolationError",
+)

--- a/src/py/tests/conftest.py
+++ b/src/py/tests/conftest.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 from pytest import TempPathFactory
 

--- a/src/py/tests/integration/cli/test_codegen_commands.py
+++ b/src/py/tests/integration/cli/test_codegen_commands.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from litestar import Litestar, get
+from litestar.params import FromPath
 from litestar.serialization import decode_json, encode_json, get_serializer
 
 from litestar_vite.codegen import generate_routes_json
@@ -18,7 +19,7 @@ def test_export_routes_integration(tmp_path: Path) -> None:
         return ["user1", "user2"]
 
     @get("/users/{user_id:int}", name="get_user", sync_to_thread=False)
-    def get_user_handler(user_id: int) -> dict[str, int]:
+    def get_user_handler(user_id: FromPath[int]) -> dict[str, int]:
         return {"id": user_id}
 
     @get("/dashboard", name="dashboard", opt={"component": "Dashboard/Index"}, sync_to_thread=False)
@@ -114,7 +115,7 @@ def test_export_routes_typescript_integration(tmp_path: Path) -> None:
         return ["user1", "user2"]
 
     @get("/users/{user_id:int}", name="get_user", sync_to_thread=False)
-    def get_user_handler(user_id: int) -> dict[str, int]:
+    def get_user_handler(user_id: FromPath[int]) -> dict[str, int]:
         return {"id": user_id}
 
     @get("/dashboard", name="dashboard", opt={"component": "Dashboard/Index"}, sync_to_thread=False)

--- a/src/py/tests/integration/cli/test_init.py
+++ b/src/py/tests/integration/cli/test_init.py
@@ -22,7 +22,7 @@ from litestar_vite import ViteConfig, VitePlugin
 
 try:
     from litestar.template.config import TemplateConfig
-    from litestar.contrib.jinja import JinjaTemplateEngine
+    from litestar.plugins.jinja import JinjaTemplateEngine
     jinja_available = True
 except ImportError:
     jinja_available = False
@@ -64,7 +64,7 @@ from pathlib import Path
 from litestar import Controller, Litestar, get
 from litestar.response import Template
 from litestar.template.config import TemplateConfig
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 
 from litestar_vite import ViteConfig, VitePlugin
 
@@ -117,7 +117,7 @@ from __future__ import annotations
 
 from litestar import Litestar
 from litestar.template.config import TemplateConfig
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 
 from litestar_vite import VitePlugin, ViteConfig
 
@@ -152,7 +152,7 @@ from pathlib import Path
 
 from litestar import Litestar
 from litestar.template.config import TemplateConfig
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 
 from litestar_vite import ViteConfig, VitePlugin
 
@@ -196,7 +196,7 @@ from pathlib import Path
 
 from litestar import Litestar
 from litestar.template.config import TemplateConfig
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 
 from litestar_vite import ViteConfig, VitePlugin
 

--- a/src/py/tests/integration/test_optional_jinja.py
+++ b/src/py/tests/integration/test_optional_jinja.py
@@ -51,7 +51,7 @@ def test_optional_jinja_init_vite_without_jinja_raises_clear_error(tmp_path: Pat
 
 def test_optional_jinja_plugin_with_jinja_available() -> None:
     """Test VitePlugin works when Jinja is available."""
-    from litestar.contrib.jinja import JinjaTemplateEngine
+    from litestar.plugins.jinja import JinjaTemplateEngine
 
     from litestar_vite.plugin import VitePlugin
 
@@ -87,7 +87,7 @@ def test_optional_jinja_plugin_without_jinja_template_engine() -> None:
 
 @patch("litestar_vite.plugin.JINJA_INSTALLED", False)
 def test_optional_jinja_plugin_import_without_jinja_contrib() -> None:
-    """Test plugin behavior when litestar.contrib.jinja is not available."""
+    """Test plugin behavior when litestar.plugins.jinja is not available."""
     # This test simulates the scenario where litestar[jinja] extra is not installed
     from litestar_vite.plugin import VitePlugin
 
@@ -184,7 +184,7 @@ def test_installation_basic_functionality_without_jinja_extra() -> None:
 
 def test_installation_full_functionality_with_jinja_extra(tmp_path: Path) -> None:
     """Test that full functionality works when jinja extra is installed."""
-    from litestar.contrib.jinja import JinjaTemplateEngine
+    from litestar.plugins.jinja import JinjaTemplateEngine
 
     from litestar_vite.config import ViteConfig
     from litestar_vite.plugin import VitePlugin

--- a/src/py/tests/test_app/app.py
+++ b/src/py/tests/test_app/app.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from litestar import Litestar
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 
 from litestar_vite import PathConfig, RuntimeConfig, ViteConfig, VitePlugin

--- a/src/py/tests/unit/inertia/conftest.py
+++ b/src/py/tests/unit/inertia/conftest.py
@@ -2,7 +2,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 import pytest
-from litestar.contrib.jinja import JinjaTemplateEngine
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.template.config import TemplateConfig
 
 from litestar_vite.config import InertiaConfig, ViteConfig

--- a/src/py/tests/unit/inertia/test_auto_registration.py
+++ b/src/py/tests/unit/inertia/test_auto_registration.py
@@ -23,7 +23,7 @@ import pytest
 from litestar import Request, get
 from litestar.config.app import AppConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
-from litestar.plugins import InitPluginProtocol
+from litestar.plugins import InitPlugin
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
@@ -48,7 +48,7 @@ def inertia_vite_config(test_app_path: Path) -> ViteConfig:
 @pytest.fixture
 def template_config_inertia(test_app_path: Path) -> TemplateConfig[Any]:
     """Template config that points at the Inertia test templates folder."""
-    from litestar.contrib.jinja import JinjaTemplateEngine
+    from litestar.plugins.jinja import JinjaTemplateEngine
 
     return TemplateConfig(engine=JinjaTemplateEngine(directory=Path(__file__).parent / "templates"))
 
@@ -136,7 +136,7 @@ def test_inertia_middleware_installed_only_once(
         assert count == 1, f"InertiaMiddleware registered {count} times, expected 1"
 
 
-class _ReboundPlugin(InitPluginProtocol):
+class _ReboundPlugin(InitPlugin):
     """Test double for plugins (e.g. older SQLSpecPlugin) that rebind plugins.
 
     This reproduces the exact failure mode from the bug report: a plugin that

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -148,7 +148,7 @@ async def test_clear_history_helper_consumed_once(
 
         # Second request - flag should be consumed (popped)
         home_response = client.get("/home", headers={InertiaHeaders.ENABLED.value: "true"})
-        assert home_response.json()["clearHistory"] is False
+        assert "clearHistory" not in home_response.json()
 
 
 async def test_clear_history_helper_response_param_takes_precedence(
@@ -894,6 +894,18 @@ def test_extract_once_props_mixed() -> None:
     assert "lazy_data" not in result
 
 
+def test_extract_once_props_nested_keeps_stable_once_keys() -> None:
+    """Test nested once props keep stable keys while path metadata can use dot paths."""
+    from litestar_vite.inertia.helpers import build_once_props_metadata, extract_once_props, once
+
+    props = {"profile": {"settings": once("settings", {"theme": "dark"})}}
+
+    result = extract_once_props(props)
+
+    assert result == ["settings"]
+    assert build_once_props_metadata([("settings", "profile.settings")]) == {"settings": {"prop": "profile.settings"}}
+
+
 def test_should_render_once_prop_with_except_once_props() -> None:
     """Test that once props honor the except-once header unless explicitly requested."""
     from litestar_vite.inertia.helpers import once, should_render
@@ -902,6 +914,22 @@ def test_should_render_once_prop_with_except_once_props() -> None:
 
     assert should_render(prop, except_once_props={"settings"}) is False
     assert should_render(prop, partial_data={"settings"}, except_once_props={"settings"}) is True
+
+
+def test_should_render_special_props_matches_dot_path_and_legacy_key() -> None:
+    """Test nested special props can be selected by v3 dot paths or legacy local keys."""
+    from litestar_vite.inertia.helpers import lazy, optional, should_render
+
+    prop = optional("permissions", lambda: ["read"])
+    deferred = lazy("permissions", ["read"])
+
+    assert should_render(prop, partial_data={"profile.permissions"}, key="profile.permissions") is True
+    assert should_render(prop, partial_data={"permissions"}, key="profile.permissions") is True
+    assert should_render(prop, partial_except={"profile.permissions"}, key="profile.permissions") is False
+    assert should_render(prop, partial_except={"permissions"}, key="profile.permissions") is False
+
+    assert should_render(deferred, partial_data={"profile.permissions"}, key="profile.permissions") is True
+    assert should_render(deferred, partial_data={"permissions"}, key="profile.permissions") is True
 
 
 # =====================================================

--- a/src/py/tests/unit/inertia/test_middleware.py
+++ b/src/py/tests/unit/inertia/test_middleware.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 from litestar import Request, get
 from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.params import FromQuery
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client
@@ -220,7 +221,7 @@ async def test_version_mismatch_preserves_query_string(
     """Test that version mismatch preserves query parameters in redirect."""
 
     @get("/search", component="Search")
-    async def handler(request: Request[Any, Any, Any], q: str = "") -> dict[str, Any]:
+    async def handler(request: Request[Any, Any, Any], q: FromQuery[str] = "") -> dict[str, Any]:
         return {"query": q}
 
     with create_test_client(

--- a/src/py/tests/unit/inertia/test_repository_exception_boundary.py
+++ b/src/py/tests/unit/inertia/test_repository_exception_boundary.py
@@ -1,0 +1,210 @@
+"""Repository exception boundary tests."""
+
+import importlib
+import sys
+import warnings
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+from litestar import Request, get
+from litestar.exceptions import HTTPException
+from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.response import Response
+from litestar.status_codes import HTTP_404_NOT_FOUND, HTTP_409_CONFLICT, HTTP_500_INTERNAL_SERVER_ERROR
+from litestar.stores.memory import MemoryStore
+from litestar.testing import create_test_client
+from litestar.utils.deprecation import LitestarDeprecationWarning
+
+from litestar_vite.config import InertiaConfig, ViteConfig
+
+
+class _RepositoryException(Exception):
+    def __init__(self, detail: str = "") -> None:
+        self.detail = detail
+        super().__init__(detail)
+
+
+def _repository_error(name: str, base: type[Exception] = Exception) -> type[Exception]:
+    return cast("type[Exception]", type(name, (base,), {}))
+
+
+def _install_advanced_alchemy_exceptions(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    exceptions = ModuleType("advanced_alchemy.exceptions")
+
+    repository_error = _repository_error("RepositoryError", _RepositoryException)
+    integrity_error = _repository_error("IntegrityError", repository_error)
+    exceptions.RepositoryError = repository_error
+    exceptions.NotFoundError = _repository_error("NotFoundError", repository_error)
+    exceptions.IntegrityError = integrity_error
+    exceptions.DuplicateKeyError = _repository_error("DuplicateKeyError", integrity_error)
+    exceptions.ForeignKeyError = _repository_error("ForeignKeyError", integrity_error)
+
+    import litestar_vite._typing as lv_typing
+
+    monkeypatch.setattr(lv_typing, "ADVANCED_ALCHEMY_INSTALLED", True)
+    monkeypatch.setattr(lv_typing, "AdvancedAlchemyRepositoryError", exceptions.RepositoryError)
+    monkeypatch.setattr(lv_typing, "AdvancedAlchemyNotFoundError", exceptions.NotFoundError)
+    monkeypatch.setattr(lv_typing, "AdvancedAlchemyIntegrityError", exceptions.IntegrityError)
+    monkeypatch.setattr(lv_typing, "AdvancedAlchemyDuplicateKeyError", exceptions.DuplicateKeyError)
+    monkeypatch.setattr(lv_typing, "AdvancedAlchemyForeignKeyError", exceptions.ForeignKeyError)
+    return exceptions
+
+
+def _install_sqlspec_exceptions(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    exceptions = ModuleType("sqlspec.exceptions")
+
+    repository_error = _repository_error("RepositoryError", _RepositoryException)
+    integrity_error = _repository_error("IntegrityError", repository_error)
+    exceptions.RepositoryError = repository_error
+    exceptions.NotFoundError = _repository_error("NotFoundError", repository_error)
+    exceptions.IntegrityError = integrity_error
+    exceptions.UniqueViolationError = _repository_error("UniqueViolationError", integrity_error)
+    exceptions.ForeignKeyViolationError = _repository_error("ForeignKeyViolationError", integrity_error)
+    exceptions.CheckViolationError = _repository_error("CheckViolationError", integrity_error)
+    exceptions.NotNullViolationError = _repository_error("NotNullViolationError", integrity_error)
+
+    import litestar_vite._typing as lv_typing
+
+    monkeypatch.setattr(lv_typing, "SQLSPEC_INSTALLED", True)
+    monkeypatch.setattr(lv_typing, "SQLSpecRepositoryError", exceptions.RepositoryError)
+    monkeypatch.setattr(lv_typing, "SQLSpecNotFoundError", exceptions.NotFoundError)
+    monkeypatch.setattr(lv_typing, "SQLSpecIntegrityError", exceptions.IntegrityError)
+    monkeypatch.setattr(lv_typing, "SQLSpecUniqueViolationError", exceptions.UniqueViolationError)
+    monkeypatch.setattr(lv_typing, "SQLSpecForeignKeyViolationError", exceptions.ForeignKeyViolationError)
+    monkeypatch.setattr(lv_typing, "SQLSpecCheckViolationError", exceptions.CheckViolationError)
+    monkeypatch.setattr(lv_typing, "SQLSpecNotNullViolationError", exceptions.NotNullViolationError)
+    return exceptions
+
+
+def test_importing_exception_handler_emits_no_litestar_deprecation_warnings() -> None:
+    """Importing the exception handler must not touch deprecated Litestar repository modules."""
+
+    sys.modules.pop("litestar_vite.inertia.exception_handler", None)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LitestarDeprecationWarning)
+        importlib.import_module("litestar_vite.inertia.exception_handler")
+
+
+def test_typing_facade_import_emits_no_litestar_deprecation_warnings() -> None:
+    """Importing the optional dependency facade must not import deprecated Litestar modules."""
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LitestarDeprecationWarning)
+        typing_module = importlib.import_module("litestar_vite.typing")
+
+    private_typing = importlib.import_module("litestar_vite._typing")
+    assert typing_module.SQLSPEC_INSTALLED is private_typing.SQLSPEC_INSTALLED
+    assert typing_module.ADVANCED_ALCHEMY_INSTALLED is private_typing.ADVANCED_ALCHEMY_INSTALLED
+    assert issubclass(typing_module.SQLSpecRepositoryError, Exception)
+    assert issubclass(typing_module.AdvancedAlchemyRepositoryError, Exception)
+
+
+def test_repository_exception_handlers_are_not_registered_without_supported_libraries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional repository handlers are skipped when supported libraries are absent."""
+
+    import litestar_vite._typing as lv_typing
+    from litestar_vite.inertia import InertiaHeaders
+    from litestar_vite.plugin import VitePlugin
+
+    monkeypatch.setattr(lv_typing, "ADVANCED_ALCHEMY_INSTALLED", False)
+    monkeypatch.setattr(lv_typing, "SQLSPEC_INSTALLED", False)
+
+    @get("/repository", component="Repository", sync_to_thread=False)
+    def handler() -> dict[str, str]:
+        raise lv_typing.SQLSpecNotFoundError("repository failure")
+
+    with create_test_client(
+        [handler],
+        middleware=[ServerSideSessionConfig().middleware],
+        plugins=[VitePlugin(config=ViteConfig(mode="template", inertia=InertiaConfig()))],
+        raise_server_exceptions=False,
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/repository", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json()["props"]["status_code"] == HTTP_500_INTERNAL_SERVER_ERROR
+
+
+@pytest.mark.parametrize(
+    ("package_name", "exception_name", "expected_status"),
+    [
+        ("advanced_alchemy", "NotFoundError", HTTP_404_NOT_FOUND),
+        ("advanced_alchemy", "IntegrityError", HTTP_409_CONFLICT),
+        ("advanced_alchemy", "DuplicateKeyError", HTTP_409_CONFLICT),
+        ("advanced_alchemy", "ForeignKeyError", HTTP_409_CONFLICT),
+        ("advanced_alchemy", "RepositoryError", HTTP_500_INTERNAL_SERVER_ERROR),
+        ("sqlspec", "NotFoundError", HTTP_404_NOT_FOUND),
+        ("sqlspec", "IntegrityError", HTTP_409_CONFLICT),
+        ("sqlspec", "UniqueViolationError", HTTP_409_CONFLICT),
+        ("sqlspec", "ForeignKeyViolationError", HTTP_409_CONFLICT),
+        ("sqlspec", "CheckViolationError", HTTP_409_CONFLICT),
+        ("sqlspec", "NotNullViolationError", HTTP_409_CONFLICT),
+        ("sqlspec", "RepositoryError", HTTP_500_INTERNAL_SERVER_ERROR),
+    ],
+)
+def test_litestar_org_repository_exception_handlers_delegate_to_inertia_response(
+    monkeypatch: pytest.MonkeyPatch, package_name: str, exception_name: str, expected_status: int
+) -> None:
+    """Supported repository exceptions are converted by plugin-registered handlers."""
+
+    from litestar_vite.inertia import InertiaHeaders
+    from litestar_vite.plugin import VitePlugin
+
+    advanced_alchemy_exceptions = _install_advanced_alchemy_exceptions(monkeypatch)
+    sqlspec_exceptions = _install_sqlspec_exceptions(monkeypatch)
+    exception_module = advanced_alchemy_exceptions if package_name == "advanced_alchemy" else sqlspec_exceptions
+    exception_type = getattr(exception_module, exception_name)
+
+    @get("/repository", component="Repository", sync_to_thread=False)
+    def handler() -> dict[str, str]:
+        raise exception_type("repository failure")
+
+    with create_test_client(
+        [handler],
+        middleware=[ServerSideSessionConfig().middleware],
+        plugins=[VitePlugin(config=ViteConfig(mode="template", inertia=InertiaConfig()))],
+        raise_server_exceptions=False,
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/repository", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code == expected_status
+    assert response.json()["props"]["status_code"] == expected_status
+    assert response.json()["props"]["message"] == "repository failure"
+
+
+def test_user_repository_exception_handler_can_delegate_to_inertia_response() -> None:
+    """End-user repository exceptions still work with direct app-level handlers."""
+
+    from litestar_vite.inertia import InertiaHeaders
+    from litestar_vite.inertia.exception_handler import exception_to_http_response
+    from litestar_vite.plugin import VitePlugin
+
+    class RepositoryLikeError(Exception):
+        pass
+
+    def repository_exception_handler(request: Request[Any, Any, Any], exc: RepositoryLikeError) -> Response[Any]:
+        http_exc = HTTPException(detail=str(exc), status_code=HTTP_409_CONFLICT)
+        return exception_to_http_response(request, http_exc)
+
+    @get("/repository", component="Repository", sync_to_thread=False)
+    def handler() -> dict[str, str]:
+        raise RepositoryLikeError("repository failure")
+
+    with create_test_client(
+        [handler],
+        exception_handlers={RepositoryLikeError: repository_exception_handler},
+        middleware=[ServerSideSessionConfig().middleware],
+        plugins=[VitePlugin(config=ViteConfig(mode="template", inertia=InertiaConfig()))],
+        raise_server_exceptions=False,
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/repository", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code == HTTP_409_CONFLICT
+    assert response.json()["props"]["status_code"] == HTTP_409_CONFLICT
+    assert response.json()["props"]["message"] == "repository failure"

--- a/src/py/tests/unit/inertia/test_request.py
+++ b/src/py/tests/unit/inertia/test_request.py
@@ -274,6 +274,20 @@ def test_page_props_to_dict() -> None:
     assert "deepMergeProps" not in result
 
 
+def test_page_props_to_dict_omits_false_history_flags_by_default() -> None:
+    """Test PageProps.to_dict() omits v3 optional history flags unless true."""
+    from litestar_vite.inertia.types import PageProps
+
+    page: PageProps[dict[str, str]] = PageProps(
+        component="Home", url="/dashboard", version="abc123", props={"user": "test"}
+    )
+
+    result = page.to_dict()
+
+    assert "encryptHistory" not in result
+    assert "clearHistory" not in result
+
+
 # =====================================================
 # Page Component Alias Tests (component_opt_keys)
 # =====================================================

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -30,6 +30,8 @@ from litestar_vite.inertia.helpers import (
     lazy,
     lazy_render,
     merge,
+    once,
+    optional,
     share,
     should_render,
 )
@@ -800,6 +802,21 @@ async def test_extract_deferred_props() -> None:
     assert sorted(groups["attributes"]) == ["projects", "teams"]
 
 
+async def test_extract_deferred_props_uses_nested_dot_paths() -> None:
+    """Test nested deferred props emit v3 dot-path metadata."""
+    props = {
+        "profile": {
+            "permissions": defer("permissions", lambda: ["read"]),
+            "teams": defer("teams", lambda: [], group="attributes"),
+        },
+        "settings": defer("settings", lambda: {}).once(),
+    }
+
+    groups = extract_deferred_props(props)
+
+    assert groups == {"default": ["profile.permissions"], "attributes": ["profile.teams"]}
+
+
 async def test_merge_helper() -> None:
     """Test merge() helper creates MergeProp with strategies."""
     # Default append strategy
@@ -852,6 +869,24 @@ async def test_extract_merge_props() -> None:
     assert prepend_list == ["messages"]
     assert deep_list == ["config"]
     assert match_on == ["items.id"]
+
+
+async def test_extract_merge_props_uses_nested_dot_paths() -> None:
+    """Test nested merge props emit v3 dot-path metadata."""
+    props = {
+        "feed": {
+            "posts": merge("posts", [{"id": 1}], match_on="id"),
+            "messages": merge("messages", [], strategy="prepend"),
+            "config": merge("config", {}, strategy="deep", match_on=["id", "type"]),
+        }
+    }
+
+    merge_list, prepend_list, deep_list, match_on = extract_merge_props(props)
+
+    assert merge_list == ["feed.posts"]
+    assert prepend_list == ["feed.messages"]
+    assert deep_list == ["feed.config"]
+    assert match_on == ["feed.posts.id", "feed.config.id", "feed.config.type"]
 
 
 async def test_should_render_with_partial_except() -> None:
@@ -1244,8 +1279,8 @@ async def test_encrypt_history_defaults_to_false(
     ) as client:
         response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
         data = response.json()
-        # encryptHistory should be false by default
-        assert data["encryptHistory"] is False
+        # encryptHistory is an optional v3 key and should be omitted when false
+        assert "encryptHistory" not in data
 
 
 async def test_encrypt_history_config_default(
@@ -1304,8 +1339,8 @@ async def test_encrypt_history_response_overrides_config(
     ) as client:
         response = client.get("/public", headers={InertiaHeaders.ENABLED.value: "true"})
         data = response.json()
-        # Response parameter should override config
-        assert data["encryptHistory"] is False
+        # Response parameter should override config and omit the false optional v3 key
+        assert "encryptHistory" not in data
 
 
 async def test_clear_history_parameter(
@@ -1353,8 +1388,143 @@ async def test_clear_history_defaults_to_false(
     ) as client:
         response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
         data = response.json()
-        # clearHistory should be false by default
-        assert data["clearHistory"] is False
+        # clearHistory is an optional v3 key and should be omitted when false
+        assert "clearHistory" not in data
+
+
+async def test_nested_special_props_emit_v3_dot_path_metadata(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test nested deferred, once, and merge props serialize with v3 dot paths."""
+
+    @get("/profile", component="Profile")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {
+            "profile": {
+                "name": "Ada",
+                "permissions": defer("permissions", lambda: ["read"]),
+                "settings": once("settings", {"theme": "dark"}),
+                "posts": merge("posts", [{"id": 1, "title": "Hello"}], match_on="id"),
+            }
+        }
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/profile", headers={InertiaHeaders.ENABLED.value: "true"})
+        data = response.json()
+
+        assert "encryptHistory" not in data
+        assert "clearHistory" not in data
+        assert data["deferredProps"] == {"default": ["profile.permissions"]}
+        assert data["onceProps"] == {"settings": {"prop": "profile.settings"}}
+        assert data["mergeProps"] == ["profile.posts"]
+        assert data["matchPropsOn"] == ["profile.posts.id"]
+        assert data["props"]["profile"] == {
+            "name": "Ada",
+            "settings": {"theme": "dark"},
+            "posts": [{"id": 1, "title": "Hello"}],
+        }
+
+
+async def test_nested_optional_prop_renders_for_dot_path_partial_reload(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test nested optional props render when requested by v3 dot path."""
+
+    @get("/profile", component="Profile")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {
+            "profile": {"name": "Ada", "permissions": optional("permissions", lambda: ["read"])},
+            "summary": "visible",
+        }
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get(
+            "/profile",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Profile",
+                InertiaHeaders.PARTIAL_DATA.value: "profile.permissions",
+            },
+        )
+        data = response.json()
+
+        assert data["props"]["profile"] == {"permissions": ["read"]}
+        assert "summary" not in data["props"]
+
+
+async def test_nested_optional_prop_renders_for_legacy_local_key_partial_reload(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test nested optional props still render when requested by legacy local key."""
+
+    @get("/profile", component="Profile")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {"profile": {"permissions": optional("permissions", lambda: ["read"])}}
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get(
+            "/profile",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Profile",
+                InertiaHeaders.PARTIAL_DATA.value: "permissions",
+            },
+        )
+        data = response.json()
+
+        assert data["props"]["profile"] == {"permissions": ["read"]}
+
+
+async def test_nested_once_metadata_survives_except_once_header(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test nested once metadata stays available when the cached prop is omitted."""
+
+    @get("/profile", component="Profile")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {"profile": {"settings": once("settings", {"theme": "dark"})}}
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get(
+            "/profile",
+            headers={InertiaHeaders.ENABLED.value: "true", InertiaHeaders.EXCEPT_ONCE_PROPS.value: "settings"},
+        )
+        data = response.json()
+
+        assert data["props"]["profile"] == {}
+        assert data["onceProps"] == {"settings": {"prop": "profile.settings"}}
 
 
 # =====================================================
@@ -1991,6 +2161,55 @@ async def test_inertia_redirect_allows_relative_url(
         response = client.get("/redirect", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
         assert response.status_code == 307
         assert response.headers.get("location") == "/dashboard"
+
+
+async def test_inertia_redirect_with_fragment_uses_inertia_redirect_header(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test same-origin fragment redirects use the v3 X-Inertia-Redirect protocol."""
+    from litestar_vite.inertia.response import InertiaRedirect
+
+    @get("/redirect", component="Redirect")
+    async def handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        return InertiaRedirect(request, redirect_to="/dashboard#details")
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/redirect", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
+        assert response.status_code == 409
+        assert response.headers.get("x-inertia-redirect") == "/dashboard#details"
+        assert "location" not in response.headers
+
+
+async def test_standard_redirect_with_fragment_keeps_location_header(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test non-Inertia fragment redirects stay standard HTTP redirects."""
+    from litestar_vite.inertia.response import InertiaRedirect
+
+    @get("/redirect", component="Redirect")
+    async def handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        return InertiaRedirect(request, redirect_to="/dashboard#details")
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/redirect", follow_redirects=False)
+        assert response.status_code == 307
+        assert response.headers.get("location") == "/dashboard#details"
 
 
 # =====================================================

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -6,9 +6,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from litestar import Request, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.exceptions import ImproperlyConfiguredException, NotAuthorizedException
 from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.params import FromPath, FromQuery
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
@@ -1371,7 +1372,7 @@ async def test_scroll_props_parameter(
     from litestar_vite.inertia.response import InertiaResponse
 
     @get("/posts", component="Posts")
-    async def handler(request: Request[Any, Any, Any], page: int = 1) -> InertiaResponse[dict[str, Any]]:
+    async def handler(request: Request[Any, Any, Any], page: FromQuery[int] = 1) -> InertiaResponse[dict[str, Any]]:
         posts = [{"id": i, "title": f"Post {i}"} for i in range((page - 1) * 10, page * 10)]
         return InertiaResponse(
             {"posts": posts},
@@ -1529,7 +1530,7 @@ async def test_http_exception_404_preserved_for_non_inertia_requests(
     from litestar.exceptions import NotFoundException
 
     @get("/api/items/{item_id:int}")
-    async def handler(request: Request[Any, Any, Any], item_id: int) -> dict[str, Any]:
+    async def handler(request: Request[Any, Any, Any], item_id: FromPath[int]) -> dict[str, Any]:
         raise NotFoundException(detail=f"Item {item_id} not found")
 
     with create_test_client(

--- a/src/py/tests/unit/inertia/test_ssr_template_mode.py
+++ b/src/py/tests/unit/inertia/test_ssr_template_mode.py
@@ -6,9 +6,9 @@ from typing import Any, Literal
 from unittest.mock import AsyncMock, patch
 
 from litestar import Request, get
-from litestar.contrib.jinja import JinjaTemplateEngine
 from litestar.di import Provide
 from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]

--- a/src/py/tests/unit/test_codegen.py
+++ b/src/py/tests/unit/test_codegen.py
@@ -1,10 +1,10 @@
 """Unit tests for codegen module."""
 
-from typing import Annotated, Any
+from typing import Any
 from uuid import UUID
 
 from litestar import Litestar, get, post
-from litestar.params import Parameter
+from litestar.params import FromPath, FromQuery
 
 from litestar_vite.codegen import escape_ts_string, generate_routes_ts, is_type_required, ts_type_for_param
 from litestar_vite.codegen._routes import extract_path_params, extract_route_metadata, make_unique_name
@@ -100,7 +100,7 @@ def test_generate_routes_ts_with_path_params() -> None:
     """Test TypeScript route generation with path parameters."""
 
     @get("/users/{user_id:int}", name="get_user", sync_to_thread=False)
-    def get_user(user_id: int) -> dict[str, int]:
+    def get_user(user_id: FromPath[int]) -> dict[str, int]:
         return {"id": user_id}
 
     app = Litestar([get_user])
@@ -122,7 +122,7 @@ def test_generate_routes_ts_with_uuid_param() -> None:
     """Test TypeScript route generation with UUID path parameter."""
 
     @get("/items/{item_id:uuid}", name="get_item", sync_to_thread=False)
-    def get_item(item_id: UUID) -> dict[str, str]:
+    def get_item(item_id: FromPath[UUID]) -> dict[str, str]:
         return {"id": str(item_id)}
 
     app = Litestar([get_item])
@@ -138,7 +138,7 @@ def test_generate_routes_ts_with_query_params() -> None:
     """Test TypeScript route generation with query parameters."""
 
     @get("/search", name="search", sync_to_thread=False)
-    def search(q: str, limit: Annotated[int | None, Parameter(default=10)] = None) -> list[str]:
+    def search(q: FromQuery[str], limit: FromQuery[int | None] = 10) -> list[str]:
         return []
 
     app = Litestar([search])
@@ -170,11 +170,11 @@ def test_generate_routes_ts_multiple_methods() -> None:
     """Test TypeScript generation with routes having multiple methods."""
 
     @get("/resources/{id:int}", name="get_resource", sync_to_thread=False)
-    def get_resource(id: int) -> dict[str, int]:
+    def get_resource(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     @post("/resources/{id:int}", name="update_resource", sync_to_thread=False)
-    def update_resource(id: int, data: dict[str, str]) -> dict[str, int]:
+    def update_resource(id: FromPath[int], data: dict[str, str]) -> dict[str, int]:
         return {"id": id}
 
     app = Litestar([get_resource, update_resource])
@@ -241,7 +241,7 @@ def test_generate_routes_ts_type_overloads() -> None:
         return "simple"
 
     @get("/with-param/{id:int}", name="with_param", sync_to_thread=False)
-    def param_route(id: int) -> dict[str, int]:
+    def param_route(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     app = Litestar([simple_route, param_route])
@@ -304,11 +304,11 @@ def test_generate_routes_ts_is_valid_typescript() -> None:
         return []
 
     @get("/users/{user_id:int}", name="get_user", sync_to_thread=False)
-    def get_user(user_id: int) -> dict[str, int]:
+    def get_user(user_id: FromPath[int]) -> dict[str, int]:
         return {"id": user_id}
 
     @get("/search", name="search", sync_to_thread=False)
-    def search(q: str) -> list[str]:
+    def search(q: FromQuery[str]) -> list[str]:
         return []
 
     app = Litestar([list_users, get_user, search])
@@ -454,7 +454,7 @@ def test_generate_routes_ts_query_params_do_not_emit_null() -> None:
     """Test generated URL param types never include `null`."""
 
     @get("/search-null", name="search_null", sync_to_thread=False)
-    def search_null(q: str | None = None) -> list[str]:
+    def search_null(q: FromQuery[str | None] = None) -> list[str]:
         return []
 
     app = Litestar([search_null])
@@ -537,7 +537,7 @@ def test_extract_route_metadata_falls_back_when_openapi_disabled() -> None:
     """Test route metadata extraction uses path parsing when OpenAPI is disabled."""
 
     @get("/users/{id:int}", name="user_detail", sync_to_thread=False)
-    def user_detail(id: int) -> dict[str, int]:
+    def user_detail(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     app = Litestar([user_detail], openapi_config=None)
@@ -550,7 +550,7 @@ def test_generate_routes_ts_no_semantic_alias_block_when_unused() -> None:
     """Test generated routes.ts does not include alias preamble when no formats are used."""
 
     @get("/users/{id:int}", name="user_by_id", sync_to_thread=False)
-    def user_by_id(id: int) -> dict[str, int]:
+    def user_by_id(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     app = Litestar([user_by_id])
@@ -595,7 +595,7 @@ def test_post_body_and_query_params_separated() -> None:
         name: str
 
     @post("/teams", name="teams.add", sync_to_thread=False)
-    def add_team(data: TeamCreate, notify: bool = False) -> dict[str, str]:
+    def add_team(data: TeamCreate, notify: FromQuery[bool] = False) -> dict[str, str]:
         return {}
 
     app = Litestar([add_team])
@@ -619,7 +619,7 @@ def test_put_body_param_excluded() -> None:
         name: str
 
     @put("/teams/{team_id:int}", name="teams.update", sync_to_thread=False)
-    def update_team(team_id: int, data: TeamUpdate) -> dict[str, str]:
+    def update_team(team_id: FromPath[int], data: TeamUpdate) -> dict[str, str]:
         return {}
 
     app = Litestar([update_team])
@@ -642,7 +642,7 @@ def test_patch_body_param_excluded() -> None:
         name: str | None = None
 
     @patch("/teams/{team_id:int}", name="teams.patch", sync_to_thread=False)
-    def patch_team(team_id: int, data: TeamPatch) -> dict[str, str]:
+    def patch_team(team_id: FromPath[int], data: TeamPatch) -> dict[str, str]:
         return {}
 
     app = Litestar([patch_team])
@@ -657,7 +657,7 @@ def test_get_no_body_params_possible() -> None:
     from litestar_vite.codegen import generate_routes_json
 
     @get("/teams", name="teams.list", sync_to_thread=False)
-    def list_teams(limit: int = 10, offset: int = 0) -> list[dict[str, str]]:
+    def list_teams(limit: FromQuery[int] = 10, offset: FromQuery[int] = 0) -> list[dict[str, str]]:
         return []
 
     app = Litestar([list_teams])
@@ -681,7 +681,7 @@ def test_schema_excluded_endpoint_body_detection() -> None:
         name: str
 
     @post("/internal/teams", name="internal.teams.add", include_in_schema=False, sync_to_thread=False)
-    def add_internal_team(data: TeamCreate, notify: bool = False) -> dict[str, str]:
+    def add_internal_team(data: TeamCreate, notify: FromQuery[bool] = False) -> dict[str, str]:
         return {}
 
     app = Litestar([add_internal_team])
@@ -711,7 +711,7 @@ def test_body_param_uses_data_convention() -> None:
         name: str
 
     @post("/teams", name="teams.add", sync_to_thread=False)
-    def add_team(data: TeamPayload, active: bool = True) -> dict[str, str]:
+    def add_team(data: TeamPayload, active: FromQuery[bool] = True) -> dict[str, str]:
         return {}
 
     app = Litestar([add_team])
@@ -847,7 +847,7 @@ def test_generate_routes_ts_str_enum_query_params_emit_literal_unions() -> None:
         MONTH = "month"
 
     @get("/trends", name="trends.list", sync_to_thread=False)
-    def trends(granularity: Granularity = Granularity.DAY) -> list[str]:
+    def trends(granularity: FromQuery[Granularity] = Granularity.DAY) -> list[str]:
         return []
 
     app = Litestar([trends])

--- a/src/py/tests/unit/test_codegen_determinism.py
+++ b/src/py/tests/unit/test_codegen_determinism.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 
 from litestar import Litestar, get, post
+from litestar.params import FromPath, FromQuery
 
 from litestar_vite.codegen import generate_inertia_pages_json, generate_routes_json, generate_routes_ts
 from litestar_vite.codegen._utils import (
@@ -185,15 +186,15 @@ def test_generate_routes_json_is_deterministic() -> None:
     """Test that generate_routes_json produces deterministic output."""
 
     @get("/users/{id:int}", name="get_user", sync_to_thread=False)
-    def get_user(id: int) -> dict[str, int]:
+    def get_user(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     @get("/posts/{id:int}", name="get_post", sync_to_thread=False)
-    def get_post(id: int) -> dict[str, int]:
+    def get_post(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     @get("/comments/{id:int}", name="get_comment", sync_to_thread=False)
-    def get_comment(id: int) -> dict[str, int]:
+    def get_comment(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     app = Litestar([get_user, get_post, get_comment])
@@ -214,15 +215,15 @@ def test_generate_routes_ts_is_deterministic() -> None:
     """Test that generate_routes_ts produces deterministic output."""
 
     @get("/users/{id:int}", name="get_user", sync_to_thread=False)
-    def get_user(id: int) -> dict[str, int]:
+    def get_user(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     @get("/posts/{id:int}", name="get_post", sync_to_thread=False)
-    def get_post(id: int) -> dict[str, int]:
+    def get_post(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     @get("/comments/{id:int}", name="get_comment", sync_to_thread=False)
-    def get_comment(id: int) -> dict[str, int]:
+    def get_comment(id: FromPath[int]) -> dict[str, int]:
         return {"id": id}
 
     app = Litestar([get_user, get_post, get_comment])
@@ -272,7 +273,7 @@ def test_generate_routes_json_params_are_sorted() -> None:
     """Test that route parameters are sorted alphabetically."""
 
     @get("/search", name="search", sync_to_thread=False)
-    def search(z_param: str, a_param: str, m_param: str) -> list[str]:
+    def search(z_param: FromQuery[str], a_param: FromQuery[str], m_param: FromQuery[str]) -> list[str]:
         return []
 
     app = Litestar([search])
@@ -288,7 +289,7 @@ def test_generate_routes_ts_params_are_sorted() -> None:
     """Test that TypeScript route parameters are sorted alphabetically."""
 
     @get("/search", name="search", sync_to_thread=False)
-    def search(z_param: str, a_param: str, m_param: str) -> list[str]:
+    def search(z_param: FromQuery[str], a_param: FromQuery[str], m_param: FromQuery[str]) -> list[str]:
         return []
 
     app = Litestar([search])

--- a/src/py/tests/unit/test_codegen_page_props.py
+++ b/src/py/tests/unit/test_codegen_page_props.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, TypedDict
 
 from litestar import Litestar, get
+from litestar.params import FromPath
 
 from litestar_vite.codegen import (
     InertiaPageMetadata,
@@ -249,7 +250,7 @@ def test_extract_inertia_pages_with_path_params() -> None:
     """Test page extraction normalizes path parameters."""
 
     @get("/users/{user_id:int}", opt={"component": "Users/Show"}, sync_to_thread=False)
-    def show_user(user_id: int) -> dict[str, int]:
+    def show_user(user_id: FromPath[int]) -> dict[str, int]:
         return {"id": user_id}
 
     app = Litestar([show_user])

--- a/src/py/tests/unit/test_config.py
+++ b/src/py/tests/unit/test_config.py
@@ -151,7 +151,7 @@ def test_proxy_mode_invalid_env_raises(monkeypatch: pytest.MonkeyPatch, value: s
 
 def test_resolve_proxy_mode_cached_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Verify proxy-mode env parsing is cached by normalized value."""
-    monkeypatch.setenv("VITE_PROXY_MODE", "direct")
+    monkeypatch.setenv("VITE_PROXY_MODE", "vite")
 
     from litestar_vite.config._runtime import _cached_resolve_proxy_mode
 

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from litestar import Litestar, get
 from litestar.exceptions import ImproperlyConfiguredException
+from litestar.params import FromPath, FromQuery
 from litestar.testing import AsyncTestClient
 
 from litestar_vite.config import ViteConfig
@@ -741,7 +742,7 @@ async def test_spa_handler_route_exclusion_api_path(spa_config: ViteConfig) -> N
         return {"users": ["alice", "bob"]}
 
     @get("/api/posts/{post_id:int}")
-    async def get_post(post_id: int) -> dict[str, int]:
+    async def get_post(post_id: FromPath[int]) -> dict[str, int]:
         return {"id": post_id}
 
     # SPA route should be registered LAST
@@ -1050,7 +1051,7 @@ async def test_spa_handler_route_exclusion_with_query_params(spa_config: ViteCon
 
     # Add API route that accepts query params
     @get("/api/search")
-    async def search(q: str) -> dict[str, str]:
+    async def search(q: FromQuery[str]) -> dict[str, str]:
         return {"query": q}
 
     app = Litestar(route_handlers=[route, search])
@@ -1216,7 +1217,7 @@ async def test_spa_handler_serves_non_root_spa_path(temp_resource_dir: Path, mon
     route = handler.create_route_handler()
 
     @get("/books/{book_id:int}")
-    async def get_book(book_id: int) -> dict:
+    async def get_book(book_id: FromPath[int]) -> dict:
         return {"book_id": book_id}
 
     app = Litestar(route_handlers=[get_book, route])

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -2,7 +2,6 @@
 
 import gc
 import sys
-import time
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any, cast
@@ -1011,21 +1010,6 @@ def test_vite_plugin_optional_memory_efficiency_without_jinja() -> None:
     # Basic checks that plugin is initialized efficiently
     assert plugin._config is not None
     assert plugin._asset_loader is None  # Lazy loading
-
-
-def test_vite_plugin_optional_performance_without_jinja() -> None:
-    """Test plugin performance when Jinja is not available."""
-    start_time = time.time()
-
-    # Plugin initialization should be fast
-    plugin = VitePlugin()
-    app_config = AppConfig()
-    plugin.on_app_init(app_config)
-
-    init_time = time.time() - start_time
-
-    # Should initialize quickly (less than 100ms)
-    assert init_time < 0.1, f"Plugin initialization too slow: {init_time}s"
 
 
 # =====================================================

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -13,6 +13,7 @@ from litestar import Litestar, get
 from litestar.config.app import AppConfig
 from litestar.exceptions import WebSocketDisconnect
 from litestar.middleware import DefineMiddleware
+from litestar.params import FromPath
 from litestar.template.config import TemplateConfig
 from litestar.testing import TestClient
 
@@ -137,7 +138,7 @@ def test_vite_plugin_app_init_without_template_config() -> None:
 def test_vite_plugin_app_init_with_jinja_template_engine(tmp_path: Path) -> None:
     """Test app initialization with Jinja template engine."""
     try:
-        from litestar.contrib.jinja import JinjaTemplateEngine
+        from litestar.plugins.jinja import JinjaTemplateEngine
     except ImportError:
         pytest.skip("Jinja not available for testing")
 
@@ -630,7 +631,7 @@ def test_static_files_config_custom_values() -> None:
 def test_vite_plugin_jinja_with_jinja_available(tmp_path: Path) -> None:
     """Test plugin behavior when Jinja is available."""
     try:
-        from litestar.contrib.jinja import JinjaTemplateEngine
+        from litestar.plugins.jinja import JinjaTemplateEngine
     except ImportError:
         pytest.skip("Jinja not available for testing")
 
@@ -657,7 +658,7 @@ def test_vite_plugin_jinja_without_jinja_available() -> None:
 def test_vite_plugin_jinja_template_callable_registration_check(tmp_path: Path) -> None:
     """Test template callable registration with isinstance check."""
     try:
-        from litestar.contrib.jinja import JinjaTemplateEngine
+        from litestar.plugins.jinja import JinjaTemplateEngine
     except ImportError:
         pytest.skip("Jinja not available for testing")
 
@@ -783,18 +784,18 @@ def test_vite_plugin_optional_works_without_jinja_template_engine() -> None:
 
 @patch("litestar_vite.plugin.JINJA_INSTALLED", False)
 def test_vite_plugin_optional_handles_missing_jinja_contrib_module() -> None:
-    """Test plugin behavior when litestar.contrib.jinja module is not available."""
+    """Test plugin behavior when litestar.plugins.jinja module is not available."""
     plugin = VitePlugin()
     app_config = AppConfig()
 
-    # Should still work even if litestar.contrib.jinja is not available
+    # Should still work even if litestar.plugins.jinja is not available
     result = plugin.on_app_init(app_config)
     assert result is app_config
 
 
 def test_vite_plugin_optional_with_jinja_engine_when_available() -> None:
     """Test plugin with Jinja engine when it is available."""
-    from litestar.contrib.jinja import JinjaTemplateEngine
+    from litestar.plugins.jinja import JinjaTemplateEngine
 
     plugin = VitePlugin()
 
@@ -868,8 +869,8 @@ def test_template_mode_jinja_callables_matrix(
     is provided. Without Jinja, ``mode='template'`` must still construct cleanly so
     raw-HTML / non-Jinja-engine consumers (HTMX, Mako, Chameleon) are not blocked.
     """
-    from litestar.contrib.jinja import JinjaTemplateEngine
     from litestar.middleware.session.server_side import ServerSideSessionConfig
+    from litestar.plugins.jinja import JinjaTemplateEngine
     from litestar.stores.base import Store
     from litestar.stores.memory import MemoryStore
     from litestar.types import Middleware
@@ -1041,7 +1042,7 @@ def test_get_litestar_route_prefixes_with_multiple_routes() -> None:
         return {"message": "users"}
 
     @get("/posts/{post_id:int}")
-    async def get_post(post_id: int) -> dict[str, int]:
+    async def get_post(post_id: FromPath[int]) -> dict[str, int]:
         return {"id": post_id}
 
     @get("/api/v1/items")
@@ -1244,7 +1245,7 @@ def test_is_litestar_route_with_path_parameters() -> None:
     from litestar_vite.plugin import is_litestar_route
 
     @get("/api/users/{user_id:int}")
-    async def get_user(user_id: int) -> dict[str, int]:
+    async def get_user(user_id: FromPath[int]) -> dict[str, int]:
         return {"id": user_id}
 
     app = Litestar(route_handlers=[get_user])

--- a/src/py/tests/unit/test_ssr_proxy_hmr.py
+++ b/src/py/tests/unit/test_ssr_proxy_hmr.py
@@ -6,7 +6,7 @@ import pytest
 from litestar import WebSocket
 from litestar.exceptions import WebSocketDisconnect
 
-from litestar_vite.plugin import create_ssr_proxy_controller
+from litestar_vite.plugin import create_ssr_websocket_handler
 
 pytestmark = pytest.mark.anyio
 
@@ -39,7 +39,7 @@ async def test_ssr_proxy_uses_hmr_target_when_available(hotfile: Path, hmr_hotfi
     """Test that SSRProxyController.ws_proxy uses the HMR target from hot.hmr."""
 
     # Create the controller class
-    ControllerClass = create_ssr_proxy_controller(hotfile_path=hotfile)
+    ControllerClass = create_ssr_websocket_handler(hotfile_path=hotfile)
     controller = ControllerClass(owner=MagicMock())
 
     # Mock WebSocket
@@ -73,7 +73,7 @@ async def test_ssr_proxy_falls_back_to_main_target_when_hmr_missing(hotfile: Pat
         await hmr_path.unlink()
 
     # Create the controller class
-    ControllerClass = create_ssr_proxy_controller(hotfile_path=hotfile)
+    ControllerClass = create_ssr_websocket_handler(hotfile_path=hotfile)
     controller = ControllerClass(owner=MagicMock())
 
     # Mock WebSocket

--- a/src/py/tests/unit/test_templates.py
+++ b/src/py/tests/unit/test_templates.py
@@ -300,6 +300,30 @@ def test_inertia_templates_do_not_use_stale_script_element_bootstrap() -> None:
     assert "If you enable use_script_element=True" not in vue_ssr
 
 
+def test_v3_inertia_shells_use_data_inertia_title_attribute() -> None:
+    """Ensure v3-facing Inertia shells use the current title attribute."""
+    paths = [
+        TEMPLATE_ROOT / "react-inertia" / "index.html.j2",
+        TEMPLATE_ROOT / "vue-inertia" / "index.html.j2",
+        TEMPLATE_ROOT / "svelte-inertia" / "index.html.j2",
+        EXAMPLES_ROOT / "react-inertia" / "index.html",
+        EXAMPLES_ROOT / "react-inertia" / "resources" / "index.html",
+        EXAMPLES_ROOT / "react-inertia-jinja" / "index.html",
+        EXAMPLES_ROOT / "react-inertia-jinja" / "templates" / "index.html",
+        EXAMPLES_ROOT / "vue-inertia" / "resources" / "index.html",
+        EXAMPLES_ROOT / "vue-inertia-jinja" / "templates" / "index.html",
+        EXAMPLES_ROOT / "vue-inertia-ssr" / "index.html",
+        EXAMPLES_ROOT / "vue-inertia-jinja-ssr" / "templates" / "index.html",
+        EXAMPLES_ROOT / "svelte-inertia" / "index.html",
+        EXAMPLES_ROOT / "svelte-inertia-jinja" / "templates" / "index.html",
+    ]
+
+    for path in paths:
+        text = path.read_text()
+        assert "<title inertia>" not in text, f"{path} still uses stale Inertia title syntax"
+        assert "<title data-inertia>" in text, f"{path} does not mark the title for Inertia updates"
+
+
 def test_inertia_jinja_templates_include_script_element_target() -> None:
     """Ensure manual Jinja script-element templates point back at the app root."""
     react_template = (EXAMPLES_ROOT / "react-inertia-jinja" / "templates" / "index.html").read_text()
@@ -382,6 +406,41 @@ def test_inertia_ssr_docs_cover_entry_files_and_bootstrap_interaction() -> None:
     assert "use_script_element" in ssr_docs
     assert "data-page" in ssr_docs
     assert "app_selector" in ssr_docs
+
+
+def test_inertia_ssr_docs_define_vite_plugin_boundary() -> None:
+    """Ensure SSR docs explain the Litestar bridge and @inertiajs/vite boundary."""
+    ssr_docs = (ROOT / "docs" / "reference" / "inertia" / "ssr.rst").read_text()
+    config_docs = (ROOT / "docs" / "frameworks" / "inertia" / "configuration.rst").read_text()
+    knowledge = (ROOT / ".agents" / "knowledge" / "inertia-protocol.md").read_text()
+
+    for text in (ssr_docs, config_docs, knowledge):
+        assert "@inertiajs/vite" in text
+        assert "litestar-vite-plugin" in text
+
+    assert "InertiaSSRConfig.command" in ssr_docs
+    assert "auto_start" in ssr_docs
+    assert "health_check" in ssr_docs
+    assert "Node ``/render``" in ssr_docs
+    assert "silent fallback" in ssr_docs
+
+
+def test_inertia_scaffolds_do_not_install_inertia_vite_plugin_by_default() -> None:
+    """Ensure generated Inertia scaffolds keep litestar-vite-plugin as the bridge owner."""
+    paths = [
+        TEMPLATE_ROOT / "react-inertia" / "package.json.j2",
+        TEMPLATE_ROOT / "vue-inertia" / "package.json.j2",
+        TEMPLATE_ROOT / "svelte-inertia" / "package.json.j2",
+        EXAMPLES_ROOT / "react-inertia" / "package.json",
+        EXAMPLES_ROOT / "react-inertia-jinja" / "package.json",
+        EXAMPLES_ROOT / "vue-inertia" / "package.json",
+        EXAMPLES_ROOT / "vue-inertia-jinja" / "package.json",
+        EXAMPLES_ROOT / "svelte-inertia" / "package.json",
+        EXAMPLES_ROOT / "svelte-inertia-jinja" / "package.json",
+    ]
+
+    for path in paths:
+        assert '"@inertiajs/vite"' not in path.read_text()
 
 
 def test_framework_docs_and_js_reference_current_domains_and_wording() -> None:

--- a/src/py/tests/unit/test_templates.py
+++ b/src/py/tests/unit/test_templates.py
@@ -408,23 +408,6 @@ def test_inertia_ssr_docs_cover_entry_files_and_bootstrap_interaction() -> None:
     assert "app_selector" in ssr_docs
 
 
-def test_inertia_ssr_docs_define_vite_plugin_boundary() -> None:
-    """Ensure SSR docs explain the Litestar bridge and @inertiajs/vite boundary."""
-    ssr_docs = (ROOT / "docs" / "reference" / "inertia" / "ssr.rst").read_text()
-    config_docs = (ROOT / "docs" / "frameworks" / "inertia" / "configuration.rst").read_text()
-    knowledge = (ROOT / ".agents" / "knowledge" / "inertia-protocol.md").read_text()
-
-    for text in (ssr_docs, config_docs, knowledge):
-        assert "@inertiajs/vite" in text
-        assert "litestar-vite-plugin" in text
-
-    assert "InertiaSSRConfig.command" in ssr_docs
-    assert "auto_start" in ssr_docs
-    assert "health_check" in ssr_docs
-    assert "Node ``/render``" in ssr_docs
-    assert "silent fallback" in ssr_docs
-
-
 def test_inertia_scaffolds_do_not_install_inertia_vite_plugin_by_default() -> None:
     """Ensure generated Inertia scaffolds keep litestar-vite-plugin as the bridge owner."""
     paths = [

--- a/src/py/tests/unit/test_templates.py
+++ b/src/py/tests/unit/test_templates.py
@@ -300,8 +300,14 @@ def test_inertia_templates_do_not_use_stale_script_element_bootstrap() -> None:
     assert "If you enable use_script_element=True" not in vue_ssr
 
 
-def test_v3_inertia_shells_use_data_inertia_title_attribute() -> None:
-    """Ensure v3-facing Inertia shells use the current title attribute."""
+def test_v3_inertia_shells_use_plain_title_tag() -> None:
+    """Ensure Inertia shells use the canonical plain ``<title>`` tag.
+
+    Per the Inertia v3 docs, the single ``<title>`` tag is always replaced by the
+    client ``<Head>`` component and needs no marker attribute. The legacy
+    ``inertia`` attribute (and its ``data-inertia`` successor) are only meaningful
+    on keyed ``<meta>``/``<link>`` elements, never on the title.
+    """
     paths = [
         TEMPLATE_ROOT / "react-inertia" / "index.html.j2",
         TEMPLATE_ROOT / "vue-inertia" / "index.html.j2",
@@ -320,8 +326,9 @@ def test_v3_inertia_shells_use_data_inertia_title_attribute() -> None:
 
     for path in paths:
         text = path.read_text()
-        assert "<title inertia>" not in text, f"{path} still uses stale Inertia title syntax"
-        assert "<title data-inertia>" in text, f"{path} does not mark the title for Inertia updates"
+        assert "<title inertia>" not in text, f"{path} still uses the legacy Inertia title attribute"
+        assert "<title data-inertia>" not in text, f"{path} marks the title with a superfluous data-inertia attribute"
+        assert "<title>" in text, f"{path} is missing a plain <title> tag"
 
 
 def test_inertia_jinja_templates_include_script_element_target() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1055,7 +1055,7 @@ wheels = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.23.5"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -581,7 +581,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1166,7 +1166,7 @@ requires-dist = [
     { name = "h2", marker = "extra == 'http2'", specifier = ">=4.0.0" },
     { name = "httpx", specifier = ">=0.24.1" },
     { name = "jinja2", marker = "extra == 'jinja'" },
-    { name = "litestar", specifier = ">=2.7.0" },
+    { name = "litestar", specifier = ">=2.22.0" },
     { name = "nodeenv", marker = "extra == 'nodeenv'" },
     { name = "typing-extensions" },
     { name = "websockets", specifier = ">=12.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -581,7 +581,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -599,14 +599,14 @@ wheels = [
 
 [[package]]
 name = "faker"
-version = "40.19.1"
+version = "40.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/01/28c8ddae8caaf82c929655000963d83e3f01265a9af34e823c2ef2eee8ac/faker-40.19.1.tar.gz", hash = "sha256:76fa71fd3bf320db25e5504eb356f9a76b8a95cd6098524d006f446035b6b89d", size = 1969318, upload-time = "2026-05-22T15:57:37.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6f/d7b251fb31de7dce0e482680bf7ca876aa0043f475c04aeefa1459ea80d4/faker-40.21.0.tar.gz", hash = "sha256:2fdee1b650a723a54432db9c6dfe17cfa29d1adc8bd60520444a07698524ba4d", size = 1970295, upload-time = "2026-06-02T17:53:46.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b4/40a1ec12ec834604f3848143343baf1c67bc9a1096e401907eaa0d25876a/faker-40.19.1-py3-none-any.whl", hash = "sha256:265259b37c013838baaae34940207288170df385d6c5281413fce56a3504d580", size = 2007643, upload-time = "2026-05-22T15:57:35.867Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/77/6adb5a9dcd028f687f81fc9f789591f9572cb5a46454337122add004e134/faker-40.21.0-py3-none-any.whl", hash = "sha256:cb6601b2ae8e128895dc96814d271eab6b930a2d2d7932c6f9ff26785c24ee18", size = 2008808, upload-time = "2026-06-02T17:53:44.346Z" },
 ]
 
 [[package]]
@@ -835,11 +835,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1900,15 +1900,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.410"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]
@@ -2310,11 +2310,11 @@ wheels = [
 
 [[package]]
 name = "snowballstemmer"
-version = "3.1.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/ee/67eef9600338e245ad7838230969a34c823ddbdbccc5e1fc43cd75b55bc9/snowballstemmer-3.1.0.tar.gz", hash = "sha256:fd9e34526b23340cd23ffea6c9f9760974ecc2c2ac9e1d81401443ccdb2a801f", size = 122523, upload-time = "2026-05-24T19:04:19.691Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/f8/0a71edf031f03c40db17503cb8ca78a69a171254e568e7db241b0ab57ea1/snowballstemmer-3.1.1.tar.gz", hash = "sha256:e07bbc54a0d798fe6010a12398422e62a8bfbba95c394fd0956ef58cb4d3e260", size = 123314, upload-time = "2026-06-03T00:56:40.194Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/83/ddbf4533c62dd32667ef1238952abef155f3d3391f5be69a352ad1638a42/snowballstemmer-3.1.0-py3-none-any.whl", hash = "sha256:17e6d1da216aa07db6dad37139ea70cf13c4b2e9a096f6e64a9648fc657d3154", size = 104550, upload-time = "2026-05-24T19:04:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/07/2ebca9b11fb9be7340a818d8d6f63feaebb146be2c4afbd6061701d6df6e/snowballstemmer-3.1.1-py3-none-any.whl", hash = "sha256:7e207fa178741da09cdee59d3ecec3827ad5f92b1fc5c9ff3755b639f71f5752", size = 104164, upload-time = "2026-06-03T00:56:38.614Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prepares litestar-vite for **Litestar 3** by migrating deprecated APIs, and fixes several **Inertia.js** integration issues.

### Litestar 3 deprecation prep
- Migrate `InitPluginProtocol` → `InitPlugin` (`VitePlugin`, `InertiaPlugin`).
- Migrate `litestar.contrib.jinja.JinjaTemplateEngine` → `litestar.plugins.jinja.JinjaTemplateEngine`.
- Remove the deprecated `litestar.repository.exceptions` dependency from Inertia exception handling.
- Add private optional-dependency shims (`_typing.py` / `typing.py`) that detect and load repository exception types from **Advanced Alchemy** and **SQLSpec**, with placeholder fallbacks when those libraries are not installed.
- Conditionally register Inertia repository exception handlers (`_register_exception_handlers` / `_make_exception_handler`) — not-found → `404`, integrity/conflict → `409` — only when the relevant library is installed. Support stays private; no public `litestar_vite.inertia.repository` facade is exposed.
- Move `JINJA_INSTALLED` / `FSSPEC_INSTALLED` into the shared `_typing.py` module.
- Update deprecation sites across runtime, tests, examples, docs, and the `llms*.txt` snapshots.

### Inertia integration fixes
- `PageProps.to_dict()` omits `encryptHistory` and `clearHistory` from the protocol payload when they are `False`.
- Change the Inertia title attribute from `<title inertia>` to `<title data-inertia>` in the React, Svelte, and Vue scaffolds (valid HTML data attribute).
- Generated Inertia scaffolds no longer install the Inertia Vite plugin by default.
- Refactor `inertia/response.py` (add `unwrap_merge_props`, remove the unused `_InertiaSSRResult` dataclass) and add SSR reference docs.

## Test plan
- New `test_repository_exception_boundary.py` covering the optional-dependency exception boundary.
- Expanded coverage across response, helpers, templates, plugin, codegen, and request tests.
