### PR TITLE
fix(scaffolding): avoid duplicate scaffold package deps

### DIFF
--- a/src/py/litestar_vite/scaffolding/generator.py
+++ b/src/py/litestar_vite/scaffolding/generator.py
@@ -3,6 +3,7 @@
 This module handles the generation of project files from templates.
 """
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -87,6 +88,7 @@ class TemplateContext:
             Dictionary of template variables.
         """
         package_versions = _build_package_version_map()
+
         return {
             "project_name": self.project_name,
             "framework": self.framework.type.value,
@@ -278,6 +280,28 @@ def generate_project(output_dir: Path, context: TemplateContext, *, overwrite: b
     return generated_files
 
 
+def _deduplicate_json_keys(content: str) -> str:
+    """Remove duplicate keys from rendered JSON content.
+
+    Jinja templates may emit the same package in both a ``{% for %}`` loop
+    (from the framework dependency list) and a conditional ``{% if %}`` block.
+    Round-tripping through ``json.loads``/``json.dumps`` collapses duplicate
+    keys automatically, keeping the last value for each key.
+
+    Args:
+        content: Rendered JSON string, potentially containing duplicate keys.
+
+    Returns:
+        JSON string with duplicate keys removed. Falls back to the original
+        content if parsing fails.
+    """
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return content
+    return json.dumps(parsed, indent=2) + "\n"
+
+
 def _render_and_write(template_path: Path, output_path: Path, context: dict[str, Any]) -> None:
     """Render a template and write to output file.
 
@@ -291,5 +315,7 @@ def _render_and_write(template_path: Path, output_path: Path, context: dict[str,
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     content = render_template(template_path, context)
+    if output_path.name == "package.json":
+        content = _deduplicate_json_keys(content)
     output_path.write_text(content, encoding="utf-8")
     console.print(f"[green]Created {output_path}[/]")

--- a/src/py/litestar_vite/scaffolding/generator.py
+++ b/src/py/litestar_vite/scaffolding/generator.py
@@ -3,7 +3,6 @@
 This module handles the generation of project files from templates.
 """
 
-import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -81,6 +80,14 @@ class TemplateContext:
     generate_client: bool = False
     extra: dict[str, Any] = field(default_factory=_DictStrAnyFactory)
 
+    def has_dependency(self, package_name: str) -> bool:
+        """Check whether the selected framework declares a package dependency."""
+        return package_name in self.framework.dependencies
+
+    def has_dev_dependency(self, package_name: str) -> bool:
+        """Check whether the selected framework declares a dev dependency."""
+        return package_name in self.framework.dev_dependencies
+
     def to_dict(self) -> dict[str, Any]:
         """Convert context to dictionary for Jinja2 rendering.
 
@@ -89,7 +96,7 @@ class TemplateContext:
         """
         package_versions = _build_package_version_map()
 
-        return {
+        context: dict[str, Any] = {
             "project_name": self.project_name,
             "framework": self.framework.type.value,
             "framework_name": self.framework.name,
@@ -115,6 +122,9 @@ class TemplateContext:
             "package_version": _package_version_resolver(package_versions),
             **self.extra,
         }
+        context["has_dependency"] = self.has_dependency
+        context["has_dev_dependency"] = self.has_dev_dependency
+        return context
 
 
 def get_template_dir() -> Path:
@@ -280,28 +290,6 @@ def generate_project(output_dir: Path, context: TemplateContext, *, overwrite: b
     return generated_files
 
 
-def _deduplicate_json_keys(content: str) -> str:
-    """Remove duplicate keys from rendered JSON content.
-
-    Jinja templates may emit the same package in both a ``{% for %}`` loop
-    (from the framework dependency list) and a conditional ``{% if %}`` block.
-    Round-tripping through ``json.loads``/``json.dumps`` collapses duplicate
-    keys automatically, keeping the last value for each key.
-
-    Args:
-        content: Rendered JSON string, potentially containing duplicate keys.
-
-    Returns:
-        JSON string with duplicate keys removed. Falls back to the original
-        content if parsing fails.
-    """
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError:
-        return content
-    return json.dumps(parsed, indent=2) + "\n"
-
-
 def _render_and_write(template_path: Path, output_path: Path, context: dict[str, Any]) -> None:
     """Render a template and write to output file.
 
@@ -315,7 +303,5 @@ def _render_and_write(template_path: Path, output_path: Path, context: dict[str,
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     content = render_template(template_path, context)
-    if output_path.name == "package.json":
-        content = _deduplicate_json_keys(content)
     output_path.write_text(content, encoding="utf-8")
     console.print(f"[green]Created {output_path}[/]")

--- a/src/py/litestar_vite/templates/base/package.json.j2
+++ b/src/py/litestar_vite/templates/base/package.json.j2
@@ -12,14 +12,16 @@
     "generate-types": "openapi-ts"{% endif %}
   },
   "dependencies": {
+{%- set emit_zod = generate_zod and not has_dependency('zod') %}
 {%- for dep in dependencies %}
-    "{{ dep }}": "{{ package_version(dep) }}"{% if not loop.last or generate_zod %},{% endif %}
+    "{{ dep }}": "{{ package_version(dep) }}"{% if not loop.last or emit_zod %},{% endif %}
 {%- endfor %}
-{%- if generate_zod %}
+{%- if emit_zod %}
     "zod": "{{ package_version('zod') }}"
 {%- endif %}
   },
   "devDependencies": {
+{%- set emit_openapi_ts = generate_client and not has_dev_dependency('@hey-api/openapi-ts') %}
 {%- for dep in dev_dependencies %}
     "{{ dep }}": "{{ package_version(dep) }}",
 {%- endfor %}
@@ -27,7 +29,7 @@
     "@tailwindcss/vite": "{{ package_version('@tailwindcss/vite') }}",
     "tailwindcss": "{{ package_version('tailwindcss') }}",
 {%- endif %}
-{%- if generate_client %}
+{%- if emit_openapi_ts %}
     "@hey-api/openapi-ts": "{{ package_version('@hey-api/openapi-ts') }}",
 {%- endif %}
     "litestar-vite-plugin": "{{ package_version('litestar-vite-plugin') }}",

--- a/src/py/litestar_vite/templates/react-inertia/package.json.j2
+++ b/src/py/litestar_vite/templates/react-inertia/package.json.j2
@@ -20,14 +20,16 @@
     "generate-types": "openapi-ts"{% endif %}
   },
   "dependencies": {
+{%- set emit_zod = generate_zod and not has_dependency('zod') %}
 {%- for dep in dependencies %}
-    "{{ dep }}": "{{ package_version(dep) }}"{% if not loop.last or generate_zod %},{% endif %}
+    "{{ dep }}": "{{ package_version(dep) }}"{% if not loop.last or emit_zod %},{% endif %}
 {%- endfor %}
-{%- if generate_zod %}
+{%- if emit_zod %}
     "zod": "{{ package_version('zod') }}"
 {%- endif %}
   },
   "devDependencies": {
+{%- set emit_openapi_ts = generate_client and not has_dev_dependency('@hey-api/openapi-ts') %}
 {%- for dep in dev_dependencies %}
     "{{ dep }}": "{{ package_version(dep) }}",
 {%- endfor %}
@@ -35,7 +37,7 @@
     "@tailwindcss/vite": "{{ package_version('@tailwindcss/vite') }}",
     "tailwindcss": "{{ package_version('tailwindcss') }}",
 {%- endif %}
-{%- if generate_client %}
+{%- if emit_openapi_ts %}
     "@hey-api/openapi-ts": "{{ package_version('@hey-api/openapi-ts') }}",
 {%- endif %}
     "litestar-vite-plugin": "{{ package_version('litestar-vite-plugin') }}"

--- a/src/py/tests/unit/test_commands.py
+++ b/src/py/tests/unit/test_commands.py
@@ -299,6 +299,74 @@ def test_scaffolding_generate_project_htmx_uses_current_extension_shell(tmp_path
     assert 'body hx-ext="litestar"' in base_template
 
 
+def test_scaffolding_react_tanstack_raw_package_template_does_not_duplicate_default_api_deps() -> None:
+    """Ensure TanStack package deps are unique before generated files are written."""
+    from litestar_vite.scaffolding import TemplateContext
+    from litestar_vite.scaffolding.generator import render_template
+    from litestar_vite.scaffolding.templates import FrameworkType, get_template
+
+    root = Path(__file__).resolve().parents[4]
+    framework = get_template(FrameworkType.REACT_TANSTACK)
+    assert framework is not None
+
+    context = TemplateContext(
+        project_name="tanstack-lite", framework=framework, use_tailwind=True, generate_zod=True, generate_client=True
+    )
+
+    package_text = render_template(
+        root / "src" / "py" / "litestar_vite" / "templates" / "base" / "package.json.j2", context.to_dict()
+    )
+
+    assert package_text.count('"zod"') == 1
+    assert package_text.count('"@hey-api/openapi-ts"') == 1
+
+
+def test_scaffolding_generate_project_react_tanstack_has_unique_default_api_deps(tmp_path: Path) -> None:
+    """Ensure generated TanStack package.json parses and keeps default API deps once."""
+    from litestar_vite.scaffolding import TemplateContext, generate_project
+    from litestar_vite.scaffolding.templates import FrameworkType, get_template
+
+    framework = get_template(FrameworkType.REACT_TANSTACK)
+    assert framework is not None
+
+    context = TemplateContext(
+        project_name="tanstack-lite", framework=framework, use_tailwind=True, generate_zod=True, generate_client=True
+    )
+
+    generate_project(tmp_path, context)
+
+    package_text = (tmp_path / "package.json").read_text()
+    package_json = decode_json(package_text)
+
+    assert package_text.count('"zod"') == 1
+    assert package_text.count('"@hey-api/openapi-ts"') == 1
+    assert package_json["dependencies"]["zod"] == V["zod"]
+    assert package_json["devDependencies"]["@hey-api/openapi-ts"] == V["@hey-api/openapi-ts"]
+
+
+def test_scaffolding_generate_project_react_tanstack_keeps_default_api_deps_when_flags_disabled(tmp_path: Path) -> None:
+    """Ensure TanStack keeps its API deps under the template-default contract."""
+    from litestar_vite.scaffolding import TemplateContext, generate_project
+    from litestar_vite.scaffolding.templates import FrameworkType, get_template
+
+    framework = get_template(FrameworkType.REACT_TANSTACK)
+    assert framework is not None
+
+    context = TemplateContext(
+        project_name="tanstack-lite", framework=framework, generate_zod=False, generate_client=False
+    )
+
+    generate_project(tmp_path, context)
+
+    package_text = (tmp_path / "package.json").read_text()
+    package_json = decode_json(package_text)
+
+    assert package_text.count('"zod"') == 1
+    assert package_text.count('"@hey-api/openapi-ts"') == 1
+    assert package_json["dependencies"]["zod"] == V["zod"]
+    assert package_json["devDependencies"]["@hey-api/openapi-ts"] == V["@hey-api/openapi-ts"]
+
+
 def test_scaffolding_generated_package_manifests_pin_dependency_versions(tmp_path: Path) -> None:
     """Ensure scaffold and example package manifests do not emit floating `latest` versions."""
     root = Path(__file__).resolve().parents[4]


### PR DESCRIPTION
## Summary

- Avoid emitting duplicate `zod` and `@hey-api/openapi-ts` entries when a framework template already declares them.
- Keep the React TanStack scaffold default Zod and OpenAPI client dependencies.
- Remove the `package.json` JSON round-trip so templates produce valid manifests before file writes.

## Tests

- `uv run pytest src/py/tests/unit/test_commands.py -q`
- `uv run pytest src/py/tests/unit/test_react_family_alignment.py src/py/tests/unit/test_templates.py src/py/tests/unit/test_meta_framework_alignment.py src/py/tests/unit/test_vue_template_alignment.py -q`
- `make lint`