### PR TITLE
fix(inertia): align response protocol handling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,20 +2,544 @@
 Changelog
 =========
 
-All commits to this project will be documented in this file.
+Notable changes to this project are documented in this file.
 
 Litestar Vite Changelog
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Unreleased
-----------
+0.26.0 (unreleased)
+-------------------
 
-- Fixed metadata loss for Inertia deferred props (#236). Metadata is now correctly extracted before props are filtered for initial/partial responses.
-- Fixed Inertia partial reload behavior where non-requested properties were incorrectly included in responses.
-- Fixed cross-loop failure for Inertia async prop callbacks (#244). Async callbacks passed to ``optional()``/``defer()``/``lazy()``/``once()`` are now pre-resolved on the request event loop, so callbacks that touch request-scoped async resources (asyncpg/aiosqlite/sqlspec sessions) no longer fail with ``InterfaceError`` or cross-loop errors. SSR HTTP fetches were also moved to the request loop in the same async pre-pass.
-- Fixed Inertia page subtree remount on every navigation/partial-reload caused by ``resolvePageComponent`` allocating a fresh wrapper closure on each call. ``wrapComponent`` now memoizes its result by source-module reference (``WeakMap``), so the resolved component identity is stable across Inertia's repeated ``resolveComponent`` calls. React/Vue no longer unmount the page tree on partial reloads, preserving local component state and avoiding redundant effect re-runs.
-- **Breaking** (Inertia internals): Removed ``inertia_plugin.portal`` and the ``BlockingPortal`` lifespan attached to ``InertiaPlugin``. Removed the ``portal=`` parameter from ``StaticProp.render()``/``DeferredProp.render()``/``OnceProp.render()``/``OptionalProp.render()``/``AlwaysProp.render()``. Removed the ``litestar_vite.inertia._async_mixin`` module (``AsyncRenderMixin`` is no longer needed). Calling ``render()`` directly on a prop with an unresolved async callback now raises ``RuntimeError``; async callbacks are pre-resolved by ``InertiaResponse`` during ASGI dispatch.
-- Updated documentation build to include ``llms.txt`` and ``llms-full.txt`` at the site root for better LLM discovery (#240).
-- Isolated TanStack Router generated assets into ``src/generated/`` in example and scaffolding templates.
-- Default ``resource_dir`` set to ``src`` for non-Inertia templates; Inertia stays on ``resources/``.
-- CLI/docs now reference `litestar assets` consistently and document `--frontend-dir`.
+- Fixed Inertia asset-version mismatch handling so only ``GET`` requests can return the protocol ``409`` refresh response; non-GET submissions now continue to their handlers instead of being downgraded and losing the request body.
+- Fixed ``share()`` with Inertia redirects so top-level sync special props are materialized before session storage and async special props are skipped instead of crashing session serialization.
+- Fixed Inertia infinite-scroll ``scrollProps`` to emit a record keyed by data prop name, matching the official client protocol.
+- Fixed auto-wrapped Inertia responses so non-Inertia JSON handlers preserve Litestar's resolved ``201``/``204`` status codes while user-created ``InertiaResponse`` statuses still win.
+- Fixed Precognition validation success handling for handlers without an explicit ``request`` parameter by using the middleware request context.
+- Fixed Inertia SSR serialization so app, handler, and response type encoders are honored for custom page prop values.
+- Fixed Inertia partial reloads so ``deferredProps`` metadata is omitted on partial responses while initial responses still advertise deferred props.
+
+0.25.0 - 2026-06-25
+-------------------
+
+- Fixed Vite 8.1 HMR compatibility by moving network overrides to ``server.ws.*`` (#292, #293).
+
+0.24.1 - 2026-06-07
+-------------------
+
+- Fixed structured handler returns so Inertia bootstrap responses expose them as HTML props (#272, #277).
+
+0.24.0 - 2026-06-03
+-------------------
+
+- Excluded the SPA handler's own routes from the Litestar route prefix list so SPA fallbacks no longer mask real backend routes (#264).
+- Added Python 3.14 to the CI test matrix (#263).
+- Fixed Inertia partial reloads so resolved keys are removed from ``deferredProps`` and non-requested properties are not included in the response (#265).
+- Replaced Biome with Oxlint and Oxfmt for JavaScript linting and formatting (#232).
+- Prepared the integration for Litestar 3 deprecations and tightened Inertia bootstrap behavior (#269).
+
+0.23.4 - 2026-05-06
+-------------------
+
+- Fixed Inertia bootstrap responses to always use the HTML content type (#256).
+
+0.23.3 - 2026-05-04
+-------------------
+
+- Normalized browser app URLs (#255).
+- Honored RuntimeConfig.executor for local typegen binary on bun/deno (#253).
+
+0.23.2 - 2026-05-04
+-------------------
+
+- Preserved resolved Vite hotfile targets (#252).
+
+0.23.1 - 2026-05-03
+-------------------
+
+- Fixed the asset loader so it re-reads the hotfile on demand (#251).
+
+0.23.0 - 2026-05-03
+-------------------
+
+- Fixed VitePlugin startup so it eagerly invokes ``InertiaPlugin.on_app_init`` (#249).
+- Cleaned up dev proxy and config (#250).
+
+0.22.2 - 2026-05-03
+-------------------
+
+- Fixed proxy requests so ``GET``, ``HEAD``, and ``OPTIONS`` requests do not send request bodies (#242, #246).
+- Fixed Inertia async prop callbacks by pre-resolving ``optional()``, ``defer()``, ``lazy()``, and ``once()`` callbacks on the request event loop, avoiding asyncpg/aiosqlite/sqlspec cross-loop failures (#244, #245).
+- Fixed Inertia page remounts during navigation and partial reloads by memoizing ``resolvePageComponent`` wrappers with a ``WeakMap`` (#245).
+- Removed the internal ``BlockingPortal`` path from Inertia prop rendering; direct unresolved async prop rendering now raises ``RuntimeError`` because async callbacks are resolved during response dispatch (#245).
+- Fixed dev-proxy and Inertia fallback regressions (#248).
+
+0.22.1 - 2026-04-19
+-------------------
+
+- Fixed metadata extraction for Inertia deferred props before initial and partial response filtering (#236, #241).
+- Updated the documentation build so ``llms.txt`` and ``llms-full.txt`` are published at the site root (#240, #241).
+- Isolated TanStack Router generated assets into ``src/generated/`` in the examples and scaffolding templates (#241).
+- Changed non-Inertia scaffold defaults to use ``src`` as ``resource_dir`` while keeping Inertia templates on ``resources`` (#241).
+- Updated CLI and documentation wording to consistently use ``litestar assets`` and document ``--frontend-dir`` (#241).
+- Added Node 24 to CI (#234).
+
+0.22.0 - 2026-03-30
+-------------------
+
+- Updated LLM guidance text (#230).
+- Added ``extra_commands`` to ``TypeGenConfig`` for frontend code-generation CLIs (#231).
+
+0.21.1 - 2026-03-29
+-------------------
+
+- Fixed ``resolvePageComponent`` types for compatibility with the Inertia v3 ``ComponentResolver`` (#229).
+
+0.21.0 - 2026-03-29
+-------------------
+
+- Fixed type-generation builds and enabled Inertia 3.0 support (#227).
+
+0.20.0 - 2026-03-23
+-------------------
+
+- Added Vite 8 support (#217).
+- Normalized resolved command binaries (#218).
+- Hardened the bridge schema and added config validation (#219).
+- Updated Angular packages to latest in examples (#220).
+
+0.19.0 - 2026-03-09
+-------------------
+
+- Aligned stable inertia contract and bootstrap guidance (#209).
+
+0.18.4 - 2026-03-05
+-------------------
+
+- Prevented proxy bypasses for dev CSS assets and hardened diagnostics (#208).
+
+0.18.3 - 2026-03-03
+-------------------
+
+- Aligned proxy/static and inertia script payload handling (#205).
+- Synced ``llms.txt`` and ``llms-full.txt`` to the v0.18.3 codebase (#206).
+
+0.18.2 - 2026-02-23
+-------------------
+
+- Fixed CLI file-existence checks so they respect ``--frontend-dir`` (#190).
+- Allowed numeric framework selection in assets init prompt (#197).
+- Fixed CLI next-step output so it includes the ``--frontend-dir`` path (#191).
+- Fixed the docs logo target and removed stale ``watch_patterns`` documentation (#199).
+- Fixed module-prefixed enum type resolution and updated docs (#200).
+
+0.18.1 - 2026-02-04
+-------------------
+
+- Fixed CLI initialization so it respects the configured ``--frontend-dir`` path (#186).
+- Improved openapi-ts error handling and included ``LICENSE`` in the npm package (#187).
+
+0.18.0 - 2026-01-29
+-------------------
+
+- Fixed proxy handling for ``node_modules`` paths and made SPA caching configurable (#184).
+
+0.17.0 - 2026-01-19
+-------------------
+
+- Changed the restricted test port from 5061 to 5050 (#177).
+- Added the static-props bridge and fixed the HTMX template (#178, #179).
+
+0.16.4 - 2026-01-07
+-------------------
+
+- Updated path validation logic to reduce spurious warnings (#175).
+
+0.16.3 - 2026-01-06
+-------------------
+
+- Removed outdated context files for Litestar, React, Svelte, Vue, Vite, and Testing (#174).
+
+0.16.2 - 2026-01-05
+-------------------
+
+- Fixed PyPI publishing by building Python distributions into ``dist/py`` so JavaScript build output is not uploaded as a Python package (#173).
+
+0.16.1 - 2026-01-05
+-------------------
+
+- Fixed source distributions by including ``package.json`` and ``package-lock.json`` for the build hook (#172).
+
+0.16.0 - 2026-01-05
+-------------------
+
+- Cleaned up and updated console format (#171).
+
+0.15.0 - 2025-12-22
+-------------------
+
+- Finalized the 0.15.0 overhaul after the prerelease series, including single-port Vite integration, framework-mode docs, Inertia protocol improvements, stronger type generation, route helpers, and Precognition support.
+- This release is a migration point; users should review the updated docs before upgrading from 0.14.x.
+
+0.15.0-rc.5 - 2025-12-21
+------------------------
+
+- Added ProxyHeadersMiddleware for secure reverse proxy support (#168).
+- Added Precognition support (#169).
+
+0.15.0-rc.4 - 2025-12-20
+------------------------
+
+- Fixed session helpers to return ``bool`` and added a query-parameter fallback for flash messages (#165).
+
+0.15.0-rc.3 - 2025-12-19
+------------------------
+
+- Fixed page-prop type resolution and deployment configuration (#161).
+- Fixed deterministic build output and write-on-change (#162).
+- Split large modules into packages (#163).
+
+0.15.0-rc.2 - 2025-12-16
+------------------------
+
+- Detected Inertia mode from ``hybrid`` in ``.litestar.json`` (#158).
+- Restored route helpers for runtime navigation (#159).
+
+0.15.0-rc.1 - 2025-12-15
+------------------------
+
+- Added auto-install during builds (#152).
+
+0.15.0-beta.6 - 2025-12-13
+--------------------------
+
+- Cleaned up routing internals (#151).
+
+0.15.0-beta.5 - 2025-12-11
+--------------------------
+
+- Cleaned up external handler (#148).
+- Enhanced body parameter detection for route handlers (#149).
+
+0.15.0-beta.4 - 2025-12-10
+--------------------------
+
+- Improved pagination support (#146).
+
+0.15.0-beta.3 - 2025-12-09
+--------------------------
+
+- Updated CI to bypass checks for GIF generation (#143).
+- Prevented vite proxy from shadowing litestar routes (#144).
+
+0.15.0-beta.2 - 2025-12-09
+--------------------------
+
+- Fixed Litestar route handling (#138).
+- Fixed the Vue Inertia favicon (#140).
+- Added the litestar-fullstack reference link (#142).
+
+0.15.0-beta.1 - 2025-12-08
+--------------------------
+
+- Added animated console gifs (#130).
+- Improved Inertia configuration and integration behavior (#131).
+- Fixed proxy handling (#132).
+
+0.15.0-alpha.7 - 2025-12-07
+---------------------------
+
+- Hardened Inertia security and quality behavior (#127).
+
+0.15.0-alpha.6 - 2025-12-06
+---------------------------
+
+- Enhanced type generation from OpenAPI schemas (#120).
+
+0.15.0-alpha.5 - 2025-12-05
+---------------------------
+
+- Added end-to-end tests for examples (#119).
+
+0.15.0-alpha.4 - 2025-12-01
+---------------------------
+
+- Removed Vite 5 support and fixed production-mode behavior (#118).
+
+0.15.0-alpha.3 - 2025-12-01
+---------------------------
+
+- Implemented lazy initialization for ViteSPAHandler (#111).
+- Cleaned up path info (#112).
+
+0.15.0-alpha.2 - 2025-11-30
+---------------------------
+
+- Overhauled the documentation (#108).
+- Updated the README (#109).
+- Corrected index auto-detection and port proxying (#110).
+
+0.15.0-alpha.1 - 2025-11-29
+---------------------------
+
+- **Breaking**: Added single-port Vite integration (#104).
+
+0.14.0 - 2025-08-21
+-------------------
+
+- Corrected a README typo (#88).
+- Added Vite 7 support and made Jinja2 optional (#93).
+
+0.13.2 - 2025-05-05
+-------------------
+
+- Fixed ``initialize_loader`` errors in the loader asset plugin (#80, #78).
+- Updated the example app to use Jinja templating (#79).
+- Fixed plugin ``index.html`` detection (#86).
+
+0.13.1 - 2025-03-27
+-------------------
+
+- **Breaking**: Dropped Python 3.8 support and added Python 3.13 tests (#70).
+- Detected and served ``index.html`` automatically (#75).
+
+0.13.0 - 2025-01-04
+-------------------
+
+- Allowed static file config options (#65).
+- Corrected issues related to hatchling (#67).
+
+0.12.1 - 2024-12-30
+-------------------
+
+- Updated ``lazy`` handling (#64).
+- Allowed no template_config, enabling you to use litestar-vite with html frameworks other than Jinja2 (#63).
+
+0.12.0 - 2024-12-23
+-------------------
+
+- Added experimental Inertia ``lazy()`` support for deferring prop rendering until a partial reload requests the data (#61).
+
+0.11.1 - 2024-12-09
+-------------------
+
+- Used subprocess directly.
+
+0.11.0 - 2024-12-09
+-------------------
+
+- Improved process management (#59).
+
+0.10.0 - 2024-12-08
+-------------------
+
+- **Breaking**: Removed the custom ``JinjaTemplateEngine`` integration and switched to patching Litestar's built-in ``TemplateConfig`` instead (#58).
+- Applications should configure Litestar templates through ``template_config=TemplateConfig(...)`` and keep ``VitePlugin`` focused on Vite assets.
+
+0.9.0 - 2024-12-07
+------------------
+
+- Reformatted the ``Makefile`` (#56).
+- Added SPA ``index.html`` auto-detection (#57).
+
+0.8.3 - 2024-12-06
+------------------
+
+- Fixed remaining npm-package publishing issues after the 0.8.x build pipeline updates.
+
+0.8.2 - 2024-12-06
+------------------
+
+- Fixed ``--root-path`` option behavior during CLI initialization (#48).
+
+0.8.1 - 2024-12-01
+------------------
+
+- Fixed the generated wheel so the ``litestar_vite`` Python module is included.
+
+0.8.0 - 2024-12-01
+------------------
+
+- Added 404 redirect option (#46).
+
+0.7.1 - 2024-11-30
+------------------
+
+- Updated ``build_docs.py`` (#54).
+- Updated release process (#55).
+
+0.7.0 - 2024-11-30
+------------------
+
+- Synchronized the Python ``litestar-vite`` package and TypeScript ``vite-plugin`` package versions after earlier version drift.
+- Updated the example app with JavaScript route helpers (#43).
+- Added API documentation, introduced the Vite plugin package, and moved project tooling to ``uv`` (#53).
+
+0.2.9 - 2024-08-04
+------------------
+
+- Updated exception handler (#42).
+
+0.2.8 - 2024-07-30
+------------------
+
+- Fixed external redirect (#41).
+
+0.2.7 - 2024-07-28
+------------------
+
+- Added ``ImproperConfig`` to exception handler (#40).
+
+0.2.6 - 2024-07-28
+------------------
+
+- Fixed URL reconstruction with ``urlunparse``.
+
+0.2.5 - 2024-07-28
+------------------
+
+- Used the referer scheme for redirects (#39).
+
+0.2.4 - 2024-07-27
+------------------
+
+- Improved invalid-session error handling (#38).
+
+0.2.3 - 2024-07-27
+------------------
+
+- Added automatic session props (#36).
+- Improved error handling (#37).
+
+0.2.2 - 2024-07-22
+------------------
+
+- Updated ``referer`` handling (#35).
+
+0.2.1 - 2024-07-21
+------------------
+
+- Fixed flash handling so it only runs when a session exists (#34).
+
+0.2.0 - 2024-07-21
+------------------
+
+- Improved integration with the ``flash`` plugin (#21).
+- Fixed Python 3.8 compatibility by avoiding ``removesuffix`` (#28).
+- Added the base Inertia.js integration (#5).
+- Enhanced Inertia.js support (#33).
+
+0.1.22 - 2024-03-23
+-------------------
+
+- Fixed template initialization (#19).
+
+0.1.21 - 2024-03-20
+-------------------
+
+- Removed ``cli`` from the required ``litestar`` optional features (#18).
+
+0.1.20 - 2024-03-17
+-------------------
+
+- Fixed serving ``public_dir`` when it exists (#17).
+
+0.1.19 - 2024-02-20
+-------------------
+
+- Replaced deprecated static-file integration (#15).
+
+0.1.18 - 2024-02-04
+-------------------
+
+- Set the engine instance during configuration and adjusted the default manifest path (#14).
+
+0.1.17 - 2024-01-02
+-------------------
+
+- Added automatic Litestar static-file configuration for Vite assets.
+
+0.1.16 - 2023-12-30
+-------------------
+
+- Improved CLI console output, simplified Jinja templates, and added environment-variable configuration support.
+
+0.1.15 - 2023-12-19
+-------------------
+
+- Fixed websocket-client rendering when dev mode is disabled.
+
+0.1.14 - 2023-12-19
+-------------------
+
+- Fixed HMR rendering so it follows dev-mode status and HMR configuration.
+
+0.1.13 - 2023-12-19
+-------------------
+
+- Fixed ``hot_file`` location loading when ``DEV_MODE`` is enabled.
+
+0.1.12 - 2023-12-19
+-------------------
+
+- Added the ``set_environment`` call to server lifespan handling.
+
+0.1.11 - 2023-12-19
+-------------------
+
+- Fixed startup before frontend assets have been built.
+
+0.1.10 - 2023-12-17
+-------------------
+
+- Cleaned up templates and added default entry points (#13).
+
+0.1.9 - 2023-12-13
+------------------
+
+- Removed stale ``asset_path`` references (#12).
+
+0.1.8 - 2023-12-13
+------------------
+
+- Removed ``asset_dir`` and allowed paths to be passed as strings (#11).
+
+0.1.7 - 2023-12-11
+------------------
+
+- Added ``build --watch`` option and updated ``README`` (#10).
+
+0.1.6 - 2023-12-10
+------------------
+
+- Updated default manifest location (#9).
+
+0.1.5 - 2023-12-10
+------------------
+
+- Optimized imports (#8).
+
+0.1.4 - 2023-12-10
+------------------
+
+- Added project templating and the JavaScript plugin (#4).
+- Added additional Vite install templates (#6).
+
+0.1.3 - 2023-10-08
+------------------
+
+- Added ``py.typed`` to the package (#3).
+
+0.1.2 - 2023-10-05
+------------------
+
+- Corrected a typo (#2).
+
+0.1.1 - 2023-10-05
+------------------
+
+- Corrected imports (#1).
+
+0.1.0 - 2023-10-04
+------------------
+
+- Initial release of the Litestar Vite plugin.

--- a/docs/frameworks/inertia/infinite-scroll.rst
+++ b/docs/frameworks/inertia/infinite-scroll.rst
@@ -69,7 +69,7 @@ Trigger partial reloads when the bottom sentinel becomes visible:
          export default function Posts() {
            const page = usePage();
            const { posts } = page.props;
-           const { scrollProps } = page;
+           const postScroll = page.props.scrollProps?.posts;
 
            return (
              <div>
@@ -77,10 +77,10 @@ Trigger partial reloads when the bottom sentinel becomes visible:
                  <PostCard key={post.id} post={post} />
                ))}
 
-               {scrollProps?.nextPage && (
+               {postScroll?.nextPage && (
                  <WhenVisible
                    always
-                   params={{ only: ["posts"], data: { page: scrollProps.nextPage } }}
+                   params={{ only: ["posts"], data: { page: postScroll.nextPage } }}
                  >
                    <Spinner />
                  </WhenVisible>
@@ -105,9 +105,9 @@ Trigger partial reloads when the bottom sentinel becomes visible:
              <PostCard v-for="post in posts" :key="post.id" :post="post" />
 
              <WhenVisible
-               v-if="page.scrollProps?.nextPage"
+               v-if="page.props.scrollProps?.posts?.nextPage"
                always
-               :params="{ only: ['posts'], data: { page: page.scrollProps.nextPage } }"
+               :params="{ only: ['posts'], data: { page: page.props.scrollProps.posts.nextPage } }"
              >
                <Spinner />
              </WhenVisible>

--- a/docs/frameworks/inertia/merging-props.rst
+++ b/docs/frameworks/inertia/merging-props.rst
@@ -219,10 +219,12 @@ Merge props are indicated in the response:
      "props": {"posts": ["Post 1", "Post 2"]},
      "mergeProps": ["posts"],
      "scrollProps": {
-       "pageName": "page",
-       "currentPage": 1,
-       "nextPage": 2,
-       "previousPage": null
+       "posts": {
+         "pageName": "page",
+         "currentPage": 1,
+         "nextPage": 2,
+         "previousPage": null
+       }
      }
    }
 

--- a/src/js/src/inertia-helpers/index.ts
+++ b/src/js/src/inertia-helpers/index.ts
@@ -140,12 +140,16 @@ export async function resolvePageComponent(path: string | string[], pages: Recor
  * Offset-based pagination props.
  *
  * Returned when a route returns Litestar's `OffsetPagination` type.
- * Contains items plus metadata for offset/limit pagination.
+ * Litestar-Vite flattens pagination metadata as top-level sibling props:
+ * the route prop contains the item array, and `total`, `limit`, and `offset`
+ * are emitted beside it.
  *
  * @example
  * ```ts
  * interface User { id: string; name: string }
- * const { items, total, limit, offset } = props.users as OffsetPaginationProps<User>
+ * type UsersPageProps = { users: User[] } & Omit<OffsetPaginationProps<User>, 'items'>
+ *
+ * const { users, total, limit, offset } = props as UsersPageProps
  * ```
  */
 export interface OffsetPaginationProps<T> {
@@ -163,12 +167,16 @@ export interface OffsetPaginationProps<T> {
  * Classic page-based pagination props.
  *
  * Returned when a route returns Litestar's `ClassicPagination` type.
- * Contains items plus metadata for page number pagination.
+ * Litestar-Vite flattens pagination metadata as top-level sibling props:
+ * the route prop contains the item array, and `currentPage`, `totalPages`,
+ * and `pageSize` are emitted beside it.
  *
  * @example
  * ```ts
  * interface Post { id: string; title: string }
- * const { items, currentPage, totalPages, pageSize } = props.posts as ClassicPaginationProps<Post>
+ * type PostsPageProps = { posts: Post[] } & Omit<ClassicPaginationProps<Post>, 'items'>
+ *
+ * const { posts, currentPage, totalPages, pageSize } = props as PostsPageProps
  * ```
  */
 export interface ClassicPaginationProps<T> {
@@ -186,12 +194,16 @@ export interface ClassicPaginationProps<T> {
  * Cursor-based pagination props.
  *
  * Used for cursor/keyset pagination, commonly with infinite scroll.
- * Contains items plus cursor tokens for navigation.
+ * Litestar-Vite flattens pagination metadata as top-level sibling props:
+ * the route prop contains the item array, and cursor metadata is emitted
+ * beside it.
  *
  * @example
  * ```ts
  * interface Message { id: string; content: string }
- * const { items, hasMore, nextCursor } = props.messages as CursorPaginationProps<Message>
+ * type MessagesPageProps = { messages: Message[] } & Omit<CursorPaginationProps<Message>, 'items'>
+ *
+ * const { messages, hasMore, nextCursor } = props as MessagesPageProps
  * if (hasMore && nextCursor) {
  *   // Fetch more with cursor
  * }
@@ -218,6 +230,11 @@ export interface CursorPaginationProps<T> {
  * Union type for any pagination props.
  *
  * Use when you need to handle multiple pagination styles.
+ * Because pagination metadata is flattened as sibling keys, two paginators in
+ * one response can collide on keys such as `total`, `limit`, `offset`,
+ * `currentPage`, or `pageSize`. Return one flattened paginator per response,
+ * or wrap additional paginators in explicit prop containers with distinct
+ * metadata.
  *
  * @example
  * ```ts
@@ -250,11 +267,12 @@ export type PaginationProps<T> = OffsetPaginationProps<T> | ClassicPaginationPro
  * import { usePage } from '@inertiajs/vue3'
  *
  * const page = usePage()
- * const scrollProps = page.props.scrollProps as ScrollProps
+ * const scrollProps = page.props.scrollProps as Record<string, ScrollProps> | undefined
+ * const postsScroll = scrollProps?.posts
  *
  * function loadMore() {
- *   if (scrollProps.nextPage) {
- *     router.get(url, { [scrollProps.pageName]: scrollProps.nextPage })
+ *   if (postsScroll?.nextPage) {
+ *     router.get(url, { [postsScroll.pageName]: postsScroll.nextPage })
  *   }
  * }
  * ```

--- a/src/js/tests/vite-compatibility.test.ts
+++ b/src/js/tests/vite-compatibility.test.ts
@@ -1,4 +1,5 @@
 import type * as FsModule from "fs"
+import nodePath from "node:path"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import litestar from "../src"
 import { isVite8Plus } from "../src/shared/vite-compat"
@@ -27,6 +28,7 @@ const originalEnv = process.env
 beforeEach(() => {
   vi.resetModules()
   process.env = { ...originalEnv }
+  process.env.LITESTAR_VITE_CONFIG_PATH = nodePath.join(process.cwd(), ".vitest-missing-litestar.json")
   vi.clearAllMocks()
 })
 

--- a/src/py/litestar_vite/inertia/exception_handler.py
+++ b/src/py/litestar_vite/inertia/exception_handler.py
@@ -69,9 +69,89 @@ def exception_to_http_response(request: "Request[UserT, AuthT, StateT]", exc: "E
             return cast("Response[Any]", create_exception_response(request, exc))
         if request.app.debug:
             return cast("Response[Any]", create_debug_response(request, exc))
-        detail = str(exc.__cause__) if exc.__cause__ is not None else str(exc)
-        return cast("Response[Any]", create_exception_response(request, InternalServerException(detail=detail)))
+        # Production (non-debug, non-HTTPException): never embed raw exception text.
+        # Debug rendering is already returned above by create_debug_response.
+        return cast("Response[Any]", create_exception_response(request, InternalServerException()))
     return create_inertia_exception_response(request, exc)
+
+
+def _exception_detail_for_response(request: "Request[Any, Any, Any]", exc: Exception) -> Any:
+    if isinstance(exc, HTTPException):
+        return exc.detail
+    if request.app.debug:
+        return str(exc)
+    return "Internal Server Error"
+
+
+def _exception_extra(exc: Exception) -> Any:
+    if not isinstance(exc, HTTPException):
+        return None
+    try:
+        return exc.extra  # pyright: ignore[reportUnknownMemberType]
+    except AttributeError:
+        return None
+
+
+def _get_inertia_plugin(request: "Request[Any, Any, Any]") -> "InertiaPlugin | None":
+    try:
+        return request.app.plugins.get("InertiaPlugin")
+    except KeyError:
+        return None
+
+
+def _store_field_errors(request: "Request[Any, Any, Any]", extras: Any, detail: Any) -> None:
+    if not extras or not isinstance(extras, (list, tuple)) or len(extras) < 1:  # pyright: ignore[reportUnknownArgumentType]
+        return
+    first_extra = extras[0]  # pyright: ignore[reportUnknownVariableType]
+    if not isinstance(first_extra, dict):
+        return
+    message: dict[str, str] = cast("dict[str, str]", first_extra)
+    key_value = message.get("key")
+    default_field = f"root.{key_value}" if key_value is not None else "root"
+    error_detail = str(message.get("message", detail) or detail)
+    match = FIELD_ERR_RE.search(error_detail)
+    field = match.group(1) if match else default_field
+    error(request, field, error_detail or str(detail))
+
+
+def _create_exception_page_response(
+    *,
+    content: dict[str, Any],
+    preferred_type: MediaType,
+    route_component: str | None,
+    is_inertia: bool,
+    status_code: int,
+) -> "Response[Any]":
+    if is_inertia and route_component is None:
+        return Response[Any](content=content, media_type=MediaType.JSON, status_code=status_code)
+    return InertiaResponse[Any](media_type=preferred_type, content=content, status_code=status_code)
+
+
+def _append_error_query(redirect_to: str, detail: Any) -> str:
+    parsed = urlparse(redirect_to)
+    error_param = f"error={quote(str(detail), safe='')}"
+    query = f"{parsed.query}&{error_param}" if parsed.query else error_param
+    return urlunparse(parsed._replace(query=query))
+
+
+def _create_unauthorized_response(
+    request: "Request[Any, Any, Any]",
+    *,
+    detail: Any,
+    flash_succeeded: bool,
+    inertia_plugin: "InertiaPlugin",
+    status_code: int,
+    exc: Exception,
+) -> "Response[Any] | None":
+    is_unauthorized = status_code == HTTP_401_UNAUTHORIZED or isinstance(exc, NotAuthorizedException)
+    redirect_to_login = inertia_plugin.config.redirect_unauthorized_to
+    if not is_unauthorized or redirect_to_login is None:
+        return None
+    if request.url.path != redirect_to_login:
+        if not flash_succeeded and detail:
+            redirect_to_login = _append_error_query(redirect_to_login, detail)
+        return InertiaRedirect(request, redirect_to=redirect_to_login)
+    return InertiaBack(request)
 
 
 def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", exc: "Exception") -> "Response[Any]":
@@ -95,23 +175,14 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
     """
     is_inertia_header = request.headers.get("x-inertia", "").lower() == "true"
     is_inertia = request.is_inertia if isinstance(request, InertiaRequest) else is_inertia_header
+    route_component = request.inertia.route_component if isinstance(request, InertiaRequest) else None
 
     status_code = exc.status_code if isinstance(exc, HTTPException) else HTTP_500_INTERNAL_SERVER_ERROR
     preferred_type = MediaType.HTML if not is_inertia else MediaType.JSON
-    detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
-    extras: Any = None
-    if isinstance(exc, HTTPException):
-        try:
-            extras = exc.extra  # pyright: ignore[reportUnknownMemberType]
-        except AttributeError:
-            extras = None
+    detail = _exception_detail_for_response(request, exc)
+    extras = _exception_extra(exc)
     content: dict[str, Any] = {"status_code": status_code, "message": detail}
-
-    inertia_plugin: "InertiaPlugin | None"
-    try:
-        inertia_plugin = request.app.plugins.get("InertiaPlugin")
-    except KeyError:
-        inertia_plugin = None
+    inertia_plugin = _get_inertia_plugin(request)
 
     if extras:
         content.update({"extra": extras})
@@ -120,16 +191,7 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
     if detail:
         flash_succeeded = flash(request, detail, category="error")
 
-    if extras and isinstance(extras, (list, tuple)) and len(extras) >= 1:  # pyright: ignore[reportUnknownArgumentType]
-        first_extra = extras[0]  # pyright: ignore[reportUnknownVariableType]
-        if isinstance(first_extra, dict):
-            message: dict[str, str] = cast("dict[str, str]", first_extra)
-            key_value = message.get("key")
-            default_field = f"root.{key_value}" if key_value is not None else "root"
-            error_detail = str(message.get("message", detail) or detail)
-            match = FIELD_ERR_RE.search(error_detail)
-            field = match.group(1) if match else default_field
-            error(request, field, error_detail or detail)
+    _store_field_errors(request, extras, detail)
 
     if status_code in {HTTP_422_UNPROCESSABLE_ENTITY, HTTP_400_BAD_REQUEST} or isinstance(
         exc, PermissionDeniedException
@@ -137,29 +199,37 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
         return InertiaBack(request)
 
     if inertia_plugin is None:
-        return InertiaResponse[Any](media_type=preferred_type, content=content, status_code=status_code)
+        return _create_exception_page_response(
+            content=content,
+            preferred_type=preferred_type,
+            route_component=route_component,
+            is_inertia=is_inertia,
+            status_code=status_code,
+        )
 
-    is_unauthorized = status_code == HTTP_401_UNAUTHORIZED or isinstance(exc, NotAuthorizedException)
-    redirect_to_login = inertia_plugin.config.redirect_unauthorized_to
-    if is_unauthorized and redirect_to_login is not None:
-        if request.url.path != redirect_to_login:
-            # If flash failed (no session), pass error message via query param
-            if not flash_succeeded and detail:
-                parsed = urlparse(redirect_to_login)
-                error_param = f"error={quote(detail, safe='')}"
-                query = f"{parsed.query}&{error_param}" if parsed.query else error_param
-                redirect_to_login = urlunparse(parsed._replace(query=query))
-            return InertiaRedirect(request, redirect_to=redirect_to_login)
-        # Already on login page - redirect back so Inertia processes flash messages
-        # (Inertia.js shows 4xx responses in a modal instead of updating page state)
-        return InertiaBack(request)
+    unauthorized_response = _create_unauthorized_response(
+        request,
+        detail=detail,
+        flash_succeeded=flash_succeeded,
+        inertia_plugin=inertia_plugin,
+        status_code=status_code,
+        exc=exc,
+    )
+    if unauthorized_response is not None:
+        return unauthorized_response
 
     if status_code in {HTTP_404_NOT_FOUND, HTTP_405_METHOD_NOT_ALLOWED} and (
         inertia_plugin.config.redirect_404 is not None and request.url.path != inertia_plugin.config.redirect_404
     ):
         return InertiaRedirect(request, redirect_to=inertia_plugin.config.redirect_404)
 
-    return InertiaResponse[Any](media_type=preferred_type, content=content, status_code=status_code)
+    return _create_exception_page_response(
+        content=content,
+        preferred_type=preferred_type,
+        route_component=route_component,
+        is_inertia=is_inertia,
+        status_code=status_code,
+    )
 
 
 def _register_exception_handlers(  # pyright: ignore[reportUnusedFunction]

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1053,37 +1053,38 @@ def should_render(  # noqa: PLR0911
     if is_always_prop(value):
         return True
 
-    # OptionalProp: Only render when explicitly requested
+    # OptionalProp: identical to LazyProp under partial reloads (v2 alias of lazy)
     if is_optional_prop(value):
-        if partial_data:
-            return _matches_partial_data(value, partial_data, key)
-        # Never included in initial loads or standard partial reloads
-        return False
+        if partial_data and not _matches_partial_data(value, partial_data, key):
+            return False
+        if partial_except and _matches_partial_except(value, partial_except, key):
+            return False
+        return not (not partial_data and not partial_except)
 
-    # OnceProp: Respect partial reload filters and omit on full visits when cached client-side
+    # OnceProp: included on initial load, cached client-side; only-then-except on partials
     if is_once_prop(value):
-        if partial_except:
-            return not _matches_partial_except(value, partial_except, key)
-        if partial_data:
-            return _matches_partial_data(value, partial_data, key)
-        if except_once_props:
+        if partial_data and not _matches_partial_data(value, partial_data, key):
+            return False
+        if partial_except and _matches_partial_except(value, partial_except, key):
+            return False
+        if not partial_data and not partial_except and except_once_props:
             return not _matches_partial_except(value, except_once_props, key)
         return True
 
-    # LazyProp (StaticProp/DeferredProp): Only render on partial reload
+    # LazyProp (StaticProp/DeferredProp): only render on partial reload; only-then-except
     if is_lazy_prop(value):
-        if partial_except:
-            return not _matches_partial_except(value, partial_except, key)
-        if partial_data:
-            return _matches_partial_data(value, partial_data, key)
-        return False
+        if partial_data and not _matches_partial_data(value, partial_data, key):
+            return False
+        if partial_except and _matches_partial_except(value, partial_except, key):
+            return False
+        return not (not partial_data and not partial_except)
 
-    # Regular values: Apply standard filtering
+    # Regular values: apply `only` (partial_data) first, then `except` (partial_except).
     if key is not None:
-        if partial_except:
-            return not _matches_partial_except(value, partial_except, key)
-        if partial_data:
-            return _matches_partial_data(value, partial_data, key)
+        if partial_data and not _matches_partial_data(value, partial_data, key):
+            return False
+        if partial_except and _matches_partial_except(value, partial_except, key):
+            return False
 
     return True
 
@@ -1309,6 +1310,25 @@ async def resolve_async_props(
     await _resolve_one(value, partial_data, partial_except, except_once_props, _key)
 
 
+_RAW_SHARED_SCOPE_KEY = "_litestar_vite_inertia_shared"
+
+
+def _get_scope_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
+    scope = cast("dict[str, Any]", request.scope)
+    scope_shared = scope.get(_RAW_SHARED_SCOPE_KEY)
+    return cast("Mapping[str, Any]", scope_shared) if isinstance(scope_shared, Mapping) else {}
+
+
+def _set_scope_shared_prop(connection: "ASGIConnection[Any, Any, Any, Any]", key: str, value: "Any") -> None:
+    scope = getattr(connection, "scope", None)
+    if not isinstance(scope, dict):
+        return
+    scope_dict = cast("dict[str, Any]", scope)
+    shared = scope_dict.setdefault(_RAW_SHARED_SCOPE_KEY, {})
+    if isinstance(shared, dict):
+        shared[key] = value
+
+
 def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
     """Return the unrendered shared props stored on the request session.
 
@@ -1319,8 +1339,11 @@ def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapp
     try:
         shared_props = request.session.get("_shared", {})
     except (AttributeError, ImproperlyConfiguredException):
-        return {}
-    return cast("Mapping[str, Any]", shared_props) if isinstance(shared_props, Mapping) else {}
+        shared_props = {}
+    session_shared: Mapping[str, Any] = (
+        cast("Mapping[str, Any]", shared_props) if isinstance(shared_props, Mapping) else {}
+    )
+    return {**session_shared, **_get_scope_shared_props(request)}
 
 
 def get_shared_props(
@@ -1354,7 +1377,13 @@ def get_shared_props(
 
     try:
         errors = request.session.pop("_errors", {})
-        shared_props = cast("dict[str,Any]", request.session.pop("_shared", {}))
+        session_shared_props = request.session.pop("_shared", {})
+        scope_shared_props = cast("dict[str, Any]", request.scope).pop(_RAW_SHARED_SCOPE_KEY, {})
+        shared_props = (
+            {**cast("Mapping[str, Any]", session_shared_props), **cast("Mapping[str, Any]", scope_shared_props)}
+            if isinstance(session_shared_props, Mapping) and isinstance(scope_shared_props, Mapping)
+            else cast("dict[str,Any]", session_shared_props)
+        )
         inertia_plugin = cast("InertiaPlugin", request.app.plugins.get("InertiaPlugin"))
 
         once_props_entries = _extract_once_prop_entries(shared_props, partial_data, partial_except)
@@ -1405,12 +1434,31 @@ def get_shared_props(
     return props
 
 
+_UNMATERIALIZABLE_SHARED = object()
+
+
+def _materialize_shared_value(value: "Any") -> "Any":
+    """Convert top-level special props into session-serializable values for share()."""
+    if is_merge_prop(value):
+        return unwrap_merge_props(value)
+    if is_special_prop(value):
+        try:
+            return value.render()
+        except RuntimeError:
+            return _UNMATERIALIZABLE_SHARED
+    return value
+
+
 def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "Any") -> "bool":
     """Share a value in the session.
 
     Shared values are included in the props of every Inertia response for
     the current request. This is useful for data that should be available
     to all components (e.g., authenticated user, permissions, settings).
+    Top-level special props are materialized before storage; nested special
+    props inside a shared dict or list are not supported. Async top-level
+    special props cannot be persisted to the session, but remain available
+    to the current response from request scope.
 
     Args:
         connection: The ASGI connection.
@@ -1420,13 +1468,22 @@ def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "
     Returns:
         True if the value was successfully shared, False otherwise.
     """
+    materialized = _materialize_shared_value(value)
+    if materialized is _UNMATERIALIZABLE_SHARED:
+        _set_scope_shared_prop(connection, key, value)
+        connection.logger.warning(
+            "Cannot persist shared prop %r: async special props cannot be materialized for session storage.", key
+        )
+        return False
+
     try:
-        connection.session.setdefault("_shared", {}).update({key: value})
+        connection.session.setdefault("_shared", {}).update({key: materialized})
     except (AttributeError, ImproperlyConfiguredException):
         msg = "Unable to share value: session not accessible (user may be unauthenticated)."
         connection.logger.debug(msg)
         return False
     else:
+        _set_scope_shared_prop(connection, key, value)
         return True
 
 

--- a/src/py/litestar_vite/inertia/middleware.py
+++ b/src/py/litestar_vite/inertia/middleware.py
@@ -66,9 +66,16 @@ def _is_inertia_request(scope_headers: "Iterable[tuple[bytes, bytes]]") -> bool:
 def redirect_on_asset_version_mismatch(request: "InertiaRequest[Any, Any, Any]") -> "InertiaExternalRedirect | None":
     """Return redirect response when client and server asset versions differ.
 
+    The Inertia asset-version check applies to GET requests only. Non-GET
+    requests must never be converted into a version-mismatch redirect, or the
+    client downgrades the submission to a GET and the request body is lost.
+
     Returns:
-        An InertiaExternalRedirect when versions differ, otherwise None.
+        An InertiaExternalRedirect when versions differ on a GET, otherwise None.
     """
+    if request.method != "GET":
+        return None
+
     if not request.is_inertia:
         return None
 

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -253,6 +253,7 @@ async def _resolve_inertia_response_data(data: "Any", request: "Request[Any, Any
             return data
 
     response: InertiaResponse[Any] = InertiaResponse(content=content)
+    response._defer_status_to_handler = True  # pyright: ignore[reportPrivateUsage]
     await response.resolve_async_props(request)
     return response
 

--- a/src/py/litestar_vite/inertia/precognition.py
+++ b/src/py/litestar_vite/inertia/precognition.py
@@ -272,4 +272,6 @@ def _find_request(args: tuple[Any, ...], kwargs: "dict[str, Any]") -> "Request[A
         if isinstance(arg, Request):  # pyright: ignore[reportUnknownVariableType]
             return arg  # pyright: ignore[reportUnknownVariableType]
 
-    return None
+    from litestar_vite.inertia.middleware import get_current_inertia_request
+
+    return get_current_inertia_request()

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -20,6 +20,7 @@ from litestar.utils.scope.state import ScopeState
 from litestar_vite.html_transform import inject_head_html, replace_element_outer_html
 from litestar_vite.inertia._utils import get_headers
 from litestar_vite.inertia.helpers import (
+    PropFilter,
     _extract_once_prop_entries,  # pyright: ignore[reportPrivateUsage]
     build_once_props_metadata,
     extract_deferred_props,
@@ -71,6 +72,7 @@ class InertiaResponse(Response[T]):
         encrypt_history: "bool | None" = None,
         clear_history: bool = False,
         scroll_props: "ScrollPropsConfig | None" = None,
+        prop_filter: "PropFilter | None" = None,
     ) -> None:
         """Handle the rendering of a given template into a bytes string.
 
@@ -101,6 +103,8 @@ class InertiaResponse(Response[T]):
             scroll_props: Configuration for infinite scroll (v2 feature).
                 Provides next/previous page information for paginated data.
                 Use the scroll_props() helper to create this configuration.
+            prop_filter: Optional route-prop filter created with ``only()`` or
+                ``except_()``. Filters this response's route content keys only.
 
         Raises:
             ValueError: If both template_name and template_str are provided.
@@ -128,12 +132,15 @@ class InertiaResponse(Response[T]):
         self.encrypt_history = encrypt_history
         self.clear_history = clear_history
         self.scroll_props = scroll_props
+        self.prop_filter = prop_filter
         # Populated by :meth:`resolve_async_props` (called from the handler
         # frame so DI-scoped resources are still alive). ``_async_prepass_done``
         # short-circuits the deferral check in :meth:`to_asgi_response`;
         # ``_cached_ssr_payload`` lets ``_render_spa`` skip the SSR fetch.
         self._async_prepass_done: bool = False
+        self._cached_page_props: "PageProps[T] | None" = None
         self._cached_ssr_payload: "_InertiaSSRResult | None" = None
+        self._defer_status_to_handler: bool = False
 
     def create_template_context(
         self,
@@ -160,11 +167,12 @@ class InertiaResponse(Response[T]):
             "csrf_input": f'<input type="hidden" name="_csrf_token" value="{csrf_token}" />',
         }
 
-    def _build_page_props(  # noqa: PLR0915
+    def _build_page_props(
         self,
         request: "Request[UserT, AuthT, StateT]",
         partial_data: "set[str] | None",
         partial_except: "set[str] | None",
+        is_partial_render: bool,
         except_once_props: "set[str] | None",
         reset_keys: "set[str]",
         vite_plugin: "VitePlugin",
@@ -176,6 +184,7 @@ class InertiaResponse(Response[T]):
             request: The request object.
             partial_data: Set of partial data keys.
             partial_except: Set of partial except keys.
+            is_partial_render: Whether this response is for an Inertia partial reload.
             except_once_props: Set of cached once-prop keys sent by the client.
             reset_keys: Set of keys to reset.
             vite_plugin: The Vite plugin instance.
@@ -216,6 +225,10 @@ class InertiaResponse(Response[T]):
             filtered_content: Any = lazy_render(cast("Any", content), partial_data, partial_except, except_once_props)
             if filtered_content is not None:
                 route_content = filtered_content
+        elif isinstance(content, Mapping) and partial_data and partial_except:
+            route_content = lazy_render(
+                cast("Mapping[str, Any]", content), partial_data, partial_except, except_once_props
+            )
         elif should_render(content, partial_data, partial_except, except_once_props):
             route_content = cast("Any", content)
 
@@ -223,18 +236,17 @@ class InertiaResponse(Response[T]):
             if isinstance(route_content, Mapping):
                 mapping_content = cast("Mapping[str, Any]", route_content)
                 for key, value in mapping_content.items():
+                    if self.prop_filter is not None and not self.prop_filter.should_include(str(key)):
+                        continue
                     shared_props[key] = value
             elif is_pagination_container(route_content):
-                prop_key = (route_handler.opt.get("key", "items") if route_handler else "items") or "items"
+                prop_key = _get_route_prop_key(route_handler)
                 shared_props[prop_key] = route_content
             else:
                 shared_props["content"] = route_content
 
         # Drop keys this partial reload just resolved, or the client loops on loadDeferredProps.
-        if partial_data:
-            for key in partial_data:
-                _discard_deferred_prop_key(deferred_props_map, key)
-        deferred_props = deferred_props_map or None
+        deferred_props = _resolve_deferred_props(deferred_props_map, partial_data, is_partial_render)
         # Extract once props tracked during get_shared_props (already rendered)
         once_props_from_shared = shared_props.pop("_once_props", [])
         once_prop_entries = _dedupe_once_prop_entries(
@@ -245,28 +257,12 @@ class InertiaResponse(Response[T]):
         merge_props_list, prepend_props_list, deep_merge_props_list, match_props_on = extract_merge_props(shared_props)
         shared_props = unwrap_merge_props(shared_props)
 
-        extracted_scroll_props: "ScrollPropsConfig | None" = self.scroll_props
-        infinite_scroll_enabled = bool(route_handler and route_handler.opt.get("infinite_scroll", False))
+        scroll_props = _apply_pagination_props(
+            shared_props, route_handler=route_handler, explicit_scroll_props=self.scroll_props
+        )
 
-        for key in tuple(shared_props):
-            value = shared_props[key]
-            if is_pagination_container(value):
-                _, scroll = extract_pagination_scroll_props(value)
-                if extracted_scroll_props is None and scroll is not None and infinite_scroll_enabled:
-                    extracted_scroll_props = scroll
-
-                pagination_dict = pagination_to_dict(value)
-                shared_props[key] = pagination_dict.pop("items")
-                shared_props.update(pagination_dict)
-
-        encrypt_history = self.encrypt_history
-        if encrypt_history is None:
-            encrypt_history = inertia_plugin.config.encrypt_history
-
-        clear_history_flag = self.clear_history
-        if not clear_history_flag:
-            with contextlib.suppress(AttributeError, ImproperlyConfiguredException):
-                clear_history_flag = request.session.pop("_inertia_clear_history", False)  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+        encrypt_history = _resolve_encrypt_history(self.encrypt_history, inertia_plugin)
+        clear_history_flag = _resolve_clear_history(self.clear_history, request)
 
         # v2.3+ protocol: Extract flash to top level (not in props)
         # This prevents flash from persisting in browser history state
@@ -286,7 +282,7 @@ class InertiaResponse(Response[T]):
             prepend_props=prepend_props_list or None,
             deep_merge_props=deep_merge_props_list or None,
             match_props_on=match_props_on or None,
-            scroll_props=extracted_scroll_props,
+            scroll_props=scroll_props,
             flash=flash_data,
         )
 
@@ -497,11 +493,31 @@ class InertiaResponse(Response[T]):
         if ssr_config is None:
             return
         page_props = self._build_page_props(
-            request, partial_data, partial_except, info.except_once_keys, info.reset_keys, vite_plugin, inertia_plugin
+            request,
+            partial_data,
+            partial_except,
+            info.is_partial_render,
+            info.except_once_keys,
+            info.reset_keys,
+            vite_plugin,
+            inertia_plugin,
         )
+        self._cached_page_props = page_props
+        type_encoders = self._resolve_type_encoders(request)
         self._cached_ssr_payload = await _render_inertia_ssr(
-            page_props.to_dict(), ssr_config.url, ssr_config.timeout, inertia_plugin.ssr_client
+            page_props.to_dict(),
+            ssr_config.url,
+            ssr_config.timeout,
+            inertia_plugin.ssr_client,
+            type_encoders=type_encoders,
         )
+
+    def _resolve_type_encoders(self, request: "Request[Any, Any, Any]") -> "TypeEncodersMap":
+        route_handler = cast("Any | None", request.scope.get("route_handler"))  # pyright: ignore[reportUnknownMemberType]
+        route_type_encoders: "TypeEncodersMap" = {}
+        if route_handler is not None:
+            route_type_encoders = cast("TypeEncodersMap", route_handler.resolve_type_encoders())
+        return {**route_type_encoders, **self.response_type_encoders}
 
     def to_asgi_response(
         self,
@@ -575,6 +591,11 @@ class InertiaResponse(Response[T]):
             {**type_encoders, **(self.response_type_encoders or {})} if type_encoders else self.response_type_encoders
         )
         serializer = get_serializer(type_encoders)
+        resolved_status_code = (
+            status_code
+            if self._defer_status_to_handler and status_code is not None
+            else (self.status_code or status_code)
+        )
 
         if not inertia_info.inertia_enabled:
             resolved_media_type = get_enum_string_value(self.media_type or media_type or MediaType.JSON)
@@ -587,7 +608,7 @@ class InertiaResponse(Response[T]):
                 headers=headers,
                 is_head_response=is_head_response,
                 media_type=resolved_media_type,
-                status_code=self.status_code or status_code,
+                status_code=resolved_status_code,
             )
 
         vite_plugin = request.app.plugins.get(VitePlugin)
@@ -606,14 +627,19 @@ class InertiaResponse(Response[T]):
             else None
         )
 
-        page_props = self._build_page_props(
-            request,
-            partial_data,
-            partial_except,
-            inertia_info.except_once_keys,
-            inertia_info.reset_keys,
-            vite_plugin,
-            inertia_plugin,
+        page_props = (
+            self._cached_page_props
+            if self._cached_page_props is not None
+            else self._build_page_props(
+                request,
+                partial_data,
+                partial_except,
+                inertia_info.is_partial_render,
+                inertia_info.except_once_keys,
+                inertia_info.reset_keys,
+                vite_plugin,
+                inertia_plugin,
+            )
         )
 
         if inertia_info.is_inertia:
@@ -628,7 +654,7 @@ class InertiaResponse(Response[T]):
                 headers=headers,
                 is_head_response=is_head_response,
                 media_type=resolved_media_type,
-                status_code=self.status_code or status_code,
+                status_code=resolved_status_code,
             )
 
         resolved_media_type = self._determine_media_type(self.media_type)
@@ -647,7 +673,7 @@ class InertiaResponse(Response[T]):
             headers=headers,
             is_head_response=is_head_response,
             media_type=resolved_media_type,
-            status_code=self.status_code or status_code,
+            status_code=resolved_status_code,
         )
 
 
@@ -878,7 +904,12 @@ def _parse_inertia_ssr_payload(payload: Any, url: str) -> _InertiaSSRResult:
 
 
 async def _render_inertia_ssr(
-    page: dict[str, Any], url: str, timeout_seconds: float, client: "httpx.AsyncClient | None" = None
+    page: dict[str, Any],
+    url: str,
+    timeout_seconds: float,
+    client: "httpx.AsyncClient | None" = None,
+    *,
+    type_encoders: "TypeEncodersMap | None" = None,
 ) -> _InertiaSSRResult:
     """Call the Inertia SSR server asynchronously and return head/body HTML.
 
@@ -888,11 +919,12 @@ async def _render_inertia_ssr(
         timeout_seconds: Request timeout in seconds.
         client: Optional shared httpx.AsyncClient for connection pooling.
             If None, creates a new client per request (slower).
+        type_encoders: Optional type encoders used to serialize page props.
 
     Returns:
         An _InertiaSSRResult with head and body HTML.
     """
-    return await _do_ssr_request(page, url, timeout_seconds, client)
+    return await _do_ssr_request(page, url, timeout_seconds, client, type_encoders=type_encoders)
 
 
 @contextlib.asynccontextmanager
@@ -911,7 +943,12 @@ async def _acquire_ssr_client(client: "httpx.AsyncClient | None") -> "AsyncGener
 
 
 async def _do_ssr_request(
-    page: dict[str, Any], url: str, timeout_seconds: float, client: "httpx.AsyncClient | None"
+    page: dict[str, Any],
+    url: str,
+    timeout_seconds: float,
+    client: "httpx.AsyncClient | None",
+    *,
+    type_encoders: "TypeEncodersMap | None" = None,
 ) -> _InertiaSSRResult:
     """Execute the SSR request with optional client reuse.
 
@@ -920,6 +957,7 @@ async def _do_ssr_request(
         url: The SSR server URL.
         timeout_seconds: Request timeout in seconds.
         client: Optional shared httpx.AsyncClient.
+        type_encoders: Optional type encoders used to serialize page props.
 
     Raises:
         ImproperlyConfiguredException: If the SSR server is unreachable,
@@ -932,7 +970,7 @@ async def _do_ssr_request(
     # in handler return values serialize the same way as the regular Inertia render path
     # (response.render uses get_serializer too). httpx's default json= serializer falls
     # back to stdlib json.dumps and rejects Struct instances.
-    body = encode_json(page, serializer=get_serializer(None))
+    body = encode_json(page, serializer=get_serializer(type_encoders))
     headers = {"content-type": "application/json"}
 
     try:
@@ -1012,6 +1050,56 @@ def _get_relative_url(request: "Request[Any, Any, Any]") -> str:
 
 def _should_use_fragment_redirect(request: "Request[Any, Any, Any]", url: str) -> bool:
     return bool(InertiaDetails(request)) and bool(urlparse(url).fragment)
+
+
+def _get_route_prop_key(route_handler: Any) -> str:
+    return (route_handler.opt.get("key", "items") if route_handler else "items") or "items"
+
+
+def _apply_pagination_props(
+    shared_props: "dict[str, Any]", *, route_handler: Any, explicit_scroll_props: "ScrollPropsConfig | None"
+) -> "dict[str, ScrollPropsConfig] | None":
+    scroll_props_map: "dict[str, ScrollPropsConfig]" = {}
+    if explicit_scroll_props is not None:
+        scroll_props_map[_get_route_prop_key(route_handler)] = explicit_scroll_props
+
+    infinite_scroll_enabled = bool(route_handler and route_handler.opt.get("infinite_scroll", False))
+    for key in tuple(shared_props):
+        value = shared_props[key]
+        if is_pagination_container(value):
+            _, scroll = extract_pagination_scroll_props(value)
+            if scroll is not None and infinite_scroll_enabled and key not in scroll_props_map:
+                scroll_props_map[key] = scroll
+
+            pagination_dict = pagination_to_dict(value)
+            shared_props[key] = pagination_dict.pop("items")
+            shared_props.update(pagination_dict)
+
+    return scroll_props_map or None
+
+
+def _resolve_deferred_props(
+    deferred_props_map: "dict[str, list[str]]", partial_data: "set[str] | None", is_partial_render: bool
+) -> "dict[str, list[str]] | None":
+    if partial_data:
+        for key in partial_data:
+            _discard_deferred_prop_key(deferred_props_map, key)
+    return None if is_partial_render else deferred_props_map or None
+
+
+def _resolve_encrypt_history(encrypt_history: "bool | None", inertia_plugin: "InertiaPlugin") -> bool:
+    return inertia_plugin.config.encrypt_history if encrypt_history is None else encrypt_history
+
+
+def _resolve_clear_history(clear_history: bool, request: "Request[Any, Any, Any]") -> bool:
+    if clear_history:
+        return True
+    with contextlib.suppress(AttributeError, ImproperlyConfiguredException):
+        return cast(
+            "bool",
+            request.session.pop("_inertia_clear_history", False),  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+        )
+    return False
 
 
 def _merge_deferred_props(target: "dict[str, list[str]]", source: "Mapping[str, list[str]]") -> None:

--- a/src/py/litestar_vite/inertia/types.py
+++ b/src/py/litestar_vite/inertia/types.py
@@ -299,7 +299,7 @@ class PageProps(Generic[T]):
     # v2.2.20+ protocol: Props that should only be resolved once and cached client-side
     once_props: "dict[str, dict[str, str | int | None]] | None" = None
 
-    scroll_props: "ScrollPropsConfig | None" = None
+    scroll_props: "dict[str, ScrollPropsConfig] | None" = None
 
     # v2.3+ protocol: Flash messages at top level (not in props)
     # This prevents flash from persisting in browser history state

--- a/src/py/tests/unit/inertia/test_exception_handler.py
+++ b/src/py/tests/unit/inertia/test_exception_handler.py
@@ -1,0 +1,130 @@
+"""Regression tests for Inertia exception handling."""
+
+from typing import Any
+
+from litestar import get
+from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.stores.memory import MemoryStore
+from litestar.template.config import TemplateConfig
+from litestar.testing import create_test_client
+
+from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
+from litestar_vite.plugin import VitePlugin
+
+
+async def test_production_500_body_omits_exception_detail(
+    inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin, template_config: TemplateConfig[Any]
+) -> None:
+    @get("/boom")
+    async def handler() -> None:
+        raise RuntimeError("secret db dsn leaked")
+
+    with create_test_client(
+        route_handlers=[handler],
+        debug=False,
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/boom")
+
+    assert response.status_code == 500
+    assert "secret db dsn leaked" not in response.text
+    assert "Internal Server Error" in response.text
+
+
+async def test_inertia_500_flash_and_body_omit_detail_in_production(
+    inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin, template_config: TemplateConfig[Any]
+) -> None:
+    @get("/boom", component="Boom")
+    async def handler() -> dict[str, str]:
+        raise RuntimeError("secret db dsn leaked")
+
+    with create_test_client(
+        route_handlers=[handler],
+        debug=False,
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/boom", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["props"]["message"] == "Internal Server Error"
+    assert "secret db dsn leaked" not in response.text
+
+
+async def test_debug_500_still_includes_detail(
+    inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin, template_config: TemplateConfig[Any]
+) -> None:
+    @get("/boom")
+    async def handler() -> None:
+        raise RuntimeError("debug detail visible")
+
+    with create_test_client(
+        route_handlers=[handler],
+        debug=True,
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/boom")
+
+    assert response.status_code == 500
+    assert "debug detail visible" in response.text
+
+
+async def test_inertia_error_without_route_component_avoids_null_component(
+    inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin, template_config: TemplateConfig[Any]
+) -> None:
+    @get("/api/data")
+    async def handler() -> dict[str, str]:
+        raise RuntimeError("api exploded")
+
+    with create_test_client(
+        route_handlers=[handler],
+        debug=False,
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/api/data", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code >= 500
+    body = response.json()
+    assert body.get("component", "MISSING") is not None
+    assert "component" not in body
+    assert body["message"] == "Internal Server Error"
+
+
+async def test_inertia_error_with_component_still_renders_page(
+    inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin, template_config: TemplateConfig[Any]
+) -> None:
+    @get("/page", component="Page")
+    async def handler() -> dict[str, str]:
+        raise RuntimeError("page exploded")
+
+    with create_test_client(
+        route_handlers=[handler],
+        debug=False,
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/page", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["component"] == "Page"
+    assert body["props"]["message"] == "Internal Server Error"

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -334,6 +334,39 @@ async def test_partial_reload_with_partial_except(
         assert "settings" not in props
 
 
+async def test_optional_prop_included_under_partial_except(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """optional() behaves like lazy() for partial-except reloads."""
+    from litestar_vite.inertia.helpers import optional
+
+    @get("/", component="Home")
+    async def handler() -> dict[str, Any]:
+        return {"a": 1, "opt": optional("opt", lambda: "v")}
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get(
+            "/",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_EXCEPT.value: "a",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Home",
+            },
+        )
+
+    props = response.json()["props"]
+    assert props["opt"] == "v"
+    assert "a" not in props
+
+
 # =====================================================
 # pagination_to_dict() Helper Tests
 # =====================================================
@@ -567,6 +600,98 @@ async def test_share_returns_true_with_session(
         assert data["props"]["user"] == {"name": "Alice"}
 
 
+async def test_share_materializes_sync_special_prop_before_session_write(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test share() writes rendered values for sync special props."""
+    from litestar_vite.inertia.helpers import always, merge, once, share
+
+    captured: dict[str, Any] = {}
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        share(request, "count", once("count", lambda: 42))
+        share(request, "flag", always("flag", "y"))
+        share(request, "posts", merge("posts", [1, 2]))
+        captured["shared"] = dict(request.session["_shared"])
+        return {}
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        assert response.status_code == 200
+
+    assert captured["shared"]["count"] == 42
+    assert isinstance(captured["shared"]["count"], int)
+    assert captured["shared"]["flag"] == "y"
+    assert captured["shared"]["posts"] == [1, 2]
+
+
+async def test_share_skips_async_special_prop(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test share() skips async special props that cannot be stored in session."""
+    from litestar_vite.inertia.helpers import defer, share
+
+    captured: dict[str, Any] = {}
+
+    async def fetch() -> int:
+        return 1
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        captured["result"] = share(request, "slow", defer("slow", fetch))
+        captured["shared"] = dict(request.session.get("_shared", {}))
+        return {}
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        assert response.status_code == 200
+
+    assert captured["result"] is False
+    assert "slow" not in captured["shared"]
+
+
+async def test_share_special_prop_survives_redirect(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test shared sync special props do not break session serialization on redirects."""
+    from litestar_vite.inertia import InertiaRedirect
+    from litestar_vite.inertia.helpers import once, share
+
+    @get("/")
+    async def handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        share(request, "cfg", once("cfg", lambda: {"a": 1}))
+        return InertiaRedirect(request, "/next")
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 307
+
+
 def test_share_returns_false_when_session_fails() -> None:
     """Test share() returns False when session access fails."""
     from unittest.mock import MagicMock
@@ -730,6 +855,16 @@ def test_optional_only_included_when_requested() -> None:
 
     # Only render when explicitly requested
     assert should_render(prop, partial_data={"comments"}) is True
+
+
+def test_optional_should_render_respects_partial_except() -> None:
+    """optional() props are included by partial-except unless excluded."""
+    from litestar_vite.inertia.helpers import optional, should_render
+
+    prop = optional("opt", lambda: 1)
+
+    assert should_render(prop, partial_except={"opt"}, key="opt") is False
+    assert should_render(prop, partial_except={"other"}, key="opt") is True
 
 
 def test_optional_callback_only_called_when_needed() -> None:

--- a/src/py/tests/unit/inertia/test_middleware.py
+++ b/src/py/tests/unit/inertia/test_middleware.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 import pytest
-from litestar import Request, get
+from litestar import Request, delete, get, patch, post, put
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.params import FromQuery
 from litestar.stores.memory import MemoryStore
@@ -100,6 +100,49 @@ async def test_version_mismatch_does_not_execute_route_handler(
 
         assert response.status_code == 409
         assert response.headers[InertiaHeaders.LOCATION.value] == "http://testserver.local/"
+
+
+async def test_version_mismatch_ignored_for_non_get_requests(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test that stale versions do not downgrade non-GET submissions into 409 redirects."""
+    ran: list[str] = []
+
+    @post("/submit", component="Form")
+    async def submit() -> dict[str, str]:
+        ran.append("post")
+        return {"ok": "post"}
+
+    @put("/submit", component="Form")
+    async def replace() -> dict[str, str]:
+        ran.append("put")
+        return {"ok": "put"}
+
+    @patch("/submit", component="Form")
+    async def update() -> dict[str, str]:
+        ran.append("patch")
+        return {"ok": "patch"}
+
+    @delete("/submit", component="Form")
+    async def remove() -> None:
+        ran.append("delete")
+
+    with create_test_client(
+        route_handlers=[submit, replace, update, remove],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        headers = {InertiaHeaders.ENABLED.value: "true", InertiaHeaders.VERSION.value: "stale-version"}
+        for method_name in ("post", "put", "patch", "delete"):
+            response = getattr(client, method_name)("/submit", headers=headers, follow_redirects=False)
+            assert response.status_code != 409
+            assert InertiaHeaders.LOCATION.value not in response.headers
+
+    assert ran == ["post", "put", "patch", "delete"]
 
 
 async def test_non_inertia_request_bypasses_version_check(

--- a/src/py/tests/unit/inertia/test_precognition.py
+++ b/src/py/tests/unit/inertia/test_precognition.py
@@ -1,15 +1,22 @@
 """Tests for Precognition support (real-time form validation)."""
 
+from dataclasses import dataclass
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
-from litestar import Request
+from litestar import Request, post
 from litestar.exceptions import ValidationException
+from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.plugins.jinja import JinjaTemplateEngine
 from litestar.status_codes import HTTP_204_NO_CONTENT, HTTP_422_UNPROCESSABLE_ENTITY
+from litestar.stores.memory import MemoryStore
+from litestar.template.config import TemplateConfig
+from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
 from litestar.types import HTTPScope
 
-from litestar_vite.inertia import InertiaHeaders
+from litestar_vite.config import InertiaConfig
+from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
 from litestar_vite.inertia.precognition import (
     PrecognitionResponse,
     create_precognition_exception_handler,
@@ -17,6 +24,7 @@ from litestar_vite.inertia.precognition import (
     precognition,
 )
 from litestar_vite.inertia.request import InertiaDetails, InertiaRequest
+from litestar_vite.plugin import VitePlugin
 
 # =====================================================
 # normalize_validation_errors() Tests
@@ -324,6 +332,37 @@ def test_precognition_decorator_request_in_kwargs() -> None:
     result = my_handler(request=mock_request)
 
     assert isinstance(result, PrecognitionResponse)
+
+
+def test_precognition_decorator_uses_middleware_context_without_request_parameter(
+    vite_plugin: VitePlugin, template_config: TemplateConfig[JinjaTemplateEngine]
+) -> None:
+    @dataclass
+    class UserPayload:
+        email: str
+
+    calls: list[str] = []
+
+    @post("/users")
+    @precognition
+    async def create_user(data: UserPayload) -> dict[str, str]:
+        calls.append(data.email)
+        return {"result": "executed"}
+
+    with create_test_client(
+        route_handlers=[create_user],
+        plugins=[InertiaPlugin(config=InertiaConfig(precognition=True)), vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.post(
+            "/users", headers={InertiaHeaders.PRECOGNITION.value: "true"}, json={"email": "sally@example.com"}
+        )
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert response.headers[InertiaHeaders.PRECOGNITION_SUCCESS.value] == "true"
+    assert calls == []
 
 
 # =====================================================

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -1,15 +1,17 @@
 import asyncio
+import json
 from pathlib import Path
 from time import sleep
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from litestar import Request, get
+from litestar import Request, delete, get, post
 from litestar.exceptions import ImproperlyConfiguredException, NotAuthorizedException
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.params import FromPath, FromQuery
 from litestar.plugins.jinja import JinjaTemplateEngine
+from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_202_ACCEPTED, HTTP_204_NO_CONTENT
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
@@ -21,6 +23,7 @@ from litestar_vite.inertia.helpers import (
     MergeProp,
     StaticProp,
     defer,
+    except_,
     extract_deferred_props,
     extract_merge_props,
     flash,
@@ -31,6 +34,7 @@ from litestar_vite.inertia.helpers import (
     lazy_render,
     merge,
     once,
+    only,
     optional,
     share,
     should_render,
@@ -38,8 +42,10 @@ from litestar_vite.inertia.helpers import (
 from litestar_vite.inertia.response import (
     InertiaBack,
     InertiaExternalRedirect,
+    InertiaResponse,
     _InertiaSSRResult,
     _parse_inertia_ssr_payload,
+    _render_inertia_ssr,
 )
 from litestar_vite.plugin import VitePlugin
 
@@ -1093,10 +1099,178 @@ async def test_explicit_response_media_type_is_respected_in_bootstrap(
         assert response.headers["content-type"].startswith("application/xhtml+xml")
 
 
+async def test_auto_wrapped_post_preserves_default_created_status(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @post("/create")
+    async def handler() -> dict[str, bool]:
+        return {"ok": True}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.post("/create")
+        assert response.status_code == HTTP_201_CREATED
+        assert response.json() == {"ok": True}
+
+
+async def test_auto_wrapped_delete_preserves_default_no_content_status(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @delete("/thing/{item_id:int}")
+    async def handler(item_id: FromPath[int]) -> None:
+        assert item_id == 1
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.delete("/thing/1")
+        assert response.status_code == HTTP_204_NO_CONTENT
+        assert response.content == b""
+
+
+async def test_user_constructed_inertia_response_status_is_honored(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @post("/submit", component="Submit")
+    async def handler() -> InertiaResponse[dict[str, str]]:
+        return InertiaResponse({"message": "accepted"}, status_code=HTTP_202_ACCEPTED)
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.post("/submit", headers={InertiaHeaders.ENABLED.value: "true"})
+        assert response.status_code == HTTP_202_ACCEPTED
+        assert response.json()["props"]["message"] == "accepted"
+
+
+async def test_auto_wrapped_inertia_get_still_uses_default_ok_status(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @get("/", component="Home")
+    async def handler() -> dict[str, str]:
+        return {"message": "ok"}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        assert response.status_code == HTTP_200_OK
+        assert response.json()["props"]["message"] == "ok"
+
+
+async def test_prop_filter_only_limits_route_props(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @get("/u", component="U")
+    async def handler() -> InertiaResponse[dict[str, list[int]]]:
+        return InertiaResponse({"users": [1], "teams": [2], "stats": [3]}, prop_filter=only("users"))
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/u", headers={InertiaHeaders.ENABLED.value: "true"})
+        data = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert data["props"]["users"] == [1]
+    assert "teams" not in data["props"]
+    assert "stats" not in data["props"]
+    assert "errors" in data["props"]
+    assert "csrf_token" in data["props"]
+    assert data["flash"] == {}
+
+
+async def test_prop_filter_except_excludes_route_props(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @get("/u", component="U")
+    async def handler() -> InertiaResponse[dict[str, list[int]]]:
+        return InertiaResponse({"users": [1], "teams": [2], "stats": [3]}, prop_filter=except_("stats"))
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/u", headers={InertiaHeaders.ENABLED.value: "true"})
+        data = response.json()
+
+    assert response.status_code == HTTP_200_OK
+    assert data["props"]["users"] == [1]
+    assert data["props"]["teams"] == [2]
+    assert "stats" not in data["props"]
+
+
+async def test_only_and_except_applied_sequentially(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @get("/", component="Home")
+    async def handler() -> dict[str, int]:
+        return {"a": 1, "b": 2, "c": 3}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get(
+            "/",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_DATA.value: "a,b",
+                InertiaHeaders.PARTIAL_EXCEPT.value: "b",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Home",
+            },
+        )
+        props = response.json()["props"]
+
+    assert props["a"] == 1
+    assert "b" not in props
+    assert "c" not in props
+
+
 async def test_hybrid_ssr_replaces_shell_root_and_injects_head(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that hybrid SSR replaces the root element instead of nesting it."""
     from litestar_vite.config import InertiaConfig, InertiaSSRConfig, PathConfig, RuntimeConfig, SPAConfig, ViteConfig
-    from litestar_vite.inertia.plugin import InertiaPlugin
 
     resource_dir = tmp_path / "resources"
     resource_dir.mkdir()
@@ -1532,6 +1706,38 @@ async def test_nested_once_metadata_survives_except_once_header(
 # =====================================================
 
 
+async def test_scroll_props_emitted_as_record_keyed_by_data_prop(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Test that infinite scroll props are keyed by the paginated data prop."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class MockPagination:
+        items: list[str]
+        limit: int
+        offset: int
+        total: int
+
+    @get("/posts", component="Posts", key="posts", infinite_scroll=True)
+    async def handler(request: Request[Any, Any, Any]) -> MockPagination:
+        return MockPagination(items=["post1", "post2"], limit=10, offset=10, total=50)
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/posts", headers={InertiaHeaders.ENABLED.value: "true"})
+        data = response.json()
+
+    assert data["scrollProps"] == {"posts": {"pageName": "page", "currentPage": 2, "previousPage": 1, "nextPage": 3}}
+
+
 async def test_scroll_props_parameter(
     inertia_plugin: InertiaPlugin,
     vite_plugin: VitePlugin,
@@ -1541,7 +1747,7 @@ async def test_scroll_props_parameter(
     from litestar_vite.inertia.helpers import scroll_props
     from litestar_vite.inertia.response import InertiaResponse
 
-    @get("/posts", component="Posts")
+    @get("/posts", component="Posts", key="posts")
     async def handler(request: Request[Any, Any, Any], page: FromQuery[int] = 1) -> InertiaResponse[dict[str, Any]]:
         posts = [{"id": i, "title": f"Post {i}"} for i in range((page - 1) * 10, page * 10)]
         return InertiaResponse(
@@ -1564,7 +1770,7 @@ async def test_scroll_props_parameter(
         data = response.json()
         # scrollProps should be present with correct data (camelCase)
         assert "scrollProps" in data
-        scroll_config = data["scrollProps"]
+        scroll_config = data["scrollProps"]["posts"]
         assert scroll_config["pageName"] == "page"
         assert scroll_config["currentPage"] == 2
         assert scroll_config["previousPage"] == 1
@@ -1595,7 +1801,7 @@ async def test_scroll_props_first_page(
     ) as client:
         response = client.get("/items", headers={InertiaHeaders.ENABLED.value: "true"})
         data = response.json()
-        scroll_config = data["scrollProps"]
+        scroll_config = data["scrollProps"]["items"]
         assert scroll_config["currentPage"] == 1
         # previousPage should not be in JSON when None (Inertia protocol)
         assert "previousPage" not in scroll_config
@@ -1626,7 +1832,7 @@ async def test_scroll_props_last_page(
     ) as client:
         response = client.get("/items", headers={InertiaHeaders.ENABLED.value: "true"})
         data = response.json()
-        scroll_config = data["scrollProps"]
+        scroll_config = data["scrollProps"]["items"]
         assert scroll_config["currentPage"] == 10
         assert scroll_config["previousPage"] == 9
         # nextPage should not be in JSON when None
@@ -1903,9 +2109,9 @@ async def test_pagination_with_infinite_scroll_opt(
         assert data["props"]["offset"] == 10
         # scroll_props should be calculated from pagination metadata
         assert "scrollProps" in data
-        assert data["scrollProps"]["currentPage"] == 2  # offset=10, limit=10 -> page 2
-        assert data["scrollProps"]["previousPage"] == 1
-        assert data["scrollProps"]["nextPage"] == 3
+        assert data["scrollProps"]["posts"]["currentPage"] == 2  # offset=10, limit=10 -> page 2
+        assert data["scrollProps"]["posts"]["previousPage"] == 1
+        assert data["scrollProps"]["posts"]["nextPage"] == 3
 
 
 async def test_pagination_classic_style_metadata(
@@ -2600,6 +2806,42 @@ async def test_deferred_prop_async_callback_resolved_via_pipeline() -> None:
         assert data["props"]["async_prop"] == "async_value"
 
 
+async def test_ssr_request_body_uses_provided_type_encoders() -> None:
+    class Widget:
+        def __init__(self, n: int) -> None:
+            self.n = n
+
+    class StubResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"head": [], "body": "<div></div>"}
+
+    class StubClient:
+        content: bytes | None = None
+
+        async def post(self, _url: str, *, content: bytes, **_kwargs: Any) -> StubResponse:
+            self.content = content
+            return StubResponse()
+
+    with pytest.raises(Exception):
+        await _render_inertia_ssr({"widget": Widget(5)}, "http://x/render", 1.0, StubClient())  # type: ignore[arg-type]
+
+    client = StubClient()
+    result = await _render_inertia_ssr(
+        {"widget": Widget(5)},
+        "http://x/render",
+        1.0,
+        client,  # type: ignore[arg-type]
+        type_encoders={Widget: lambda widget: {"w": widget.n}},
+    )
+
+    assert result.body == "<div></div>"
+    assert client.content is not None
+    assert json.loads(client.content.decode()) == {"widget": {"w": 5}}
+
+
 # ===== SSR Response Size Validation =====
 
 
@@ -2729,12 +2971,7 @@ def test_inertia_deferred_props_full_cycle() -> None:
         data_partial = response_partial.json()
         assert data_partial["props"]["deferred"] == "slow_result"
         assert "immediate" not in data_partial["props"]
-        # The resolved key must not be re-advertised as still-deferred,
-        # or the @inertiajs/core v3 client loops on loadDeferredProps.
-        assert "deferred" not in data_partial.get("deferredProps", {}).get("default", []), (
-            "Server echoed the resolved deferred key back in `deferredProps`; "
-            "this causes the Inertia v3 client to re-fire `loadDeferredProps` in an infinite loop."
-        )
+        assert data_partial.get("deferredProps") in (None, {})
 
 
 def test_deferred_props_partial_reload_strips_resolved_keys_from_metadata() -> None:
@@ -2764,10 +3001,8 @@ def test_deferred_props_partial_reload_strips_resolved_keys_from_metadata() -> N
         assert body.get("deferredProps") in (None, {}), body.get("deferredProps")
 
 
-def test_deferred_props_partial_reload_preserves_unrequested_metadata() -> None:
-    """When only one of two deferred props is requested, the unrequested one
-    must remain in `deferredProps` so the client can fetch it later.
-    """
+def test_deferred_props_partial_reload_omits_unrequested_metadata() -> None:
+    """Partial reloads do not advertise deferred props metadata."""
 
     @get("/", component="Home")
     async def handler() -> dict[str, Any]:
@@ -2789,15 +3024,11 @@ def test_deferred_props_partial_reload_preserves_unrequested_metadata() -> None:
         )
         body = partial.json()
         assert body["props"]["first"] == "value-1"
-        assert "first" not in body["deferredProps"].get("default", [])
-        assert "second" in body["deferredProps"]["default"]
+        assert body.get("deferredProps") in (None, {}), body.get("deferredProps")
 
 
-def test_deferred_props_grouped_partial_reload_strips_only_requested_group() -> None:
-    """When deferred props live in distinct groups, a partial reload for one
-    group's keys must strip those keys from their group only; other groups
-    stay intact and an emptied group is removed entirely.
-    """
+def test_deferred_props_grouped_partial_reload_omits_all_groups() -> None:
+    """Grouped deferred props metadata is omitted on partial reloads."""
 
     @get("/", component="Home")
     async def handler() -> dict[str, Any]:
@@ -2822,10 +3053,7 @@ def test_deferred_props_grouped_partial_reload_strips_only_requested_group() -> 
         )
         body = partial.json()
         assert body["props"]["stats"] == {"hits": 1}
-        assert "metrics" not in body.get("deferredProps", {}), (
-            "An emptied group must be removed from `deferredProps` entirely."
-        )
-        assert body["deferredProps"]["security"] == ["perms"]
+        assert body.get("deferredProps") in (None, {}), body.get("deferredProps")
 
 
 def test_deferred_props_initial_response_still_advertises_all_keys() -> None:

--- a/src/py/tests/unit/inertia/test_ssr_template_mode.py
+++ b/src/py/tests/unit/inertia/test_ssr_template_mode.py
@@ -1,5 +1,7 @@
 """Regression coverage for Inertia SSR firing when mode='template' (issue #243)."""
 
+import json
+import re
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Literal
@@ -15,7 +17,7 @@ from litestar.testing import create_test_client  # pyright: ignore[reportUnknown
 
 from litestar_vite.config import InertiaConfig, InertiaSSRConfig, PathConfig, RuntimeConfig, ViteConfig
 from litestar_vite.inertia import InertiaPlugin
-from litestar_vite.inertia.helpers import once
+from litestar_vite.inertia.helpers import flash, once
 from litestar_vite.inertia.response import _InertiaSSRResult
 from litestar_vite.plugin import VitePlugin
 
@@ -109,6 +111,73 @@ async def test_template_mode_ssr_endpoint_invoked(tmp_path: Path) -> None:
     assert "SSR_BODY" in response.text
     assert "SSR_TITLE" in response.text
     assert "CLIENT_PLACEHOLDER" not in response.text
+
+
+async def test_ssr_full_page_preserves_flash_across_single_build(tmp_path: Path) -> None:
+    """SSR prefetch and final hydration must use the same PageProps object."""
+    inertia_plugin, vite_plugin, template_config = _build_template_plugins(tmp_path, ssr=True)
+    captured: dict[str, Any] = {}
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        flash(request, "hi")
+        return {"message": "ok"}
+
+    async def fake_render(page: dict[str, Any], *_args: Any, **_kwargs: Any) -> _InertiaSSRResult:
+        captured["page"] = page
+        return _InertiaSSRResult(head=[], body='<div id="app">SSR_BODY</div>')
+
+    with patch("litestar_vite.inertia.response._render_inertia_ssr", side_effect=fake_render):
+        with create_test_client(
+            route_handlers=[handler],
+            plugins=[inertia_plugin, vite_plugin],
+            template_config=template_config,
+            middleware=[ServerSideSessionConfig().middleware],
+            stores={"sessions": MemoryStore()},
+            raise_server_exceptions=False,
+        ) as client:
+            response = client.get("/")
+
+    assert response.status_code == 200, response.text
+    assert captured["page"]["flash"] == {"info": ["hi"]}
+    match = re.search(r'<script id="app_page" type="application/json">(.*?)</script>', response.text, re.DOTALL)
+    assert match is not None
+    hydrated_page = json.loads(match.group(1))
+    assert hydrated_page["flash"] == {"info": ["hi"]}
+
+
+async def test_ssr_prefetch_uses_resolved_type_encoders(tmp_path: Path) -> None:
+    """SSR prefetch receives the same resolved type encoders as the normal response path."""
+    inertia_plugin, vite_plugin, template_config = _build_template_plugins(tmp_path, ssr=True)
+    captured_kwargs: dict[str, Any] = {}
+
+    class Widget:
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+    @get("/", component="Home", type_encoders={Widget: lambda widget: {"handler": widget.value}})
+    async def handler() -> dict[str, Any]:
+        return {"widget": Widget(9)}
+
+    async def fake_render(_page: dict[str, Any], *_args: Any, **kwargs: Any) -> _InertiaSSRResult:
+        captured_kwargs.update(kwargs)
+        return _InertiaSSRResult(head=[], body='<div id="app">SSR_BODY</div>')
+
+    with patch("litestar_vite.inertia.response._render_inertia_ssr", side_effect=fake_render):
+        with create_test_client(
+            route_handlers=[handler],
+            plugins=[inertia_plugin, vite_plugin],
+            template_config=template_config,
+            middleware=[ServerSideSessionConfig().middleware],
+            stores={"sessions": MemoryStore()},
+            raise_server_exceptions=False,
+            type_encoders={Widget: lambda widget: {"app": widget.value}},
+        ) as client:
+            response = client.get("/")
+
+    assert response.status_code == 200, response.text
+    type_encoders = captured_kwargs["type_encoders"]
+    assert type_encoders[Widget](Widget(9)) == {"handler": 9}
 
 
 async def test_spa_mode_ssr_endpoint_invoked_without_jinja(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Align Inertia response behavior with protocol expectations for asset-version mismatches, partial reloads, deferred metadata, scroll props, SSR serialization, and error envelopes.
- Preserve Litestar-resolved status codes for auto-wrapped responses while keeping explicit `InertiaResponse` statuses authoritative.
- Update Inertia helper docs for keyed `scrollProps` and flattened pagination metadata, including the multi-paginator collision limitation.

Closes #304
Refs #305