### PR TITLE
fix: address scaffold runtime and csrf issues

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,9 @@ Litestar Vite Changelog
 - Fixed Precognition validation success handling for handlers without an explicit ``request`` parameter by using the middleware request context.
 - Fixed Inertia SSR serialization so app, handler, and response type encoders are honored for custom page prop values.
 - Fixed Inertia partial reloads so ``deferredProps`` metadata is omitted on partial responses while initial responses still advertise deferred props.
+- Fixed ``litestar assets init`` so generated ``package.json`` files no longer emit duplicate dependency keys. (#303)
+- Added ``ViteConfig(enabled=...)`` and ``VITE_ENABLED`` so Vite routes and lifespans can be disabled in CLI, worker, and test contexts while keeping asset CLI commands available. (#301)
+- Fixed ``getCsrfToken()`` so SPA and HTMX helpers can fall back to the ``csrftoken`` or ``XSRF-TOKEN`` cookie when injected page-state sources are absent. (#299)
 
 0.25.0 - 2026-06-25
 -------------------

--- a/docs/usage/vite.rst
+++ b/docs/usage/vite.rst
@@ -197,6 +197,9 @@ You configure the Litestar backend using the `ViteConfig` object passed to the `
    * - `deploy`
      - `DeployConfig | bool`
      - Deployment configuration for CDN publishing.
+   * - `enabled`
+     - `bool | None`
+     - Controls whether `VitePlugin` wires asset routes, SPA handlers, and lifespans. `None` auto-detects known non-serving contexts, `True` forces active, and `False` makes the plugin inert while keeping CLI/config access available. Reads from ``VITE_ENABLED`` when unset.
 
 **`SPAConfig` Parameters**:
 
@@ -456,7 +459,7 @@ What it checks (high level):
 - Python vs explicit Vite plugin overrides (``assetUrl``, ``bundleDir``, ``resourceDir``, ``staticDir``, ``hotFile``, typegen flags)
 - Core paths exist (``resource_dir``, ``static_dir``) and entrypoint ``input`` files exist
 - Dev/production artifacts (manifest in prod; hotfile/Vite reachability only with ``--runtime-checks``)
-- Environment variables that override runtime (``VITE_PORT``, ``VITE_HOST``, ``VITE_PROXY_MODE``, ``VITE_BASE_URL``)
+- Environment variables that override runtime (``VITE_PORT``, ``VITE_HOST``, ``VITE_PROXY_MODE``, ``VITE_BASE_URL``, ``VITE_ENABLED``)
 - Proxy-mode bypass risks (for example, ``server.origin`` set in ``vite.config`` while ``proxy_mode`` is ``vite``/``proxy``)
 
 Common warning: ``Proxy Mode Origin Override``

--- a/src/js/src/helpers/csrf.ts
+++ b/src/js/src/helpers/csrf.ts
@@ -5,6 +5,7 @@
  * 1. window.__LITESTAR_CSRF__ (SPA mode)
  * 2. <meta name="csrf-token" content="..."> (template mode)
  * 3. Inertia shared props (Inertia mode)
+ * 4. csrftoken / XSRF-TOKEN cookie (SPA fallback)
  *
  * @module
  */
@@ -20,6 +21,7 @@ interface CsrfTokenCache {
   windowToken?: string
   metaToken?: string
   inertiaToken?: string
+  cookieToken?: string
 }
 
 let csrfTokenCache: CsrfTokenCache | null = null
@@ -64,6 +66,31 @@ function getInertiaToken(): string | undefined {
   return undefined
 }
 
+function getCookie(name: string): string | undefined {
+  if (typeof document === "undefined" || typeof document.cookie !== "string") {
+    return undefined
+  }
+
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; ${name}=`)
+  if (parts.length === 2) {
+    const raw = parts.pop()?.split(";").shift()
+    if (raw !== undefined && raw.length > 0) {
+      try {
+        return decodeURIComponent(raw)
+      } catch {
+        return raw
+      }
+    }
+  }
+
+  return undefined
+}
+
+function getCookieToken(): string | undefined {
+  return getCookie("csrftoken") ?? getCookie("XSRF-TOKEN")
+}
+
 /**
  * Get the CSRF token from the page.
  *
@@ -71,6 +98,7 @@ function getInertiaToken(): string | undefined {
  * 1. window.__LITESTAR_CSRF__ (injected by SPA handler)
  * 2. <meta name="csrf-token"> element
  * 3. Inertia page props (if Inertia is present)
+ * 4. csrftoken / XSRF-TOKEN cookie
  *
  * @returns The CSRF token or empty string if not found
  *
@@ -103,13 +131,15 @@ export function getCsrfToken(): string {
 
   const metaToken = getMetaToken()
   const inertiaToken = getInertiaToken()
-  const token = metaToken ?? inertiaToken ?? ""
+  const cookieToken = getCookieToken()
+  const token = metaToken ?? inertiaToken ?? cookieToken ?? ""
 
   if (
     csrfTokenCache &&
     csrfTokenCache.windowToken === undefined &&
     csrfTokenCache.metaToken === metaToken &&
     csrfTokenCache.inertiaToken === inertiaToken &&
+    csrfTokenCache.cookieToken === cookieToken &&
     csrfTokenCache.token === token
   ) {
     return csrfTokenCache.token
@@ -120,6 +150,7 @@ export function getCsrfToken(): string {
     windowToken: undefined,
     metaToken,
     inertiaToken,
+    cookieToken,
   }
 
   return token

--- a/src/js/tests/helpers/csrf.test.ts
+++ b/src/js/tests/helpers/csrf.test.ts
@@ -166,6 +166,90 @@ describe("csrf helpers", () => {
 
       expect(token).toBe("")
     })
+
+    it("reads csrftoken cookie when window, meta, and Inertia sources are absent", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "foo=bar; csrftoken=cookie-token-abc; other=1",
+      } as unknown as Document
+
+      expect(getCsrfToken()).toBe("cookie-token-abc")
+    })
+
+    it("prefers csrftoken over XSRF-TOKEN", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "XSRF-TOKEN=xsrf-value; csrftoken=litestar-value",
+      } as unknown as Document
+
+      expect(getCsrfToken()).toBe("litestar-value")
+    })
+
+    it("falls back to XSRF-TOKEN when csrftoken cookie is absent", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "XSRF-TOKEN=xsrf-only",
+      } as unknown as Document
+
+      expect(getCsrfToken()).toBe("xsrf-only")
+    })
+
+    it("URL-decodes the cookie value", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "csrftoken=a%2Bb%2Fc%3D",
+      } as unknown as Document
+
+      expect(getCsrfToken()).toBe("a+b/c=")
+    })
+
+    it("meta tag wins over cookie", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      const mockMeta = { getAttribute: vi.fn(() => "meta-token") }
+      ;(globalThis.document as unknown as { querySelector: unknown }).querySelector = vi.fn(() => mockMeta)
+      ;(globalThis.document as unknown as { cookie: string }).cookie = "csrftoken=cookie-token"
+
+      expect(getCsrfToken()).toBe("meta-token")
+    })
+
+    it("Inertia prop wins over cookie", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "csrftoken=cookie-token",
+      } as unknown as Document
+      ;(globalThis.window as unknown as Record<string, unknown>).__INERTIA_PAGE__ = {
+        props: { csrf_token: "inertia-token" },
+      }
+
+      expect(getCsrfToken()).toBe("inertia-token")
+    })
+
+    it("window global wins over cookie", () => {
+      globalThis.window.__LITESTAR_CSRF__ = "window-token"
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "csrftoken=cookie-token",
+      } as unknown as Document
+
+      expect(getCsrfToken()).toBe("window-token")
+    })
+
+    it("returns a rotated cookie token instead of a stale cached value", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      globalThis.document = {
+        querySelector: vi.fn(() => null),
+        cookie: "csrftoken=first",
+      } as unknown as Document
+      expect(getCsrfToken()).toBe("first")
+
+      ;(globalThis.document as unknown as { cookie: string }).cookie = "csrftoken=second"
+      expect(getCsrfToken()).toBe("second")
+    })
   })
 
   describe("csrfHeaders", () => {

--- a/src/py/litestar_vite/config/_vite.py
+++ b/src/py/litestar_vite/config/_vite.py
@@ -172,6 +172,7 @@ class ViteConfig:
         dev_mode: Convenience shortcut for runtime.dev_mode.
         base_url: Base URL for the app entry point.
         deploy: Deployment configuration for CDN publishing.
+        enabled: Whether VitePlugin actively wires serving routes and lifespans.
     """
 
     mode: "Literal['spa', 'template', 'htmx', 'hybrid', 'inertia', 'framework', 'ssr', 'ssg', 'external'] | None" = None
@@ -184,6 +185,18 @@ class ViteConfig:
     dev_mode: bool = False
     base_url: "str | None" = field(default_factory=lambda: os.getenv("VITE_BASE_URL"))
     deploy: "DeployConfig | bool" = False
+    enabled: "bool | None" = None
+    """Whether the plugin actively serves assets/routes.
+
+    - ``None`` (default): auto-detect; serving apps behave as before and known non-serving
+      invocations such as ``litestar assets ...`` are inert.
+    - ``True``: force active; inference cannot disable the plugin.
+    - ``False``: fully inert; skip asset/route wiring, static routers, SPA handlers,
+      and Vite lifespans while leaving CLI/config access available.
+
+    When unset, ``VITE_ENABLED`` is consulted. An explicit constructor value wins over
+    the environment variable.
+    """
     static_props: "dict[str, Any]" = field(default_factory=empty_dict_factory)
     """Static data to pass to the JavaScript application via the bridge file.
 
@@ -252,6 +265,7 @@ class ViteConfig:
 
     def __post_init__(self) -> None:
         """Normalize configurations and apply shortcuts."""
+        self._resolve_enabled()
         self._normalize_mode()
         self._normalize_types()
         self._normalize_inertia()
@@ -267,6 +281,13 @@ class ViteConfig:
         self._ensure_spa_default()
         self._auto_enable_dev_mode()
         self._warn_missing_assets()
+
+    def _resolve_enabled(self) -> None:
+        """Resolve VITE_ENABLED only when enabled was not set explicitly."""
+        if self.enabled is None:
+            env = os.getenv("VITE_ENABLED")
+            if env is not None:
+                self.enabled = env.strip() in TRUE_VALUES
 
     def _auto_detect_react(self) -> None:
         """Enable React Fast Refresh automatically for React templates.

--- a/src/py/litestar_vite/plugin/__init__.py
+++ b/src/py/litestar_vite/plugin/__init__.py
@@ -50,6 +50,7 @@ from litestar_vite.plugin._utils import (
     get_litestar_route_prefixes,
     is_litestar_route,
     is_non_serving_assets_cli,
+    is_non_serving_context,
     log_fail,
     log_info,
     log_success,
@@ -182,6 +183,14 @@ class VitePlugin(InitPlugin, CLIPlugin):
         if self._vite_process is None:
             self._vite_process = ViteProcess(executor=self._config.executor)
         return self._vite_process
+
+    def _is_inert(self) -> bool:
+        """Return whether HTTP-serving Vite wiring should be skipped."""
+        if self._config.enabled is False:
+            return True
+        if self._config.enabled is True:
+            return False
+        return is_non_serving_context()
 
     def _get_ssr_process(self) -> ViteProcess:
         """Get or create the SSR process manager lazily.
@@ -618,6 +627,10 @@ class VitePlugin(InitPlugin, CLIPlugin):
         Returns:
             The modified application configuration.
         """
+        if self._is_inert():
+            log_info("VitePlugin inert; skipping asset and route wiring")
+            return app_config
+
         from litestar import Response
         from litestar.connection import Request as LitestarRequest
 
@@ -796,6 +809,10 @@ class VitePlugin(InitPlugin, CLIPlugin):
         Yields:
             None
         """
+        if self._is_inert():
+            yield
+            return
+
         if self._config.is_dev_mode:
             self._ensure_proxy_target()
 

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -8,6 +8,7 @@ __all__ = (
     "infer_port_from_argv",
     "is_litestar_route",
     "is_non_serving_assets_cli",
+    "is_non_serving_context",
     "is_proxy_debug",
     "log_fail",
     "log_info",
@@ -176,6 +177,15 @@ def is_non_serving_assets_cli() -> bool:
         " assets init",
     )
     return any(cmd in argv_str for cmd in non_serving_commands)
+
+
+def is_non_serving_context() -> bool:
+    """Return True for high-confidence non-HTTP-serving process contexts.
+
+    This is used only when ViteConfig.enabled is left in auto mode. Ambiguous
+    contexts should opt out explicitly with ``enabled=False`` or ``VITE_ENABLED=false``.
+    """
+    return is_non_serving_assets_cli()
 
 
 def log_success(message: str) -> None:

--- a/src/py/litestar_vite/scaffolding/generator.py
+++ b/src/py/litestar_vite/scaffolding/generator.py
@@ -95,6 +95,20 @@ class TemplateContext:
             Dictionary of template variables.
         """
         package_versions = _build_package_version_map()
+        resolve = _package_version_resolver(package_versions)
+
+        dependencies_map: dict[str, str] = {name: resolve(name) for name in self.framework.dependencies}
+        if self.generate_zod:
+            dependencies_map["zod"] = resolve("zod")
+
+        dev_dependencies_map: dict[str, str] = {name: resolve(name) for name in self.framework.dev_dependencies}
+        if self.use_tailwind:
+            dev_dependencies_map["@tailwindcss/vite"] = resolve("@tailwindcss/vite")
+            dev_dependencies_map["tailwindcss"] = resolve("tailwindcss")
+        if self.generate_client:
+            dev_dependencies_map["@hey-api/openapi-ts"] = resolve("@hey-api/openapi-ts")
+        dev_dependencies_map["litestar-vite-plugin"] = resolve("litestar-vite-plugin")
+        dev_dependencies_map["vite"] = resolve("vite")
 
         context: dict[str, Any] = {
             "project_name": self.project_name,
@@ -116,10 +130,12 @@ class TemplateContext:
             "generate_client": self.generate_client,
             "dependencies": self.framework.dependencies,
             "dev_dependencies": self.framework.dev_dependencies,
+            "dependencies_map": dependencies_map,
+            "dev_dependencies_map": dev_dependencies_map,
             "vite_plugin": self.framework.vite_plugin,
             "uses_vite": self.framework.uses_vite,
             "package_versions": package_versions,
-            "package_version": _package_version_resolver(package_versions),
+            "package_version": resolve,
             **self.extra,
         }
         context["has_dependency"] = self.has_dependency

--- a/src/py/litestar_vite/templates/base/package.json.j2
+++ b/src/py/litestar_vite/templates/base/package.json.j2
@@ -12,27 +12,13 @@
     "generate-types": "openapi-ts"{% endif %}
   },
   "dependencies": {
-{%- set emit_zod = generate_zod and not has_dependency('zod') %}
-{%- for dep in dependencies %}
-    "{{ dep }}": "{{ package_version(dep) }}"{% if not loop.last or emit_zod %},{% endif %}
+{%- for name, version in dependencies_map.items() %}
+    "{{ name }}": "{{ version }}"{% if not loop.last %},{% endif %}
 {%- endfor %}
-{%- if emit_zod %}
-    "zod": "{{ package_version('zod') }}"
-{%- endif %}
   },
   "devDependencies": {
-{%- set emit_openapi_ts = generate_client and not has_dev_dependency('@hey-api/openapi-ts') %}
-{%- for dep in dev_dependencies %}
-    "{{ dep }}": "{{ package_version(dep) }}",
+{%- for name, version in dev_dependencies_map.items() %}
+    "{{ name }}": "{{ version }}"{% if not loop.last %},{% endif %}
 {%- endfor %}
-{%- if use_tailwind %}
-    "@tailwindcss/vite": "{{ package_version('@tailwindcss/vite') }}",
-    "tailwindcss": "{{ package_version('tailwindcss') }}",
-{%- endif %}
-{%- if emit_openapi_ts %}
-    "@hey-api/openapi-ts": "{{ package_version('@hey-api/openapi-ts') }}",
-{%- endif %}
-    "litestar-vite-plugin": "{{ package_version('litestar-vite-plugin') }}",
-    "vite": "{{ package_version('vite') }}"
   }
 }

--- a/src/py/tests/unit/test_commands.py
+++ b/src/py/tests/unit/test_commands.py
@@ -367,6 +367,25 @@ def test_scaffolding_generate_project_react_tanstack_keeps_default_api_deps_when
     assert package_json["devDependencies"]["@hey-api/openapi-ts"] == V["@hey-api/openapi-ts"]
 
 
+def test_scaffolding_generate_project_react_inertia_jinja_has_unique_vite_dev_dep(tmp_path: Path) -> None:
+    """Ensure base-rendered Inertia Jinja package.json keeps Vite once."""
+    from litestar_vite.scaffolding import TemplateContext, generate_project
+    from litestar_vite.scaffolding.templates import FrameworkType, get_template
+
+    framework = get_template(FrameworkType.REACT_INERTIA_JINJA)
+    assert framework is not None
+
+    context = TemplateContext(project_name="inertia-lite", framework=framework)
+
+    generate_project(tmp_path, context)
+
+    package_text = (tmp_path / "package.json").read_text()
+    package_json = decode_json(package_text)
+
+    assert package_text.count('    "vite":') == 1
+    assert package_json["devDependencies"]["vite"] == V["vite"]
+
+
 def test_scaffolding_generated_package_manifests_pin_dependency_versions(tmp_path: Path) -> None:
     """Ensure scaffold and example package manifests do not emit floating `latest` versions."""
     root = Path(__file__).resolve().parents[4]

--- a/src/py/tests/unit/test_config.py
+++ b/src/py/tests/unit/test_config.py
@@ -84,6 +84,29 @@ def test_dev_mode_shortcut() -> None:
     assert config.is_dev_mode is True
 
 
+# ===== ViteConfig.enabled / inert resolution =====
+
+
+def test_vite_config_enabled_defaults_to_none_auto() -> None:
+    assert ViteConfig().enabled is None
+
+
+def test_vite_config_enabled_explicit_false_is_preserved() -> None:
+    assert ViteConfig(enabled=False).enabled is False
+
+
+def test_vite_config_enabled_reads_vite_enabled_env_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VITE_ENABLED", "false")
+
+    assert ViteConfig().enabled is False
+
+
+def test_vite_config_enabled_constructor_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VITE_ENABLED", "false")
+
+    assert ViteConfig(enabled=True).enabled is True
+
+
 def test_mode_auto_detection_spa_with_index_html(tmp_path: Path) -> None:
     """Test mode auto-detection when index.html exists."""
     resource_dir = tmp_path / "resources"

--- a/src/py/tests/unit/test_plugin_inert.py
+++ b/src/py/tests/unit/test_plugin_inert.py
@@ -1,0 +1,83 @@
+"""Tests for VitePlugin inert registration mode."""
+
+import sys
+
+import pytest
+from litestar import Litestar, get
+from litestar.config.app import AppConfig
+
+from litestar_vite import ViteConfig, VitePlugin
+
+
+def _route_paths(app: Litestar) -> set[str]:
+    return {route.path for route in app.routes}
+
+
+def test_plugin_enabled_false_registers_no_vite_routes() -> None:
+    @get("/api/ping")
+    async def ping() -> dict[str, str]:
+        return {"ok": "1"}
+
+    baseline = Litestar(route_handlers=[ping])
+    with_plugin = Litestar(route_handlers=[ping], plugins=[VitePlugin(config=ViteConfig(enabled=False))])
+
+    assert _route_paths(with_plugin) == _route_paths(baseline)
+
+
+def test_plugin_enabled_false_adds_no_middleware_or_lifespan() -> None:
+    plugin = VitePlugin(config=ViteConfig(enabled=False))
+    cfg = AppConfig()
+    before_middleware = len(cfg.middleware)
+    before_lifespan = len(cfg.lifespan)
+    before_handlers = cfg.exception_handlers
+
+    out = plugin.on_app_init(cfg)
+
+    assert len(out.middleware) == before_middleware
+    assert len(out.lifespan) == before_lifespan
+    assert out.exception_handlers == before_handlers
+
+
+def test_plugin_enabled_false_keeps_cli_and_config_active() -> None:
+    from click import Group
+
+    plugin = VitePlugin(config=ViteConfig(enabled=False))
+    group = Group()
+
+    plugin.on_cli_init(group)
+
+    assert "assets" in group.commands
+    assert plugin.config is not None
+    assert plugin.asset_loader is not None
+
+
+def test_plugin_server_lifespan_inert_yields_without_side_effects() -> None:
+    plugin = VitePlugin(config=ViteConfig(enabled=False))
+    app = Litestar(route_handlers=[])
+
+    with plugin.server_lifespan(app):
+        pass
+
+    assert plugin._vite_process is None
+
+
+def test_plugin_auto_inert_in_assets_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["litestar", "assets", "build"])
+
+    @get("/api/ping")
+    async def ping() -> dict[str, str]:
+        return {"ok": "1"}
+
+    baseline = Litestar(route_handlers=[ping])
+    inferred = Litestar(route_handlers=[ping], plugins=[VitePlugin(config=ViteConfig())])
+
+    assert _route_paths(inferred) == _route_paths(baseline)
+
+
+def test_plugin_explicit_true_beats_assets_cli_inference(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["litestar", "assets", "build"])
+    plugin = VitePlugin(config=ViteConfig(enabled=True, mode="spa"))
+
+    out = plugin.on_app_init(AppConfig())
+
+    assert len(out.lifespan) >= 1

--- a/src/py/tests/unit/test_scaffold_manifest_render_matrix.py
+++ b/src/py/tests/unit/test_scaffold_manifest_render_matrix.py
@@ -1,0 +1,73 @@
+"""Regression tests for scaffolded package manifests."""
+
+import itertools
+import json
+from typing import Any
+
+import pytest
+
+from litestar_vite.scaffolding.generator import TemplateContext, get_template_dir, render_template
+from litestar_vite.scaffolding.templates import FRAMEWORK_TEMPLATES, FrameworkType
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    for key, _ in pairs:
+        if key in seen:
+            msg = f"duplicate key {key!r}"
+            raise ValueError(msg)
+        seen.add(key)
+    return dict(pairs)
+
+
+def _render_package_json(framework: FrameworkType, flags: dict[str, bool]) -> str:
+    context = TemplateContext(
+        project_name="demo",
+        framework=FRAMEWORK_TEMPLATES[framework],
+        use_tailwind=flags["use_tailwind"],
+        enable_ssr=flags["enable_ssr"],
+        enable_types=flags["enable_types"],
+        generate_zod=flags["generate_zod"],
+        generate_client=flags["generate_client"],
+    )
+    template_dir = get_template_dir()
+    framework_package = template_dir / framework.value / "package.json.j2"
+    package_template = framework_package if framework_package.exists() else template_dir / "base" / "package.json.j2"
+    return render_template(package_template, context.to_dict())
+
+
+_PACKAGE_FLAG_NAMES = ("use_tailwind", "enable_ssr", "enable_types", "generate_zod", "generate_client")
+_PACKAGE_FLAG_COMBOS = [
+    dict(zip(_PACKAGE_FLAG_NAMES, combo, strict=True)) for combo in itertools.product([False, True], repeat=5)
+]
+
+
+@pytest.mark.parametrize("framework", list(FrameworkType))
+def test_scaffold_manifest_render_has_no_duplicate_keys(framework: FrameworkType) -> None:
+    for flags in _PACKAGE_FLAG_COMBOS:
+        text = _render_package_json(framework, flags)
+        json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+
+
+def test_scaffold_react_tanstack_issue_303_repro_has_no_duplicate_keys() -> None:
+    text = _render_package_json(
+        FrameworkType.REACT_TANSTACK,
+        {
+            "use_tailwind": True,
+            "enable_ssr": False,
+            "enable_types": True,
+            "generate_zod": True,
+            "generate_client": True,
+        },
+    )
+
+    json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+
+
+@pytest.mark.parametrize("framework", list(FrameworkType))
+def test_scaffold_manifest_dependency_versions_are_unique_and_preserved(framework: FrameworkType) -> None:
+    for flags in _PACKAGE_FLAG_COMBOS:
+        text = _render_package_json(framework, flags)
+        parsed = json.loads(text)
+        rejecting = json.loads(text, object_pairs_hook=_reject_duplicate_keys)
+        assert parsed == rejecting, f"{framework.value}: deduped content changed for flags={flags}"

--- a/src/py/tests/unit/test_utils.py
+++ b/src/py/tests/unit/test_utils.py
@@ -90,6 +90,27 @@ def test_is_non_serving_assets_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     assert utils.is_non_serving_assets_cli() is False
 
 
+# ===== is_non_serving_context centralization =====
+
+
+def test_is_non_serving_context_true_for_assets_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["litestar", "assets", "build"])
+
+    assert utils.is_non_serving_context() is True
+
+
+def test_is_non_serving_context_false_for_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["litestar", "run"])
+
+    assert utils.is_non_serving_context() is False
+
+
+def test_is_non_serving_assets_cli_still_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["litestar", "assets", "deploy"])
+
+    assert utils.is_non_serving_assets_cli() is True
+
+
 def test_write_runtime_config_file_records_deploy_asset_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LITESTAR_VERSION", "9.9.9")
     config = ViteConfig(


### PR DESCRIPTION
## Summary

- Render the base scaffold `package.json` dependency objects from de-duplicated dependency maps and add duplicate-key manifest regression coverage.
- Add `ViteConfig(enabled=...)` / `VITE_ENABLED` so Vite route and lifespan wiring can be disabled in CLI, worker, and test contexts while keeping asset CLI commands available.
- Add CSRF cookie fallback support for `csrftoken` and `XSRF-TOKEN` when window, meta, and Inertia sources are absent.

Closes #303
Closes #301
Closes #299