### PR TITLE
perf: tighten vite integration hot paths

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,27 +7,33 @@ Notable changes to this project are documented in this file.
 Litestar Vite Changelog
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-0.26.0 (unreleased)
+0.26.0 - 2026-07-05
 -------------------
 
-- Fixed Inertia asset-version mismatch handling so only ``GET`` requests can return the protocol ``409`` refresh response; non-GET submissions now continue to their handlers instead of being downgraded and losing the request body.
-- Fixed ``share()`` with Inertia redirects so top-level sync special props are materialized before session storage and async special props are skipped instead of crashing session serialization.
-- Fixed Inertia infinite-scroll ``scrollProps`` to emit a record keyed by data prop name, matching the official client protocol.
-- Fixed auto-wrapped Inertia responses so non-Inertia JSON handlers preserve Litestar's resolved ``201``/``204`` status codes while user-created ``InertiaResponse`` statuses still win.
-- Fixed Precognition validation success handling for handlers without an explicit ``request`` parameter by using the middleware request context.
-- Fixed Inertia SSR serialization so app, handler, and response type encoders are honored for custom page prop values.
-- Fixed Inertia partial reloads so ``deferredProps`` metadata is omitted on partial responses while initial responses still advertise deferred props.
+- Fixed Inertia asset-version mismatch handling so only ``GET`` requests can return the protocol ``409`` refresh response; non-GET submissions now continue to their handlers instead of being downgraded and losing the request body. (#306)
+- Fixed ``share()`` with Inertia redirects so top-level sync special props are materialized before session storage and async special props are skipped instead of crashing session serialization. (#306)
+- Fixed Inertia infinite-scroll ``scrollProps`` to emit a record keyed by data prop name, matching the official client protocol. (#306)
+- Fixed auto-wrapped Inertia responses so non-Inertia JSON handlers preserve Litestar's resolved ``201``/``204`` status codes while user-created ``InertiaResponse`` statuses still win. (#306)
+- Fixed Precognition validation success handling for handlers without an explicit ``request`` parameter by using the middleware request context. (#306)
+- Fixed Inertia SSR serialization so app, handler, and response type encoders are honored for custom page prop values. (#306)
+- Fixed Inertia partial reloads so ``deferredProps`` metadata is omitted on partial responses while initial responses still advertise deferred props. (#306)
 - Fixed ``litestar assets init`` so generated ``package.json`` files no longer emit duplicate dependency keys. (#302, #303)
 - Fixed type generation so the JS plugin resolves local ``@hey-api/openapi-ts`` installs first, uses a pinned package-manager fallback when needed, fails production builds loudly by default, and lets ``TypeGenConfig(fail_on_error=False)`` or ``types.failOnError = false`` opt out. (#311, #314)
 - Fixed type generation reliability for generated outputs by preserving queued dev regenerations, checking that expected output files exist before reusing caches, watching ``routes.json``, emitting ``static-props.ts`` from the shared CLI path, and handling semantic aliases and nested hey-api operation types. (#311, #314)
 - Fixed Vite dev-server resilience by revalidating hotfile targets by mtime, recovering after missing or replaced hotfiles, tolerating additive/corrupt bridge config files, aligning TLS certificate env vars, and preserving static-files defaults when user overrides leave fields unset. (#312, #314)
 - Fixed ``litestar assets init`` scaffold correctness for framework variants without dedicated directories, Tailwind CSS/PostCSS dependencies and entry inputs, current hey-api/TanStack/Vite template APIs, transactional writes, and non-interactive collision handling. (#313, #314)
 - Updated npm publishing to use trusted publishing with provenance and no npm token. (#314)
-- Fixed Vite dev-server lifecycle handling so unexpected exits are restarted with capped backoff and intentional shutdowns do not trigger restarts.
-- Changed SPA/proxy route-prefix fallbacks so ``/docs`` is no longer reserved unless Litestar actually registers docs there or ``RuntimeConfig.extra_route_prefixes`` includes it.
+- Fixed Vite dev-server lifecycle handling so unexpected exits are restarted with capped backoff and intentional shutdowns do not trigger restarts. (#317)
+- Changed SPA/proxy route-prefix fallbacks so ``/docs`` is no longer reserved unless Litestar actually registers docs there or ``RuntimeConfig.extra_route_prefixes`` includes it. (#317)
 - Added ``ViteConfig(enabled=...)`` and ``VITE_ENABLED`` so Vite routes and lifespans can be disabled in CLI, worker, and test contexts while keeping asset CLI commands available. (#301, #310)
-- Added ``RuntimeConfig.extra_route_prefixes`` for deliberately reserving custom backend prefixes from SPA/proxy fallbacks.
+- Added ``RuntimeConfig.extra_route_prefixes`` for deliberately reserving custom backend prefixes from SPA/proxy fallbacks. (#317)
 - Fixed ``getCsrfToken()`` so SPA and HTMX helpers can fall back to the ``csrftoken`` or ``XSRF-TOKEN`` cookie when injected page-state sources are absent. (#299, #310)
+- Hardened HTMX helper handling so dynamic ``href``, ``src``, and ``action`` attributes reject dangerous protocols and expression checks catch denied globals reconstructed through string concatenation. (#316)
+- Simplified Vite integration internals by consolidating type-config resolution, hotfile handling, proxy helpers, Inertia prop wrappers, and typing-only helper paths without removing public exports. (#316)
+- Reduced duplicate work in type generation, route metadata extraction, proxy header filtering, deploy diffing, bridge reads, placeholder probing, and Inertia response wrapping while preserving generated output paths and public behavior. (#315)
+- Fixed SPA startup so async lifespan initialization uses the async handler path and custom Inertia component option keys are preserved when startup wrappers are installed. (#315)
+- Fixed production SPA manifest resolution for Vite's default ``.vite/manifest.json`` path and recursive deploy change detection for nested bundle assets. (#315)
+- Updated Python dependencies: ``typing-extensions`` 4.16.0, ``prek`` 0.4.8, ``slotscheck`` 0.20.1, and ``coverage`` 7.15.0. (#309)
 
 0.25.0 - 2026-06-25
 -------------------

--- a/src/js/src/index.ts
+++ b/src/js/src/index.ts
@@ -1504,29 +1504,47 @@ function dirname(): string {
   return path.resolve(process.cwd(), "../dist/js")
 }
 
+let cachedDevServerPlaceholderCandidates: string[] | undefined
+let cachedDevServerPlaceholderPath: string | undefined
+
 function getDevServerPlaceholderCandidates(): string[] {
+  if (cachedDevServerPlaceholderCandidates) {
+    return cachedDevServerPlaceholderCandidates
+  }
+
   const distJsRoot = "dist/js"
   const placeholderName = "dev-server-index.html"
   const moduleDir = dirname()
 
   const candidates = [
-    path.join(dirname(), placeholderName),
+    path.join(moduleDir, placeholderName),
     path.join(process.cwd(), distJsRoot, placeholderName),
     path.join(process.cwd(), "src", "js", distJsRoot, placeholderName),
     path.resolve(process.cwd(), "..", distJsRoot, placeholderName),
     path.join(moduleDir, distJsRoot, placeholderName),
   ]
 
-  return [...new Set(candidates)]
+  cachedDevServerPlaceholderCandidates = [...new Set(candidates)]
+  return cachedDevServerPlaceholderCandidates
 }
 
 async function loadDevServerPlaceholder(): Promise<string> {
+  if (cachedDevServerPlaceholderPath) {
+    try {
+      return await fs.promises.readFile(cachedDevServerPlaceholderPath, "utf-8")
+    } catch {
+      cachedDevServerPlaceholderPath = undefined
+    }
+  }
+
   const candidates = getDevServerPlaceholderCandidates()
   let lastError: unknown = new Error("Failed to load dev server placeholder index.html")
 
   for (const candidatePath of candidates) {
     try {
-      return await fs.promises.readFile(candidatePath, "utf-8")
+      const content = await fs.promises.readFile(candidatePath, "utf-8")
+      cachedDevServerPlaceholderPath = candidatePath
+      return content
     } catch (error) {
       lastError = error
     }

--- a/src/js/src/shared/bridge-schema.ts
+++ b/src/js/src/shared/bridge-schema.ts
@@ -335,28 +335,53 @@ export function parseBridgeSchema(value: unknown): BridgeSchema {
 export function readBridgeConfig(explicitPath?: string): BridgeSchema | null {
   const envPath = explicitPath ?? process.env.LITESTAR_VITE_CONFIG_PATH
   if (envPath) {
-    if (!fs.existsSync(envPath)) {
-      return null
-    }
-    try {
-      return readBridgeConfigFile(envPath)
-    } catch (error) {
-      warn(error instanceof Error ? error.message : String(error))
-      return null
-    }
+    return readBridgeConfigFileCached(envPath)
   }
 
   const defaultPath = path.join(process.cwd(), ".litestar.json")
-  if (fs.existsSync(defaultPath)) {
-    try {
-      return readBridgeConfigFile(defaultPath)
-    } catch (error) {
-      warn(error instanceof Error ? error.message : String(error))
-      return null
+  return readBridgeConfigFileCached(defaultPath)
+}
+
+interface BridgeConfigCacheEntry {
+  mtimeMs: number
+  config: BridgeSchema | null
+}
+
+const bridgeConfigCache = new Map<string, BridgeConfigCacheEntry>()
+
+function readBridgeConfigFileCached(filePath: string): BridgeSchema | null {
+  const resolvedPath = path.resolve(filePath)
+  if (!fs.existsSync(resolvedPath)) {
+    return null
+  }
+
+  let mtimeMs: number | null = null
+  try {
+    mtimeMs = fs.statSync(resolvedPath).mtimeMs
+  } catch {
+    mtimeMs = null
+  }
+
+  if (mtimeMs !== null) {
+    const cached = bridgeConfigCache.get(resolvedPath)
+    if (cached?.mtimeMs === mtimeMs) {
+      return cached.config
     }
   }
 
-  return null
+  try {
+    const config = readBridgeConfigFile(resolvedPath)
+    if (mtimeMs !== null) {
+      bridgeConfigCache.set(resolvedPath, { mtimeMs, config })
+    }
+    return config
+  } catch (error) {
+    warn(error instanceof Error ? error.message : String(error))
+    if (mtimeMs !== null) {
+      bridgeConfigCache.set(resolvedPath, { mtimeMs, config: null })
+    }
+    return null
+  }
 }
 
 function readBridgeConfigFile(filePath: string): BridgeSchema {

--- a/src/js/src/shared/typegen-plugin.ts
+++ b/src/js/src/shared/typegen-plugin.ts
@@ -341,6 +341,10 @@ export function createLitestarTypeGenPlugin(typesConfig: RequiredTypeGenConfig, 
     },
 
     async buildStart() {
+      if (resolvedConfig?.command === "build" && process.env.LITESTAR_VITE_SKIP_BUILD_TYPEGEN === "1") {
+        return
+      }
+
       if (typesConfig.enabled && hasPythonConfig === false) {
         const projectRoot = resolvedConfig?.root ?? process.cwd()
         const openapiPath = path.resolve(projectRoot, typesConfig.openapiPath)

--- a/src/js/tests/index.test.ts
+++ b/src/js/tests/index.test.ts
@@ -1539,6 +1539,26 @@ describe("litestar-vite-plugin", () => {
       expect(mockNext).not.toHaveBeenCalled()
     })
 
+    it("caches placeholder path probing across placeholder responses", async () => {
+      const appUrl = "http://test.app"
+      process.env.APP_URL = appUrl
+      await setupServer()
+      mockFs(null)
+
+      const existsSpy = vi.spyOn(fs, "existsSync")
+
+      await mockMiddleware({ url: "/index.html", originalUrl: "/index.html" }, mockRes, mockNext)
+      const firstProbeCount = existsSpy.mock.calls.filter(([candidate]) => String(candidate).endsWith("dev-server-index.html")).length
+
+      mockRes.end.mockClear()
+      await mockMiddleware({ url: "/", originalUrl: "/" }, mockRes, mockNext)
+      const totalProbeCount = existsSpy.mock.calls.filter(([candidate]) => String(candidate).endsWith("dev-server-index.html")).length
+
+      expect(totalProbeCount).toBe(firstProbeCount)
+      expect(mockRes.end).toHaveBeenCalledWith(actualPlaceholderContent.replace(/{{ APP_URL }}/g, appUrl))
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
     it("serves placeholder when index.html is not detected and url is /", async () => {
       // When no index.html exists (hybrid/inertia mode), serve the placeholder at root
       // This helps users who accidentally navigate to the Vite dev server port

--- a/src/js/tests/shared/bridge-schema.test.ts
+++ b/src/js/tests/shared/bridge-schema.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { parseBridgeSchema, readBridgeConfig } from "../../src/shared/bridge-schema"
 
 const baseBridgeConfig = {
@@ -95,6 +95,29 @@ describe("bridge schema additive fields", () => {
     try {
       expect(readBridgeConfig(configPath)).toBeNull()
     } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it("memoizes bridge file reads until path mtime changes", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "litestar-bridge-"))
+    const configPath = path.join(tmpDir, ".litestar.json")
+    fs.writeFileSync(configPath, JSON.stringify(baseBridgeConfig))
+    const readSpy = vi.spyOn(fs, "readFileSync")
+
+    try {
+      expect(readBridgeConfig(configPath)?.port).toBe(5173)
+      expect(readBridgeConfig(configPath)?.port).toBe(5173)
+      expect(readSpy).toHaveBeenCalledTimes(1)
+
+      fs.writeFileSync(configPath, JSON.stringify({ ...baseBridgeConfig, port: 5174 }))
+      const mtime = new Date(Date.now() + 1000)
+      fs.utimesSync(configPath, mtime, mtime)
+
+      expect(readBridgeConfig(configPath)?.port).toBe(5174)
+      expect(readSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      readSpy.mockRestore()
       fs.rmSync(tmpDir, { recursive: true, force: true })
     }
   })

--- a/src/js/tests/shared/typegen-plugin.test.ts
+++ b/src/js/tests/shared/typegen-plugin.test.ts
@@ -180,6 +180,23 @@ describe("createLitestarTypeGenPlugin", () => {
     expect(context.error).not.toHaveBeenCalled()
   })
 
+  it("skips buildStart generation when Python assets build already ran typegen", async () => {
+    process.env.LITESTAR_VITE_SKIP_BUILD_TYPEGEN = "1"
+    const plugin = createPlugin()
+    plugin.configResolved?.(createResolvedConfig("build") as never)
+    const context = { error: vi.fn(), warn: vi.fn() }
+
+    try {
+      await plugin.buildStart?.call(context as never)
+    } finally {
+      delete process.env.LITESTAR_VITE_SKIP_BUILD_TYPEGEN
+    }
+
+    expect(mocks.runTypeGeneration).not.toHaveBeenCalled()
+    expect(context.error).not.toHaveBeenCalled()
+    expect(context.warn).not.toHaveBeenCalled()
+  })
+
   it("reruns once when a change arrives during active generation", async () => {
     let resolveFirst: (value: unknown) => void = () => undefined
     const firstRun = new Promise((resolve) => {

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -48,6 +48,20 @@ FRAMEWORK_CHOICES = [
 ]
 
 
+@contextlib.contextmanager
+def _temporary_env_var(name: str, value: str) -> "Any":
+    """Temporarily set an environment variable."""
+    previous = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = previous
+
+
 def _format_command(command: "list[str] | None") -> str:
     """Join a command list for display.
 
@@ -218,13 +232,19 @@ def _prepare_and_build(config: ViteConfig, root_dir: Path, console: Any, app: "L
         set_environment(config=config)
     os.environ.setdefault("VITE_BASE_URL", config.base_url or "/")
 
-    ext = config.runtime.external_dev_server
-    if isinstance(ext, ExternalDevServer) and ext.enabled:
-        build_cmd = ext.build_command or config.executor.build_command
-        console.print(f"[dim]Running external build: {' '.join(build_cmd)}[/]")
-        config.executor.execute(build_cmd, cwd=root_dir)
-    else:
-        config.executor.execute(config.build_command, cwd=root_dir)
+    env_manager = (
+        _temporary_env_var("LITESTAR_VITE_SKIP_BUILD_TYPEGEN", "1")
+        if generated_assets and isinstance(config.types, TypeGenConfig)
+        else contextlib.nullcontext()
+    )
+    with env_manager:
+        ext = config.runtime.external_dev_server
+        if isinstance(ext, ExternalDevServer) and ext.enabled:
+            build_cmd = ext.build_command or config.executor.build_command
+            console.print(f"[dim]Running external build: {' '.join(build_cmd)}[/]")
+            config.executor.execute(build_cmd, cwd=root_dir)
+        else:
+            config.executor.execute(config.build_command, cwd=root_dir)
 
 
 def _run_vite_build(

--- a/src/py/litestar_vite/codegen/__init__.py
+++ b/src/py/litestar_vite/codegen/__init__.py
@@ -10,7 +10,7 @@ Internal implementation details (OpenAPI integration, TypeScript conversion)
 are kept in private submodules to keep the public API clean.
 """
 
-from litestar_vite.codegen._export import ExportResult, export_integration_assets
+from litestar_vite.codegen._export import ExportResult, export_integration_assets, typegen_outputs_requested
 from litestar_vite.codegen._inertia import (
     InertiaPageMetadata,
     extract_inertia_pages,
@@ -44,5 +44,6 @@ __all__ = (
     "generate_routes_json",
     "generate_routes_ts",
     "strip_timestamp_for_comparison",
+    "typegen_outputs_requested",
     "write_if_changed",
 )

--- a/src/py/litestar_vite/codegen/_export.py
+++ b/src/py/litestar_vite/codegen/_export.py
@@ -48,6 +48,18 @@ def fmt_path(path: Path) -> str:
         return str(path)
 
 
+def typegen_outputs_requested(config: "ViteConfig", types_config: "TypeGenConfig") -> bool:
+    """Return whether the typegen config asks for any generated artifact."""
+    del config
+    return any((
+        types_config.generate_sdk,
+        types_config.generate_zod,
+        types_config.generate_schemas,
+        types_config.generate_routes,
+        types_config.generate_page_props,
+    ))
+
+
 def export_integration_assets(
     app: "Litestar", config: "ViteConfig", *, serializer: "Callable[[Any], bytes] | None" = None
 ) -> ExportResult:
@@ -83,6 +95,8 @@ def export_integration_assets(
         return result
 
     types_config = config.types
+    if not typegen_outputs_requested(config, types_config):
+        return result
 
     # Check if OpenAPI is available
     openapi_plugin = next((p for p in app.plugins._plugins if isinstance(p, OpenAPIPlugin)), None)  # pyright: ignore[reportPrivateUsage]
@@ -122,12 +136,24 @@ def export_integration_assets(
     # Step 2: Export openapi.json
     export_openapi(schema_dict=schema_dict, types_config=types_config, serializer=serializer, result=result)
 
+    from litestar_vite.codegen._routes import extract_route_metadata
+
+    routes_metadata = extract_route_metadata(app, openapi_schema=schema_dict)
+
     # Step 3: Export routes.json (always pass openapi_schema for consistency)
-    export_routes_json(app=app, types_config=types_config, openapi_schema=schema_dict, result=result)
+    export_routes_json(
+        app=app, types_config=types_config, openapi_schema=schema_dict, routes_metadata=routes_metadata, result=result
+    )
 
     # Step 4: Export routes.ts (if enabled)
     if types_config.generate_routes:
-        export_routes_ts(app=app, types_config=types_config, openapi_schema=schema_dict, result=result)
+        export_routes_ts(
+            app=app,
+            types_config=types_config,
+            openapi_schema=schema_dict,
+            routes_metadata=routes_metadata,
+            result=result,
+        )
 
     # Step 5: Export inertia-pages.json (if enabled)
     if (
@@ -164,7 +190,12 @@ def export_openapi(
 
 
 def export_routes_json(
-    *, app: "Litestar", types_config: "TypeGenConfig", openapi_schema: "dict[str, Any]", result: ExportResult
+    *,
+    app: "Litestar",
+    types_config: "TypeGenConfig",
+    openapi_schema: "dict[str, Any]",
+    routes_metadata: "list[Any]",
+    result: ExportResult,
 ) -> None:
     """Export routes metadata to JSON file."""
     from litestar_vite.codegen._routes import generate_routes_json
@@ -182,7 +213,9 @@ def export_routes_json(
         routes_path = types_config.output / "routes.json"
 
     # Always pass openapi_schema for consistent output between CLI and plugin
-    routes_data = generate_routes_json(app, include_components=True, openapi_schema=openapi_schema)
+    routes_data = generate_routes_json(
+        app, include_components=True, openapi_schema=openapi_schema, routes_metadata=routes_metadata
+    )
     routes_data["litestar_version"] = litestar_version
 
     routes_content = encode_deterministic_json(routes_data)
@@ -194,7 +227,12 @@ def export_routes_json(
 
 
 def export_routes_ts(
-    *, app: "Litestar", types_config: "TypeGenConfig", openapi_schema: "dict[str, Any]", result: ExportResult
+    *,
+    app: "Litestar",
+    types_config: "TypeGenConfig",
+    openapi_schema: "dict[str, Any]",
+    routes_metadata: "list[Any]",
+    result: ExportResult,
 ) -> None:
     """Export typed routes TypeScript file."""
     from litestar_vite.codegen._routes import generate_routes_ts
@@ -205,7 +243,9 @@ def export_routes_ts(
         routes_ts_path = types_config.output / "routes.ts"
 
     # Always pass openapi_schema for consistent output
-    routes_ts_content = generate_routes_ts(app, openapi_schema=openapi_schema, global_route=types_config.global_route)
+    routes_ts_content = generate_routes_ts(
+        app, openapi_schema=openapi_schema, global_route=types_config.global_route, routes_metadata=routes_metadata
+    )
 
     if write_if_changed(routes_ts_path, routes_ts_content):
         result.exported_files.append(fmt_path(routes_ts_path))

--- a/src/py/litestar_vite/codegen/_routes.py
+++ b/src/py/litestar_vite/codegen/_routes.py
@@ -392,6 +392,7 @@ def generate_routes_json(
     exclude: "list[str] | None" = None,
     include_components: bool = False,
     openapi_schema: dict[str, Any] | None = None,
+    routes_metadata: "list[RouteMetadata] | None" = None,
 ) -> dict[str, Any]:
     """Generate Ziggy-compatible routes JSON.
 
@@ -401,7 +402,11 @@ def generate_routes_json(
     Returns:
         A Ziggy-compatible routes payload as a dictionary with sorted keys.
     """
-    routes_metadata = extract_route_metadata(app, only=only, exclude=exclude, openapi_schema=openapi_schema)
+    routes_metadata = (
+        routes_metadata
+        if routes_metadata is not None
+        else extract_route_metadata(app, only=only, exclude=exclude, openapi_schema=openapi_schema)
+    )
 
     # Sort routes by name for deterministic output
     sorted_routes = sorted(routes_metadata, key=lambda r: r.name)
@@ -492,6 +497,7 @@ def generate_routes_ts(
     exclude: "list[str] | None" = None,
     openapi_schema: dict[str, Any] | None = None,
     global_route: bool = False,
+    routes_metadata: "list[RouteMetadata] | None" = None,
 ) -> str:
     """Generate typed routes TypeScript file (Ziggy-style).
 
@@ -501,7 +507,11 @@ def generate_routes_ts(
     Returns:
         The generated TypeScript source.
     """
-    routes_metadata = extract_route_metadata(app, only=only, exclude=exclude, openapi_schema=openapi_schema)
+    routes_metadata = (
+        routes_metadata
+        if routes_metadata is not None
+        else extract_route_metadata(app, only=only, exclude=exclude, openapi_schema=openapi_schema)
+    )
 
     # Sort routes by name for deterministic output
     sorted_routes = sorted(routes_metadata, key=lambda r: r.name)

--- a/src/py/litestar_vite/config/_runtime.py
+++ b/src/py/litestar_vite/config/_runtime.py
@@ -10,6 +10,44 @@ from litestar_vite.config._constants import TRUE_VALUES
 
 __all__ = ("ExternalDevServer", "RuntimeConfig", "resolve_trusted_proxies")
 
+_EXECUTOR_COMMANDS: dict[str, dict[str, tuple[str, ...]]] = {
+    "node": {
+        "run": ("npm", "run", "dev"),
+        "build": ("npm", "run", "build"),
+        "build_watch": ("npm", "run", "watch"),
+        "serve": ("npm", "run", "serve"),
+        "install": ("npm", "install"),
+    },
+    "bun": {
+        "run": ("bun", "run", "dev"),
+        "build": ("bun", "run", "build"),
+        "build_watch": ("bun", "run", "watch"),
+        "serve": ("bun", "run", "serve"),
+        "install": ("bun", "install"),
+    },
+    "deno": {
+        "run": ("deno", "task", "dev"),
+        "build": ("deno", "task", "build"),
+        "build_watch": ("deno", "task", "watch"),
+        "serve": ("deno", "task", "serve"),
+        "install": ("deno", "install"),
+    },
+    "yarn": {
+        "run": ("yarn", "dev"),
+        "build": ("yarn", "build"),
+        "build_watch": ("yarn", "watch"),
+        "serve": ("yarn", "serve"),
+        "install": ("yarn", "install"),
+    },
+    "pnpm": {
+        "run": ("pnpm", "dev"),
+        "build": ("pnpm", "build"),
+        "build_watch": ("pnpm", "watch"),
+        "serve": ("pnpm", "serve"),
+        "install": ("pnpm", "install"),
+    },
+}
+
 
 @lru_cache(maxsize=32)
 def _cached_resolve_trusted_proxies(env_value: str | None) -> "tuple[str, ...] | Literal['*'] | None":
@@ -234,53 +272,15 @@ class RuntimeConfig:
         if self.executor is None:
             self.executor = "node"
 
-        executor_commands = {
-            "node": {
-                "run": ["npm", "run", "dev"],
-                "build": ["npm", "run", "build"],
-                "build_watch": ["npm", "run", "watch"],
-                "serve": ["npm", "run", "serve"],
-                "install": ["npm", "install"],
-            },
-            "bun": {
-                "run": ["bun", "run", "dev"],
-                "build": ["bun", "run", "build"],
-                "build_watch": ["bun", "run", "watch"],
-                "serve": ["bun", "run", "serve"],
-                "install": ["bun", "install"],
-            },
-            "deno": {
-                "run": ["deno", "task", "dev"],
-                "build": ["deno", "task", "build"],
-                "build_watch": ["deno", "task", "watch"],
-                "serve": ["deno", "task", "serve"],
-                "install": ["deno", "install"],
-            },
-            "yarn": {
-                "run": ["yarn", "dev"],
-                "build": ["yarn", "build"],
-                "build_watch": ["yarn", "watch"],
-                "serve": ["yarn", "serve"],
-                "install": ["yarn", "install"],
-            },
-            "pnpm": {
-                "run": ["pnpm", "dev"],
-                "build": ["pnpm", "build"],
-                "build_watch": ["pnpm", "watch"],
-                "serve": ["pnpm", "serve"],
-                "install": ["pnpm", "install"],
-            },
-        }
-
-        if self.executor in executor_commands:
-            cmds = executor_commands[self.executor]
+        if self.executor in _EXECUTOR_COMMANDS:
+            cmds = _EXECUTOR_COMMANDS[self.executor]
             if self.run_command is None:
-                self.run_command = cmds["run"]
+                self.run_command = list(cmds["run"])
             if self.build_command is None:
-                self.build_command = cmds["build"]
+                self.build_command = list(cmds["build"])
             if self.build_watch_command is None:
-                self.build_watch_command = cmds["build_watch"]
+                self.build_watch_command = list(cmds["build_watch"])
             if self.serve_command is None:
-                self.serve_command = cmds["serve"]
+                self.serve_command = list(cmds["serve"])
             if self.install_command is None:
-                self.install_command = cmds["install"]
+                self.install_command = list(cmds["install"])

--- a/src/py/litestar_vite/deploy.py
+++ b/src/py/litestar_vite/deploy.py
@@ -199,25 +199,33 @@ class ViteDeployer:
         Returns:
             Mapping of relative remote paths to file metadata.
         """
-
-        try:
-            entries = cast("list[dict[str, Any]]", self.fs.ls(self.remote_path, detail=True))
-        except (FileNotFoundError, OSError):
-            return {}
-
         remote_files: dict[str, FileInfo] = {}
         base = self.remote_path.rstrip("/")
-        for entry in entries:
+        for entry in self._iter_remote_entries(self.remote_path):
             name = entry.get("name")
             if name is None:
-                continue
-            if entry.get("type") == "directory":
                 continue
             rel_path = self._relative_remote_path(name, base)
             remote_files[rel_path] = FileInfo(
                 path=rel_path, size=int(entry.get("size", 0)), mtime=float(entry.get("mtime", 0.0))
             )
         return remote_files
+
+    def _iter_remote_entries(self, root: str) -> "Iterable[dict[str, Any]]":
+        """Yield remote file entries recursively from ``root``."""
+        try:
+            entries = cast("list[dict[str, Any]]", self.fs.ls(root, detail=True))
+        except (FileNotFoundError, OSError):
+            return
+
+        for entry in entries:
+            name = entry.get("name")
+            if name is None:
+                continue
+            if entry.get("type") == "directory":
+                yield from self._iter_remote_entries(str(name))
+                continue
+            yield entry
 
     @staticmethod
     def compute_diff(local: dict[str, FileInfo], remote: dict[str, FileInfo], delete_orphaned: bool) -> SyncPlan:

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -186,7 +186,9 @@ class InertiaPlugin(InitPlugin):
         # objects are only fully resolved with runtime attributes
         # (has_sync_callable, signature_model, etc.) after route registration
         # completes.
-        app_config.on_startup.append(_wrap_app_handlers)  # pyright: ignore[reportUnknownMemberType]
+        app_config.on_startup.append(  # pyright: ignore[reportUnknownMemberType]
+            functools.partial(_wrap_app_handlers, component_opt_keys=self.config.component_opt_keys)
+        )
 
         return app_config
 
@@ -293,13 +295,21 @@ def _wrap_handler_fn(handler: "HTTPRouteHandler") -> None:
     handler.has_sync_callable = False
 
 
-def _wrap_app_handlers(app: "Litestar") -> None:
-    """Idempotently wrap every HTTP route handler on the live app.
+def _handler_supports_inertia(handler: "HTTPRouteHandler", *, component_opt_keys: "tuple[str, ...]") -> bool:
+    """Return whether a route handler declares an Inertia page target."""
+    opt: dict[str, Any] = handler.opt or {}
+    return any(bool(opt.get(key)) for key in component_opt_keys)
+
+
+def _wrap_app_handlers(app: "Litestar", *, component_opt_keys: "tuple[str, ...]" = ("component", "page")) -> None:
+    """Idempotently wrap Inertia-capable HTTP route handlers on the live app.
 
     Run after Litestar's full route registration so dynamically-attached
     handlers (controllers instantiated late, plugins, etc.) are also wrapped.
     """
     for route in app.routes:
         for handler in getattr(route, "route_handlers", ()):
-            if isinstance(handler, HTTPRouteHandler):
+            if isinstance(handler, HTTPRouteHandler) and _handler_supports_inertia(
+                handler, component_opt_keys=component_opt_keys
+            ):
                 _wrap_handler_fn(handler)

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -255,7 +255,8 @@ class InertiaResponse(Response[T]):
         once_props = build_once_props_metadata(once_prop_entries) or None
 
         merge_props_list, prepend_props_list, deep_merge_props_list, match_props_on = extract_merge_props(shared_props)
-        shared_props = unwrap_merge_props(shared_props)
+        if merge_props_list or prepend_props_list or deep_merge_props_list or match_props_on:
+            shared_props = unwrap_merge_props(shared_props)
 
         scroll_props = _apply_pagination_props(
             shared_props, route_handler=route_handler, explicit_scroll_props=self.scroll_props

--- a/src/py/litestar_vite/plugin/__init__.py
+++ b/src/py/litestar_vite/plugin/__init__.py
@@ -30,7 +30,7 @@ from litestar.middleware import DefineMiddleware
 from litestar.plugins import CLIPlugin, InitPlugin
 from litestar.static_files import create_static_files_router  # pyright: ignore[reportUnknownVariableType]
 
-from litestar_vite.config import JINJA_INSTALLED, TRUE_VALUES, ExternalDevServer
+from litestar_vite.config import JINJA_INSTALLED, TRUE_VALUES, ExternalDevServer, TypeGenConfig
 from litestar_vite.loader import ViteAssetLoader
 from litestar_vite.plugin._process import ViteProcess
 from litestar_vite.plugin._proxy import (
@@ -788,7 +788,13 @@ class VitePlugin(InitPlugin, CLIPlugin):
         Args:
             app: The Litestar application instance.
         """
-        from litestar_vite.codegen import export_integration_assets
+        if not isinstance(self._config.types, TypeGenConfig):
+            return
+
+        from litestar_vite.codegen import export_integration_assets, typegen_outputs_requested
+
+        if not typegen_outputs_requested(self._config, self._config.types):
+            return
 
         try:
             result = export_integration_assets(app, self._config)
@@ -931,7 +937,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
         await self._asset_loader.initialize()
 
         if self._spa_handler is not None and not self._spa_handler.is_initialized:
-            self._spa_handler.initialize_sync(vite_url=self._proxy_target)
+            await self._spa_handler.initialize_async(vite_url=self._proxy_target)
             log_success("SPA handler initialized")
 
         is_ssr_mode = self._config.wants_html_proxy

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -101,7 +101,9 @@ _HOP_BY_HOP_HEADERS = frozenset({
     "content-encoding",
 })
 
-_WS_REQUEST_SKIP_HEADERS = _HOP_BY_HOP_HEADERS | {
+_REQUEST_SKIP_HEADERS = _HOP_BY_HOP_HEADERS
+
+_WS_REQUEST_SKIP_HEADERS = _REQUEST_SKIP_HEADERS | {
     "host",
     "upgrade",
     "sec-websocket-key",
@@ -148,9 +150,9 @@ def _extract_request_headers(
     if not headers:
         return []
 
-    skip = {_normalize_header_key(name) for name in _HOP_BY_HOP_HEADERS}
+    skip = _REQUEST_SKIP_HEADERS
     if extra_skip_headers is not None:
-        skip.update(_normalize_header_key(name) for name in extra_skip_headers)
+        skip = skip | frozenset(_normalize_header_key(name) for name in extra_skip_headers)
 
     hop_by_hop = set(skip)
     hop_by_hop.update(_collect_connection_tokens(headers))

--- a/src/py/tests/unit/inertia/test_auto_registration.py
+++ b/src/py/tests/unit/inertia/test_auto_registration.py
@@ -31,6 +31,7 @@ from litestar.testing import create_test_client  # pyright: ignore[reportUnknown
 from litestar_vite.config import InertiaConfig, PathConfig, RuntimeConfig, ViteConfig
 from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
 from litestar_vite.inertia.middleware import InertiaMiddleware
+from litestar_vite.inertia.plugin import _wrap_app_handlers
 from litestar_vite.plugin import VitePlugin
 
 
@@ -99,6 +100,34 @@ def test_inertia_envelope_returned_when_auto_registered(
         assert data["props"]["thing"] == "value"
 
 
+def test_inertia_envelope_uses_custom_component_opt_keys(
+    test_app_path: Path, template_config_inertia: TemplateConfig[Any]
+) -> None:
+    config = ViteConfig(
+        mode="template",
+        paths=PathConfig(bundle_dir=test_app_path / "public", resource_dir=test_app_path / "resources"),
+        runtime=RuntimeConfig(dev_mode=True),
+        inertia=InertiaConfig(root_template="index.html.j2", component_opt_keys=("view", "component", "page")),
+    )
+
+    @get("/", opt={"view": "Dashboard"})
+    async def handler() -> dict[str, str]:
+        return {"thing": "value"}
+
+    with create_test_client(
+        plugins=[VitePlugin(config=config)],
+        route_handlers=[handler],
+        template_config=template_config_inertia,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        data = response.json()
+
+        assert data["component"] == "Dashboard"
+        assert data["props"]["thing"] == "value"
+
+
 def test_inertia_html_shell_uses_template_render(
     inertia_vite_config: ViteConfig, template_config_inertia: TemplateConfig[Any]
 ) -> None:
@@ -134,6 +163,49 @@ def test_inertia_middleware_installed_only_once(
         # InertiaMiddleware is appended as a class (not DefineMiddleware).
         count = sum(1 for mw in middleware_classes if mw is InertiaMiddleware)
         assert count == 1, f"InertiaMiddleware registered {count} times, expected 1"
+
+
+def test_wrap_app_handlers_skips_non_inertia_handlers() -> None:
+    @get("/api")
+    async def api_handler() -> dict[str, bool]:
+        return {"ok": True}
+
+    @get("/page", component="Home")
+    async def page_handler() -> dict[str, str]:
+        return {"thing": "value"}
+
+    with create_test_client(route_handlers=[api_handler, page_handler]) as client:
+        _wrap_app_handlers(client.app)
+
+        handlers = {
+            path: handler
+            for route in client.app.routes
+            for handler in getattr(route, "route_handlers", ())
+            if "GET" in getattr(handler, "http_methods", ())
+            for path in getattr(handler, "paths", ())
+        }
+
+        assert getattr(handlers["/api"].fn, "_inertia_wrapped", False) is False
+        assert getattr(handlers["/page"].fn, "_inertia_wrapped", False) is True
+
+
+def test_wrap_app_handlers_honors_custom_component_opt_keys() -> None:
+    @get("/page", opt={"view": "Dashboard"})
+    async def page_handler() -> dict[str, str]:
+        return {"thing": "value"}
+
+    with create_test_client(route_handlers=[page_handler]) as client:
+        _wrap_app_handlers(client.app, component_opt_keys=("view", "component", "page"))
+
+        handlers = {
+            path: handler
+            for route in client.app.routes
+            for handler in getattr(route, "route_handlers", ())
+            if "GET" in getattr(handler, "http_methods", ())
+            for path in getattr(handler, "paths", ())
+        }
+
+        assert getattr(handlers["/page"].fn, "_inertia_wrapped", False) is True
 
 
 class _ReboundPlugin(InitPlugin):

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -101,6 +101,28 @@ async def test_component_inertia_header_enabled(
         assert "content" not in data["props"]
 
 
+async def test_response_skips_merge_unwrap_when_no_merge_props(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {"thing": {"nested": "value"}}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        with patch("litestar_vite.inertia.response.unwrap_merge_props", side_effect=AssertionError("unused")):
+            response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.json()["props"]["thing"] == {"nested": "value"}
+
+
 async def test_component_inertia_flash_header_enabled(
     inertia_plugin: InertiaPlugin,
     vite_plugin: VitePlugin,

--- a/src/py/tests/unit/test_cli.py
+++ b/src/py/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -74,6 +75,16 @@ class FakeExecutor(JSExecutor):
         if self.fail_execute:
             raise ViteExecutionError(args, 1, "boom")
         self.executes.append((args, cwd))
+
+
+class EnvCapturingExecutor(FakeExecutor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.build_typegen_env_values: list[str | None] = []
+
+    def execute(self, args: list[str], cwd: Path) -> None:
+        self.build_typegen_env_values.append(os.environ.get("LITESTAR_VITE_SKIP_BUILD_TYPEGEN"))
+        super().execute(args, cwd)
 
 
 class FakeDeployer:
@@ -231,6 +242,23 @@ def test_cli_run_vite_build_executes(tmp_path: Path) -> None:
     assert generate.called
     assert typegen.called
     assert fake_executor.executes
+
+
+def test_cli_run_vite_build_skips_js_build_typegen_after_cli_typegen(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, types=True)
+    config = app.plugins.get(VitePlugin).config
+    fake_executor = EnvCapturingExecutor()
+    config._executor_instance = fake_executor
+
+    with (
+        patch("litestar_vite.cli._generate_schema_and_routes", return_value=True),
+        patch("litestar_vite.cli._invoke_typegen_cli"),
+        patch("litestar_vite.cli.set_environment"),
+    ):
+        _run_vite_build(config, tmp_path, Mock(), no_build=False, app=app)
+
+    assert fake_executor.build_typegen_env_values == ["1"]
+    assert "LITESTAR_VITE_SKIP_BUILD_TYPEGEN" not in os.environ
 
 
 def test_cli_run_vite_build_failure(tmp_path: Path) -> None:

--- a/src/py/tests/unit/test_codegen.py
+++ b/src/py/tests/unit/test_codegen.py
@@ -1,6 +1,8 @@
 """Unit tests for codegen module."""
 
+from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 from uuid import UUID
 
 from litestar import Litestar, get, post
@@ -21,6 +23,7 @@ from litestar_vite.codegen._ts import (
     ts_type_from_openapi,
     wrap_for_array,
 )
+from litestar_vite.config import PathConfig, TypeGenConfig, ViteConfig
 
 
 def testts_type_for_param_basic_types() -> None:
@@ -43,6 +46,26 @@ def testts_type_for_param_special_formats() -> None:
     assert ts_type_for_param("email") == "string"
     assert ts_type_for_param("uri") == "string"
     assert ts_type_for_param("path") == "string"
+
+
+def test_export_integration_assets_extracts_route_metadata_once(tmp_path: Path) -> None:
+    from litestar_vite.codegen import _routes as routes_module
+    from litestar_vite.codegen import export_integration_assets
+
+    @get("/users/{user_id:int}")
+    async def handler(user_id: FromPath[int]) -> dict[str, int]:
+        return {"user_id": user_id}
+
+    app = Litestar(route_handlers=[handler])
+    config = ViteConfig(
+        paths=PathConfig(root=tmp_path), types=TypeGenConfig(output=tmp_path / "generated", generate_routes=True)
+    )
+    real_extract = routes_module.extract_route_metadata
+
+    with patch("litestar_vite.codegen._routes.extract_route_metadata", wraps=real_extract) as extract:
+        export_integration_assets(app, config)
+
+    extract.assert_called_once()
 
 
 def testts_type_for_param_optional_handling() -> None:

--- a/src/py/tests/unit/test_deploy.py
+++ b/src/py/tests/unit/test_deploy.py
@@ -155,3 +155,28 @@ def test_sync_memory_filesystem(tmp_path: Path) -> None:
     assert "upload:assets/main.js" in actions
     assert "delete:old.js" in actions
     assert result.dry_run is False
+
+
+def test_sync_dry_run_detects_nested_remote_orphans(tmp_path: Path) -> None:
+    bundle = tmp_path / "dist"
+    bundle.mkdir()
+    (bundle / "assets").mkdir()
+    (bundle / "assets" / "main.js").write_text("new")
+    manifest = bundle / "manifest.json"
+    manifest.write_text('{"entry":{"file":"assets/main.js"}}')
+
+    fs = MemoryFileSystem()
+    fs.pipe_file("deploy/assets/main.js", b"new")
+    fs.pipe_file("deploy/assets/nested/old.js", b"old")
+
+    deployer = ViteDeployer(
+        bundle_dir=bundle,
+        manifest_name="manifest.json",
+        deploy_config=DeployConfig(enabled=True, storage_backend="memory://deploy"),
+        fs=fs,
+        remote_path="deploy",
+    )
+
+    result = deployer.sync(dry_run=True)
+
+    assert result.deleted == ["assets/nested/old.js"]

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -84,6 +84,31 @@ def spa_config(temp_resource_dir: Path, monkeypatch: pytest.MonkeyPatch) -> Vite
     )
 
 
+def test_load_manifest_sync_reads_vite_default_manifest_path(tmp_path: Path) -> None:
+    """AppHandler should load Vite's default bundle_dir/.vite/manifest.json."""
+    from litestar_vite.config import PathConfig, RuntimeConfig
+
+    resource_dir = tmp_path / "resources"
+    resource_dir.mkdir()
+    (resource_dir / "index.html").write_text("<html></html>")
+
+    bundle_dir = tmp_path / "public"
+    manifest_path = bundle_dir / ".vite" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text('{"main.js":{"file":"assets/main.hash.js"}}')
+
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(root=tmp_path, resource_dir="resources", bundle_dir="public", static_dir="public"),
+        runtime=RuntimeConfig(dev_mode=False),
+    )
+    handler = AppHandler(config)
+
+    handler._load_manifest_sync()
+
+    assert handler._manifest == {"main.js": {"file": "assets/main.hash.js"}}
+
+
 @pytest.fixture
 def spa_config_dev(temp_resource_dir: Path) -> ViteConfig:
     """Create a ViteConfig for SPA mode in development.

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from litestar import Litestar, get
@@ -19,7 +19,7 @@ from litestar.params import FromPath
 from litestar.template.config import TemplateConfig
 from litestar.testing import TestClient
 
-from litestar_vite.config import PathConfig, RuntimeConfig, ViteConfig
+from litestar_vite.config import PathConfig, RuntimeConfig, TypeGenConfig, ViteConfig
 from litestar_vite.plugin import ProxyHeadersMiddleware, StaticFilesConfig, VitePlugin, ViteProcess, ViteProxyMiddleware
 
 pytestmark = pytest.mark.anyio
@@ -370,6 +370,40 @@ def test_vite_plugin_lifespan_in_production_mode() -> None:
     # Should yield without starting Vite process in production
     with plugin.server_lifespan(app):
         pass  # Should complete without issues
+
+
+def test_vite_plugin_export_types_sync_skips_when_typegen_disabled(tmp_path: Path) -> None:
+    config = ViteConfig(paths=PathConfig(root=tmp_path), runtime=RuntimeConfig(dev_mode=False))
+    plugin = VitePlugin(config=config)
+    plugin._config.types = False
+    app = Litestar(route_handlers=[])
+
+    with patch("litestar_vite.codegen.export_integration_assets") as export:
+        plugin._export_types_sync(app)
+
+    export.assert_not_called()
+
+
+def test_vite_plugin_export_types_sync_skips_when_no_typegen_outputs_requested(tmp_path: Path) -> None:
+    config = ViteConfig(
+        paths=PathConfig(root=tmp_path),
+        runtime=RuntimeConfig(dev_mode=False),
+        types=TypeGenConfig(
+            output=tmp_path / "generated",
+            generate_sdk=False,
+            generate_routes=False,
+            generate_page_props=False,
+            generate_schemas=False,
+            generate_zod=False,
+        ),
+    )
+    plugin = VitePlugin(config=config)
+    app = Litestar(route_handlers=[])
+
+    with patch("litestar_vite.codegen.export_integration_assets") as export:
+        plugin._export_types_sync(app)
+
+    export.assert_not_called()
 
 
 @patch("litestar_vite.plugin.set_environment")
@@ -1591,6 +1625,26 @@ async def test_vite_plugin_proxy_client_created_in_dev_mode_with_vite_proxy() ->
 
     # After lifespan, proxy_client should be closed and set to None
     assert plugin.proxy_client is None
+
+
+async def test_vite_plugin_lifespan_initializes_spa_handler_async() -> None:
+    """SPA handler setup must stay on the running event loop during async lifespan."""
+    config = ViteConfig(runtime=RuntimeConfig(dev_mode=True), mode="spa")
+    plugin = VitePlugin(config=config)
+    plugin._asset_loader = Mock()
+    plugin._asset_loader.initialize = AsyncMock()
+    plugin._spa_handler = Mock()
+    plugin._spa_handler.is_initialized = False
+    plugin._spa_handler.initialize_async = AsyncMock()
+    plugin._spa_handler.initialize_sync = Mock()
+    plugin._spa_handler.shutdown_async = AsyncMock()
+    app = Litestar(route_handlers=[])
+
+    async with plugin.lifespan(app):
+        pass
+
+    plugin._spa_handler.initialize_async.assert_awaited_once_with(vite_url=plugin._proxy_target)
+    plugin._spa_handler.initialize_sync.assert_not_called()
 
 
 async def test_vite_plugin_proxy_client_created_in_dev_mode_with_ssr_proxy() -> None:


### PR DESCRIPTION
## Summary

- reduce repeated work in the typegen/export, route metadata, proxy, deploy, and handler paths
- keep SPA worker lifespan initialization on the active async event loop
- preserve custom Inertia component option keys during startup wrapping
