### PR TITLE
refactor: simplify vite integration internals

### DIFF
--- a/src/js/src/astro.ts
+++ b/src/js/src/astro.ts
@@ -31,9 +31,8 @@ import type { IncomingMessage, ServerResponse } from "node:http"
 import path from "node:path"
 import type { Plugin, ViteDevServer } from "vite"
 import { readBridgeConfig } from "./shared/bridge-schema.js"
-import { DEBOUNCE_MS } from "./shared/constants.js"
 import { normalizeHost, resolveHotFilePath, resolveLitestarPort } from "./shared/network.js"
-import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig } from "./shared/typegen-plugin.js"
+import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig, resolveTypesConfig } from "./shared/typegen-plugin.js"
 import { hmrServerConfig } from "./shared/vite-compat.js"
 
 /**
@@ -307,81 +306,13 @@ function resolveConfig(config: LitestarAstroConfig = {}): ResolvedLitestarAstroC
     litestarPort = resolvedLitestarPort
   }
 
-  // Resolve types config
-  let typesConfig: RequiredTypeGenConfig | false = false
-
-  const defaultTypesOutput = "src/generated"
-  const buildTypeDefaults = (output: string) => ({
-    openapiPath: path.join(output, "openapi.json"),
-    routesPath: path.join(output, "routes.json"),
-    pagePropsPath: path.join(output, "inertia-pages.json"),
-    schemasTsPath: path.join(output, "schemas.ts"),
+  const typesConfig = resolveTypesConfig({
+    requested: config.types,
+    pythonConfig: pythonTypesConfig ?? undefined,
+    defaultOutput: "src/generated",
+    mergePythonWhenTrue: true,
+    mergePythonForObject: true,
   })
-
-  if (config.types === true) {
-    const output = pythonTypesConfig?.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    typesConfig = {
-      enabled: true,
-      output,
-      openapiPath: pythonTypesConfig?.openapiPath ?? defaults.openapiPath,
-      routesPath: pythonTypesConfig?.routesPath ?? defaults.routesPath,
-      pagePropsPath: pythonTypesConfig?.pagePropsPath ?? defaults.pagePropsPath,
-      schemasTsPath: pythonTypesConfig?.schemasTsPath ?? defaults.schemasTsPath,
-      generateZod: pythonTypesConfig?.generateZod ?? false,
-      generateSdk: pythonTypesConfig?.generateSdk ?? true,
-      generateRoutes: pythonTypesConfig?.generateRoutes ?? true,
-      generatePageProps: pythonTypesConfig?.generatePageProps ?? true,
-      generateSchemas: pythonTypesConfig?.generateSchemas ?? true,
-      globalRoute: pythonTypesConfig?.globalRoute ?? false,
-      failOnError: pythonTypesConfig?.failOnError,
-      debounce: DEBOUNCE_MS,
-    }
-  } else if (typeof config.types === "object" && config.types !== null) {
-    const userProvidedOutput = Object.hasOwn(config.types, "output")
-    const output = config.types.output ?? pythonTypesConfig?.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    const openapiFallback = userProvidedOutput ? defaults.openapiPath : (pythonTypesConfig?.openapiPath ?? defaults.openapiPath)
-    const routesFallback = userProvidedOutput ? defaults.routesPath : (pythonTypesConfig?.routesPath ?? defaults.routesPath)
-    const pagePropsFallback = userProvidedOutput ? defaults.pagePropsPath : (pythonTypesConfig?.pagePropsPath ?? defaults.pagePropsPath)
-    const schemasFallback = userProvidedOutput ? defaults.schemasTsPath : (pythonTypesConfig?.schemasTsPath ?? defaults.schemasTsPath)
-
-    typesConfig = {
-      enabled: config.types.enabled ?? true,
-      output,
-      openapiPath: config.types.openapiPath ?? openapiFallback,
-      routesPath: config.types.routesPath ?? routesFallback,
-      pagePropsPath: config.types.pagePropsPath ?? pagePropsFallback,
-      schemasTsPath: config.types.schemasTsPath ?? schemasFallback,
-      generateZod: config.types.generateZod ?? pythonTypesConfig?.generateZod ?? false,
-      generateSdk: config.types.generateSdk ?? pythonTypesConfig?.generateSdk ?? true,
-      generateRoutes: config.types.generateRoutes ?? pythonTypesConfig?.generateRoutes ?? true,
-      generatePageProps: config.types.generatePageProps ?? pythonTypesConfig?.generatePageProps ?? true,
-      generateSchemas: config.types.generateSchemas ?? pythonTypesConfig?.generateSchemas ?? true,
-      globalRoute: config.types.globalRoute ?? pythonTypesConfig?.globalRoute ?? false,
-      failOnError: config.types.failOnError ?? pythonTypesConfig?.failOnError,
-      debounce: config.types.debounce ?? DEBOUNCE_MS,
-    }
-  } else if (config.types !== false && pythonTypesConfig?.enabled) {
-    const output = pythonTypesConfig.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    typesConfig = {
-      enabled: true,
-      output,
-      openapiPath: pythonTypesConfig.openapiPath ?? defaults.openapiPath,
-      routesPath: pythonTypesConfig.routesPath ?? defaults.routesPath,
-      pagePropsPath: pythonTypesConfig.pagePropsPath ?? defaults.pagePropsPath,
-      schemasTsPath: pythonTypesConfig.schemasTsPath ?? defaults.schemasTsPath,
-      generateZod: pythonTypesConfig.generateZod ?? false,
-      generateSdk: pythonTypesConfig.generateSdk ?? true,
-      generateRoutes: pythonTypesConfig.generateRoutes ?? true,
-      generatePageProps: pythonTypesConfig.generatePageProps ?? true,
-      generateSchemas: pythonTypesConfig.generateSchemas ?? true,
-      globalRoute: pythonTypesConfig.globalRoute ?? false,
-      failOnError: pythonTypesConfig.failOnError,
-      debounce: DEBOUNCE_MS,
-    }
-  }
 
   return {
     apiProxy: config.apiProxy ?? "http://localhost:8000",

--- a/src/js/src/helpers/htmx.ts
+++ b/src/js/src/helpers/htmx.ts
@@ -271,7 +271,12 @@ const directives: Dir[] = [
         } else if (v == null || v === false) {
           el.removeAttribute(name)
         } else {
-          el.setAttribute(name, v === true ? "" : String(v))
+          const value = v === true ? "" : String(v)
+          if (isDangerousUrlAttribute(name, value)) {
+            el.removeAttribute(name)
+            return
+          }
+          el.setAttribute(name, value)
         }
       }
     },
@@ -548,7 +553,99 @@ function stripStrings(s: string): string {
     .replace(/'(?:[^'\\]|\\.)*'/g, "") // single-quoted strings
 }
 
+function readQuotedLiteral(s: string, start: number): { end: number; value: string } | null {
+  const quote = s[start]
+  if (quote !== "'" && quote !== '"' && quote !== "`") return null
+
+  let value = ""
+  for (let i = start + 1; i < s.length; i++) {
+    const ch = s[i]
+    if (ch === "\\") {
+      if (i + 1 >= s.length) return null
+      const escaped = readEscapedCharacter(s, i + 1)
+      if (!escaped) return null
+      value += escaped.value
+      i = escaped.end - 1
+      continue
+    }
+    if (quote === "`" && ch === "$" && s[i + 1] === "{") {
+      return null
+    }
+    if (ch === quote) {
+      return { end: i + 1, value }
+    }
+    value += ch
+  }
+  return null
+}
+
+function readEscapedCharacter(s: string, start: number): { end: number; value: string } | null {
+  const ch = s[start]
+  if (ch === "u") {
+    if (s[start + 1] === "{") {
+      const close = s.indexOf("}", start + 2)
+      if (close === -1) return null
+      const codePoint = Number.parseInt(s.slice(start + 2, close), 16)
+      return Number.isFinite(codePoint) ? { end: close + 1, value: String.fromCodePoint(codePoint) } : null
+    }
+    const codePoint = Number.parseInt(s.slice(start + 1, start + 5), 16)
+    return Number.isFinite(codePoint) ? { end: start + 5, value: String.fromCharCode(codePoint) } : null
+  }
+  if (ch === "x") {
+    const codePoint = Number.parseInt(s.slice(start + 1, start + 3), 16)
+    return Number.isFinite(codePoint) ? { end: start + 3, value: String.fromCharCode(codePoint) } : null
+  }
+  const escapes: Record<string, string> = { b: "\b", f: "\f", n: "\n", r: "\r", t: "\t", v: "\v" }
+  return { end: start + 1, value: escapes[ch] ?? ch }
+}
+
+function skipTrivia(s: string, start: number): number {
+  let i = start
+  while (i < s.length) {
+    while (/\s/.test(s[i] ?? "")) i += 1
+    if (s[i] === "/" && s[i + 1] === "/") {
+      i = s.indexOf("\n", i + 2)
+      if (i === -1) return s.length
+      continue
+    }
+    if (s[i] === "/" && s[i + 1] === "*") {
+      const close = s.indexOf("*/", i + 2)
+      if (close === -1) return s.length
+      i = close + 2
+      continue
+    }
+    break
+  }
+  return i
+}
+
+function hasBlockedStringConcatenation(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const first = readQuotedLiteral(s, i)
+    if (!first) continue
+
+    const parts = [first.value]
+    let cursor = skipTrivia(s, first.end)
+    while (s[cursor] === "+") {
+      const nextStart = skipTrivia(s, cursor + 1)
+      const next = readQuotedLiteral(s, nextStart)
+      if (!next) break
+      parts.push(next.value)
+      cursor = skipTrivia(s, next.end)
+    }
+
+    if (parts.length > 1 && BLOCKED_GLOBALS.includes(parts.join(""))) {
+      return true
+    }
+    i = first.end - 1
+  }
+  return false
+}
+
 function isExpressionSafe(s: string): boolean {
+  if (hasBlockedStringConcatenation(s)) {
+    return false
+  }
   const stripped = stripStrings(s)
   return !BLOCKED_RE.test(stripped)
 }
@@ -595,6 +692,11 @@ function compileTextExpr(t: string): ((c: Ctx) => unknown) | null {
 const DANGEROUS_TAGS = new Set(["script", "style", "iframe", "object", "embed", "form", "meta", "link", "base"])
 const DANGEROUS_ATTR_RE = /^on/i
 const DANGEROUS_PROTO_RE = /^\s*javascript\s*:/i
+const URL_ATTRS = new Set(["href", "src", "action"])
+
+function isDangerousUrlAttribute(name: string, value: string): boolean {
+  return URL_ATTRS.has(name.toLowerCase()) && DANGEROUS_PROTO_RE.test(value)
+}
 
 function sanitizeHtml(html: string): string {
   const tpl = document.createElement("template")
@@ -616,7 +718,7 @@ function sanitizeNode(node: Node): void {
       for (const attr of Array.from(el.attributes)) {
         if (DANGEROUS_ATTR_RE.test(attr.name)) {
           el.removeAttribute(attr.name)
-        } else if ((attr.name === "href" || attr.name === "src" || attr.name === "action") && DANGEROUS_PROTO_RE.test(attr.value)) {
+        } else if (isDangerousUrlAttribute(attr.name, attr.value)) {
           el.removeAttribute(attr.name)
         }
       }

--- a/src/js/src/index.ts
+++ b/src/js/src/index.ts
@@ -3,16 +3,15 @@ import type { AddressInfo } from "node:net"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 import colors from "picocolors"
-import { loadEnv, type Plugin, type PluginOption, type ResolvedConfig, type SSROptions, type UserConfig, type ViteDevServer } from "vite"
+import { loadEnv, type Plugin, type PluginOption, type ProxyOptions, type ResolvedConfig, type SSROptions, type UserConfig, type ViteDevServer } from "vite"
 import fullReload, { type Config as FullReloadConfig } from "vite-plugin-full-reload"
 
 import { checkBackendAvailability, type LitestarMeta, loadLitestarMeta } from "./litestar-meta.js"
 import { type BridgeSchema, readBridgeConfig } from "./shared/bridge-schema.js"
-import { DEBOUNCE_MS } from "./shared/constants.js"
 import { createLogger } from "./shared/logger.js"
 import { resolveLitestarPort } from "./shared/network.js"
 import { resolveDefaultSdkClientPlugin } from "./shared/typegen-core.js"
-import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig } from "./shared/typegen-plugin.js"
+import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig, resolveTypesConfig } from "./shared/typegen-plugin.js"
 import { buildInputOptions, hmrServerConfig, resolveUserBuildInput } from "./shared/vite-compat.js"
 
 /**
@@ -436,34 +435,35 @@ function resolveLitestarPlugin(pluginConfig: ResolvedPluginConfig): Plugin {
       const effectiveAppUrl = normalizeAppUrl(env.APP_URL || pythonDefaults?.appUrl || undefined).url ?? undefined
       const proxyHmrClientPort = pythonDefaults?.proxyMode === "vite" ? resolveLitestarPort(pythonDefaults.litestarPort, effectiveAppUrl, process.env) : null
 
-      const withProxyErrorSilencer = (proxyConfig: Record<string, any> | undefined) => {
+      type ServerProxyConfig = NonNullable<NonNullable<UserConfig["server"]>["proxy"]>
+      const withProxyErrorSilencer = (proxyConfig: ServerProxyConfig | undefined): ServerProxyConfig | undefined => {
         if (!proxyConfig) return undefined
-        return Object.fromEntries(
-          Object.entries(proxyConfig).map(([key, value]) => {
-            if (typeof value !== "object" || value === null) {
-              return [key, value]
+        const entries: Array<[string, string | ProxyOptions]> = Object.entries(proxyConfig).map(([key, value]) => {
+          if (typeof value !== "object" || value === null) {
+            return [key, value]
+          }
+          const existingConfigure = value.configure
+          const valueWithWebsocket = Object.hasOwn(value, "ws") ? value : { ...value, ws: true }
+          const configure: NonNullable<ProxyOptions["configure"]> = (proxy, opts) => {
+            proxy.on("error", (err: Error) => {
+              const msg = err.message
+              if (shuttingDown || msg.includes("ECONNREFUSED") || msg.includes("ECONNRESET") || msg.includes("socket hang up")) {
+                return
+              }
+            })
+            if (typeof existingConfigure === "function") {
+              existingConfigure(proxy, opts)
             }
-            const existingConfigure = value.configure
-            const valueWithWebsocket = Object.hasOwn(value, "ws") ? value : { ...value, ws: true }
-            return [
-              key,
-              {
-                ...valueWithWebsocket,
-                configure(proxy: any, opts: any) {
-                  proxy.on("error", (err: any) => {
-                    const msg = String(err?.message ?? "")
-                    if (shuttingDown || msg.includes("ECONNREFUSED") || msg.includes("ECONNRESET") || msg.includes("socket hang up")) {
-                      return
-                    }
-                  })
-                  if (typeof existingConfigure === "function") {
-                    existingConfigure(proxy, opts)
-                  }
-                },
-              },
-            ]
-          }),
-        )
+          }
+          return [
+            key,
+            {
+              ...valueWithWebsocket,
+              configure,
+            },
+          ]
+        })
+        return Object.fromEntries(entries) as ServerProxyConfig
       }
       const explicitServerOrigin = typeof userConfig.server?.origin === "string" && userConfig.server.origin.length > 0 ? userConfig.server.origin : undefined
       const shouldForceDirectServerOrigin = explicitServerOrigin !== undefined || pythonDefaults?.proxyMode === "direct"
@@ -1057,101 +1057,13 @@ function resolvePluginConfig(config: string | string[] | PluginConfig): Resolved
     resolvedConfig.refresh = [{ paths: refreshPaths }]
   }
 
-  // Resolve types configuration
-  // Priority: explicit vite.config.ts > .litestar.json > hardcoded defaults
-  //
-  // Behavior:
-  // - undefined or "auto": read from .litestar.json, disabled if not found
-  // - true: use hardcoded defaults (ignore .litestar.json)
-  // - false: disabled
-  // - object: use explicit config (ignore .litestar.json for types)
-  let typesConfig: RequiredTypeGenConfig | false = false
-  const defaultTypesOutput = "src/generated"
-  const defaultOpenapiPath = path.join(defaultTypesOutput, "openapi.json")
-  const defaultRoutesPath = path.join(defaultTypesOutput, "routes.json")
-  const defaultSchemasTsPath = path.join(defaultTypesOutput, "schemas.ts")
-  const defaultPagePropsPath = path.join(defaultTypesOutput, "inertia-pages.json")
-
-  if (resolvedConfig.types === false) {
-    // Explicitly disabled - do nothing, typesConfig stays false
-  } else if (resolvedConfig.types === true) {
-    // Explicitly enabled with hardcoded defaults (ignores .litestar.json)
-    typesConfig = {
-      enabled: true,
-      output: defaultTypesOutput,
-      openapiPath: defaultOpenapiPath,
-      routesPath: defaultRoutesPath,
-      pagePropsPath: defaultPagePropsPath,
-      schemasTsPath: defaultSchemasTsPath,
-      generateZod: false,
-      generateSdk: true,
-      generateRoutes: true,
-      generatePageProps: true,
-      generateSchemas: true,
-      globalRoute: false,
-      failOnError: undefined,
-      debounce: DEBOUNCE_MS,
-    }
-  } else if (resolvedConfig.types === "auto" || typeof resolvedConfig.types === "undefined") {
-    // Auto mode: read from .litestar.json if available, otherwise disabled
-    if (pythonDefaults?.types) {
-      typesConfig = {
-        enabled: pythonDefaults.types.enabled,
-        output: pythonDefaults.types.output,
-        openapiPath: pythonDefaults.types.openapiPath,
-        routesPath: pythonDefaults.types.routesPath,
-        pagePropsPath: pythonDefaults.types.pagePropsPath,
-        schemasTsPath: pythonDefaults.types.schemasTsPath ?? path.join(pythonDefaults.types.output, "schemas.ts"),
-        generateZod: pythonDefaults.types.generateZod,
-        generateSdk: pythonDefaults.types.generateSdk,
-        generateRoutes: pythonDefaults.types.generateRoutes,
-        generatePageProps: pythonDefaults.types.generatePageProps,
-        generateSchemas: pythonDefaults.types.generateSchemas ?? true,
-        globalRoute: pythonDefaults.types.globalRoute,
-        failOnError: pythonDefaults.types.failOnError,
-        debounce: DEBOUNCE_MS,
-      }
-    }
-    // If no pythonDefaults, typesConfig stays false (disabled)
-  } else if (typeof resolvedConfig.types === "object" && resolvedConfig.types !== null) {
-    // Explicit object config - user overrides
-    const userProvidedOpenapi = Object.hasOwn(resolvedConfig.types, "openapiPath")
-    const userProvidedRoutes = Object.hasOwn(resolvedConfig.types, "routesPath")
-    const userProvidedPageProps = Object.hasOwn(resolvedConfig.types, "pagePropsPath")
-    const userProvidedSchemasTs = Object.hasOwn(resolvedConfig.types, "schemasTsPath")
-
-    const resolvedTypesConfig: RequiredTypeGenConfig = {
-      enabled: resolvedConfig.types.enabled ?? true,
-      output: resolvedConfig.types.output ?? defaultTypesOutput,
-      openapiPath: resolvedConfig.types.openapiPath ?? (resolvedConfig.types.output ? path.join(resolvedConfig.types.output, "openapi.json") : defaultOpenapiPath),
-      routesPath: resolvedConfig.types.routesPath ?? (resolvedConfig.types.output ? path.join(resolvedConfig.types.output, "routes.json") : defaultRoutesPath),
-      pagePropsPath: resolvedConfig.types.pagePropsPath ?? (resolvedConfig.types.output ? path.join(resolvedConfig.types.output, "inertia-pages.json") : defaultPagePropsPath),
-      schemasTsPath: resolvedConfig.types.schemasTsPath ?? (resolvedConfig.types.output ? path.join(resolvedConfig.types.output, "schemas.ts") : defaultSchemasTsPath),
-      generateZod: resolvedConfig.types.generateZod ?? false,
-      generateSdk: resolvedConfig.types.generateSdk ?? true,
-      generateRoutes: resolvedConfig.types.generateRoutes ?? true,
-      generatePageProps: resolvedConfig.types.generatePageProps ?? true,
-      generateSchemas: resolvedConfig.types.generateSchemas ?? true,
-      globalRoute: resolvedConfig.types.globalRoute ?? false,
-      failOnError: resolvedConfig.types.failOnError ?? pythonDefaults?.types?.failOnError,
-      debounce: resolvedConfig.types.debounce ?? DEBOUNCE_MS,
-    }
-
-    // If the user only set output (not openapi/routes/pageProps), cascade them under output for consistency
-    if (!userProvidedOpenapi && resolvedConfig.types.output) {
-      resolvedTypesConfig.openapiPath = path.join(resolvedTypesConfig.output, "openapi.json")
-    }
-    if (!userProvidedRoutes && resolvedConfig.types.output) {
-      resolvedTypesConfig.routesPath = path.join(resolvedTypesConfig.output, "routes.json")
-    }
-    if (!userProvidedPageProps && resolvedConfig.types.output) {
-      resolvedTypesConfig.pagePropsPath = path.join(resolvedTypesConfig.output, "inertia-pages.json")
-    }
-    if (!userProvidedSchemasTs && resolvedConfig.types.output) {
-      resolvedTypesConfig.schemasTsPath = path.join(resolvedTypesConfig.output, "schemas.ts")
-    }
-    typesConfig = resolvedTypesConfig
-  }
+  // Resolve types configuration. Core plugin behavior preserves explicit JS config
+  // as the source of truth; only auto mode reads Python defaults.
+  const typesConfig = resolveTypesConfig({
+    requested: resolvedConfig.types,
+    pythonConfig: pythonDefaults?.types ?? undefined,
+    defaultOutput: "src/generated",
+  })
 
   // Auto-detect Inertia from .litestar.json if not explicitly set.
   // Inertia can be used with spa, hybrid, or template mode; bridge spa metadata
@@ -1336,9 +1248,7 @@ function resolveFullReloadConfig({ refresh }: ResolvedPluginConfig): PluginOptio
   return (config as RefreshConfig[]).flatMap((c) => {
     const plugin = fullReload(c.paths, c.config)
 
-    /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-    /** @ts-ignore */
-    plugin.__litestar_plugin_config = c
+    ;(plugin as Plugin & { __litestar_plugin_config?: RefreshConfig }).__litestar_plugin_config = c
 
     return plugin
   })
@@ -1430,14 +1340,10 @@ function resolveDevServerUrl(address: AddressInfo, config: ResolvedConfig, userC
 }
 
 function isIpv6(address: AddressInfo): boolean {
-  return (
-    address.family === "IPv6" ||
-    // In node >=18.0 <18.4 this was an integer value. This was changed in a minor version.
-    // See: https://github.com/laravel/vite-plugin/issues/103
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore-next-line
-    address.family === 6
-  )
+  const family = address.family as string | number
+  // In node >=18.0 <18.4 this was an integer value. This was changed in a minor version.
+  // See: https://github.com/laravel/vite-plugin/issues/103
+  return family === "IPv6" || family === 6
 }
 
 /**
@@ -1446,9 +1352,8 @@ function isIpv6(address: AddressInfo): boolean {
  * @see https://vite.dev/guide/ssr.html#ssr-externals
  */
 function noExternalInertiaHelpers(config: UserConfig): true | Array<string | RegExp> {
-  /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-  /* @ts-ignore */
-  const userNoExternal = (config.ssr as SSROptions | undefined)?.noExternal
+  const ssrConfig = typeof config.ssr === "object" && config.ssr !== null ? (config.ssr as SSROptions) : undefined
+  const userNoExternal = ssrConfig?.noExternal
   const pluginNoExternal = ["litestar-vite-plugin"]
 
   if (userNoExternal === true) {

--- a/src/js/src/nuxt.ts
+++ b/src/js/src/nuxt.ts
@@ -28,9 +28,8 @@ import path from "node:path"
 import colors from "picocolors"
 import type { Plugin } from "vite"
 import { type BridgeTypesConfig, readBridgeConfig } from "./shared/bridge-schema.js"
-import { DEBOUNCE_MS } from "./shared/constants.js"
 import { normalizeHost, resolveHotFilePath, resolveLitestarPort } from "./shared/network.js"
-import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig } from "./shared/typegen-plugin.js"
+import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig, resolveTypesConfig } from "./shared/typegen-plugin.js"
 import { hmrServerConfig } from "./shared/vite-compat.js"
 
 /**
@@ -250,80 +249,13 @@ function resolveConfig(config: LitestarNuxtConfig = {}): ResolvedNuxtConfig {
     litestarPort = resolvedLitestarPort
   }
 
-  let typesConfig: RequiredTypeGenConfig | false = false
-
-  const defaultTypesOutput = "generated"
-  const buildTypeDefaults = (output: string) => ({
-    openapiPath: path.join(output, "openapi.json"),
-    routesPath: path.join(output, "routes.json"),
-    pagePropsPath: path.join(output, "inertia-pages.json"),
-    schemasTsPath: path.join(output, "schemas.ts"),
+  const typesConfig = resolveTypesConfig({
+    requested: config.types,
+    pythonConfig: pythonTypesConfig ?? undefined,
+    defaultOutput: "generated",
+    mergePythonWhenTrue: true,
+    mergePythonForObject: true,
   })
-
-  if (config.types === true) {
-    const output = pythonTypesConfig?.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    typesConfig = {
-      enabled: true,
-      output,
-      openapiPath: pythonTypesConfig?.openapiPath ?? defaults.openapiPath,
-      routesPath: pythonTypesConfig?.routesPath ?? defaults.routesPath,
-      pagePropsPath: pythonTypesConfig?.pagePropsPath ?? defaults.pagePropsPath,
-      schemasTsPath: pythonTypesConfig?.schemasTsPath ?? defaults.schemasTsPath,
-      generateZod: pythonTypesConfig?.generateZod ?? false,
-      generateSdk: pythonTypesConfig?.generateSdk ?? true,
-      generateRoutes: pythonTypesConfig?.generateRoutes ?? true,
-      generatePageProps: pythonTypesConfig?.generatePageProps ?? true,
-      generateSchemas: pythonTypesConfig?.generateSchemas ?? true,
-      globalRoute: pythonTypesConfig?.globalRoute ?? false,
-      failOnError: pythonTypesConfig?.failOnError,
-      debounce: DEBOUNCE_MS,
-    }
-  } else if (typeof config.types === "object" && config.types !== null) {
-    const userProvidedOutput = Object.hasOwn(config.types, "output")
-    const output = config.types.output ?? pythonTypesConfig?.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    const openapiFallback = userProvidedOutput ? defaults.openapiPath : (pythonTypesConfig?.openapiPath ?? defaults.openapiPath)
-    const routesFallback = userProvidedOutput ? defaults.routesPath : (pythonTypesConfig?.routesPath ?? defaults.routesPath)
-    const pagePropsFallback = userProvidedOutput ? defaults.pagePropsPath : (pythonTypesConfig?.pagePropsPath ?? defaults.pagePropsPath)
-    const schemasFallback = userProvidedOutput ? defaults.schemasTsPath : (pythonTypesConfig?.schemasTsPath ?? defaults.schemasTsPath)
-
-    typesConfig = {
-      enabled: config.types.enabled ?? true,
-      output,
-      openapiPath: config.types.openapiPath ?? openapiFallback,
-      routesPath: config.types.routesPath ?? routesFallback,
-      pagePropsPath: config.types.pagePropsPath ?? pagePropsFallback,
-      schemasTsPath: config.types.schemasTsPath ?? schemasFallback,
-      generateZod: config.types.generateZod ?? pythonTypesConfig?.generateZod ?? false,
-      generateSdk: config.types.generateSdk ?? pythonTypesConfig?.generateSdk ?? true,
-      generateRoutes: config.types.generateRoutes ?? pythonTypesConfig?.generateRoutes ?? true,
-      generatePageProps: config.types.generatePageProps ?? pythonTypesConfig?.generatePageProps ?? true,
-      generateSchemas: config.types.generateSchemas ?? pythonTypesConfig?.generateSchemas ?? true,
-      globalRoute: config.types.globalRoute ?? pythonTypesConfig?.globalRoute ?? false,
-      failOnError: config.types.failOnError ?? pythonTypesConfig?.failOnError,
-      debounce: config.types.debounce ?? DEBOUNCE_MS,
-    }
-  } else if (config.types !== false && pythonTypesConfig?.enabled) {
-    const output = pythonTypesConfig.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    typesConfig = {
-      enabled: true,
-      output,
-      openapiPath: pythonTypesConfig.openapiPath ?? defaults.openapiPath,
-      routesPath: pythonTypesConfig.routesPath ?? defaults.routesPath,
-      pagePropsPath: pythonTypesConfig.pagePropsPath ?? defaults.pagePropsPath,
-      schemasTsPath: pythonTypesConfig.schemasTsPath ?? defaults.schemasTsPath,
-      generateZod: pythonTypesConfig.generateZod ?? false,
-      generateSdk: pythonTypesConfig.generateSdk ?? true,
-      generateRoutes: pythonTypesConfig.generateRoutes ?? true,
-      generatePageProps: pythonTypesConfig.generatePageProps ?? true,
-      generateSchemas: pythonTypesConfig.generateSchemas ?? true,
-      globalRoute: pythonTypesConfig.globalRoute ?? false,
-      failOnError: pythonTypesConfig.failOnError,
-      debounce: DEBOUNCE_MS,
-    }
-  }
 
   return {
     apiProxy: config.apiProxy ?? "http://localhost:8000",

--- a/src/js/src/shared/constants.ts
+++ b/src/js/src/shared/constants.ts
@@ -13,30 +13,6 @@
 export const DEBOUNCE_MS = 300
 
 /**
- * Timeout in milliseconds for backend health checks.
- *
- * Used when checking if the Litestar backend is available
- * before attempting to fetch OpenAPI schema.
- */
-export const BACKEND_CHECK_TIMEOUT_MS = 2000
-
-/**
- * Default asset URL path.
- *
- * Used as fallback when no explicit assetUrl is configured.
- * Should match the default in Python ViteConfig.
- */
-export const DEFAULT_ASSET_URL = "/static/"
-
-/**
- * Default output directory for generated TypeScript types.
- *
- * Used by framework integrations as fallback when no output
- * is specified in Python bridge config or plugin options.
- */
-export const DEFAULT_TYPES_OUTPUT = "src/generated"
-
-/**
  * Pinned fallback package spec for @hey-api/openapi-ts.
  *
  * Keep this in sync with CURRENT_NPM_VERSION_RANGES in the Python scaffold

--- a/src/js/src/shared/typegen-plugin.ts
+++ b/src/js/src/shared/typegen-plugin.ts
@@ -12,6 +12,8 @@ import path from "node:path"
 import colors from "picocolors"
 import type { Plugin, ResolvedConfig, ViteDevServer } from "vite"
 
+import type { BridgeTypesConfig } from "./bridge-schema.js"
+import { DEBOUNCE_MS } from "./constants.js"
 import { debounce } from "./debounce.js"
 import { shouldRegeneratePageProps, shouldRunOpenApiTs, updateOpenApiTsCache, updatePagePropsCache } from "./typegen-cache.js"
 import { runTypeGeneration, type TypeGenCoreConfig, type TypeGenLogger, type TypeGenResult } from "./typegen-core.js"
@@ -44,6 +46,127 @@ export interface TypeGenPluginOptions {
   executor?: string
   /** Whether .litestar.json was present (used for buildStart warnings) */
   hasPythonConfig?: boolean
+}
+
+export interface TypesConfigShape {
+  enabled?: boolean
+  output?: string
+  openapiPath?: string
+  routesPath?: string
+  pagePropsPath?: string
+  schemasTsPath?: string
+  generateZod?: boolean
+  generateSdk?: boolean
+  generateRoutes?: boolean
+  generatePageProps?: boolean
+  generateSchemas?: boolean
+  globalRoute?: boolean
+  failOnError?: boolean
+  debounce?: number
+}
+
+export interface ResolveTypesConfigOptions {
+  requested: boolean | "auto" | TypesConfigShape | undefined
+  pythonConfig?: BridgeTypesConfig
+  defaultOutput: string
+  mergePythonWhenTrue?: boolean
+  mergePythonForObject?: boolean
+}
+
+function buildTypeDefaults(output: string) {
+  return {
+    openapiPath: path.join(output, "openapi.json"),
+    routesPath: path.join(output, "routes.json"),
+    pagePropsPath: path.join(output, "inertia-pages.json"),
+    schemasTsPath: path.join(output, "schemas.ts"),
+  }
+}
+
+function resolveFromPython(pythonConfig: BridgeTypesConfig, defaultOutput: string): RequiredTypeGenConfig {
+  const output = pythonConfig.output ?? defaultOutput
+  const defaults = buildTypeDefaults(output)
+  return {
+    enabled: true,
+    output,
+    openapiPath: pythonConfig.openapiPath ?? defaults.openapiPath,
+    routesPath: pythonConfig.routesPath ?? defaults.routesPath,
+    pagePropsPath: pythonConfig.pagePropsPath ?? defaults.pagePropsPath,
+    schemasTsPath: pythonConfig.schemasTsPath ?? defaults.schemasTsPath,
+    generateZod: pythonConfig.generateZod ?? false,
+    generateSdk: pythonConfig.generateSdk ?? true,
+    generateRoutes: pythonConfig.generateRoutes ?? true,
+    generatePageProps: pythonConfig.generatePageProps ?? true,
+    generateSchemas: pythonConfig.generateSchemas ?? true,
+    globalRoute: pythonConfig.globalRoute ?? false,
+    failOnError: pythonConfig.failOnError,
+    debounce: DEBOUNCE_MS,
+  }
+}
+
+function resolveDefaultTypesConfig(defaultOutput: string): RequiredTypeGenConfig {
+  const defaults = buildTypeDefaults(defaultOutput)
+  return {
+    enabled: true,
+    output: defaultOutput,
+    openapiPath: defaults.openapiPath,
+    routesPath: defaults.routesPath,
+    pagePropsPath: defaults.pagePropsPath,
+    schemasTsPath: defaults.schemasTsPath,
+    generateZod: false,
+    generateSdk: true,
+    generateRoutes: true,
+    generatePageProps: true,
+    generateSchemas: true,
+    globalRoute: false,
+    failOnError: undefined,
+    debounce: DEBOUNCE_MS,
+  }
+}
+
+export function resolveTypesConfig(options: ResolveTypesConfigOptions): RequiredTypeGenConfig | false {
+  const { requested, pythonConfig, defaultOutput, mergePythonWhenTrue = false, mergePythonForObject = false } = options
+
+  if (requested === false) {
+    return false
+  }
+
+  if (requested === true) {
+    if (mergePythonWhenTrue && pythonConfig) {
+      return resolveFromPython(pythonConfig, defaultOutput)
+    }
+    return resolveDefaultTypesConfig(defaultOutput)
+  }
+
+  if (requested === "auto" || typeof requested === "undefined") {
+    return pythonConfig?.enabled ? resolveFromPython(pythonConfig, defaultOutput) : false
+  }
+
+  const userProvidedOutput = Object.hasOwn(requested, "output")
+  const output = requested.output ?? (mergePythonForObject ? pythonConfig?.output : undefined) ?? defaultOutput
+  const defaults = buildTypeDefaults(output)
+  const pathFallback = (key: "openapiPath" | "routesPath" | "pagePropsPath" | "schemasTsPath") => {
+    if (!mergePythonForObject || userProvidedOutput) {
+      return defaults[key]
+    }
+    return pythonConfig?.[key] ?? defaults[key]
+  }
+
+  return {
+    enabled: requested.enabled ?? true,
+    output,
+    openapiPath: requested.openapiPath ?? pathFallback("openapiPath"),
+    routesPath: requested.routesPath ?? pathFallback("routesPath"),
+    pagePropsPath: requested.pagePropsPath ?? pathFallback("pagePropsPath"),
+    schemasTsPath: requested.schemasTsPath ?? pathFallback("schemasTsPath"),
+    generateZod: requested.generateZod ?? (mergePythonForObject ? pythonConfig?.generateZod : undefined) ?? false,
+    generateSdk: requested.generateSdk ?? (mergePythonForObject ? pythonConfig?.generateSdk : undefined) ?? true,
+    generateRoutes: requested.generateRoutes ?? (mergePythonForObject ? pythonConfig?.generateRoutes : undefined) ?? true,
+    generatePageProps: requested.generatePageProps ?? (mergePythonForObject ? pythonConfig?.generatePageProps : undefined) ?? true,
+    generateSchemas: requested.generateSchemas ?? (mergePythonForObject ? pythonConfig?.generateSchemas : undefined) ?? true,
+    globalRoute: requested.globalRoute ?? (mergePythonForObject ? pythonConfig?.globalRoute : undefined) ?? false,
+    failOnError: requested.failOnError ?? pythonConfig?.failOnError,
+    debounce: requested.debounce ?? DEBOUNCE_MS,
+  }
 }
 
 async function getFileMtime(filePath: string): Promise<string> {

--- a/src/js/src/sveltekit.ts
+++ b/src/js/src/sveltekit.ts
@@ -34,9 +34,8 @@ import path from "node:path"
 import colors from "picocolors"
 import type { ViteDevServer } from "vite"
 import { type BridgeTypesConfig, readBridgeConfig } from "./shared/bridge-schema.js"
-import { DEBOUNCE_MS } from "./shared/constants.js"
 import { normalizeHost, resolveHotFilePath, resolveLitestarPort } from "./shared/network.js"
-import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig } from "./shared/typegen-plugin.js"
+import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig, resolveTypesConfig } from "./shared/typegen-plugin.js"
 import { hmrServerConfig } from "./shared/vite-compat.js"
 
 /**
@@ -259,84 +258,13 @@ function resolveConfig(config: LitestarSvelteKitConfig = {}): ResolvedConfig {
     litestarPort = resolvedLitestarPort
   }
 
-  let typesConfig: RequiredTypeGenConfig | false = false
-
-  const defaultTypesOutput = "src/lib/generated"
-  const buildTypeDefaults = (output: string) => ({
-    openapiPath: path.join(output, "openapi.json"),
-    routesPath: path.join(output, "routes.json"),
-    pagePropsPath: path.join(output, "inertia-pages.json"),
-    schemasTsPath: path.join(output, "schemas.ts"),
+  const typesConfig = resolveTypesConfig({
+    requested: config.types,
+    pythonConfig: pythonTypesConfig ?? undefined,
+    defaultOutput: "src/lib/generated",
+    mergePythonWhenTrue: true,
+    mergePythonForObject: true,
   })
-
-  // Priority: explicit Vite config > Python runtime config > disabled
-  if (config.types === true) {
-    // Explicit `types: true` in Vite config - use Python config if available, else defaults
-    const output = pythonTypesConfig?.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    typesConfig = {
-      enabled: true,
-      output,
-      openapiPath: pythonTypesConfig?.openapiPath ?? defaults.openapiPath,
-      routesPath: pythonTypesConfig?.routesPath ?? defaults.routesPath,
-      pagePropsPath: pythonTypesConfig?.pagePropsPath ?? defaults.pagePropsPath,
-      schemasTsPath: pythonTypesConfig?.schemasTsPath ?? defaults.schemasTsPath,
-      generateZod: pythonTypesConfig?.generateZod ?? false,
-      generateSdk: pythonTypesConfig?.generateSdk ?? true,
-      generateRoutes: pythonTypesConfig?.generateRoutes ?? true,
-      generatePageProps: pythonTypesConfig?.generatePageProps ?? true,
-      generateSchemas: pythonTypesConfig?.generateSchemas ?? true,
-      globalRoute: pythonTypesConfig?.globalRoute ?? false,
-      failOnError: pythonTypesConfig?.failOnError,
-      debounce: DEBOUNCE_MS,
-    }
-  } else if (typeof config.types === "object" && config.types !== null) {
-    // Explicit types object in Vite config - merge with Python config
-    const userProvidedOutput = Object.hasOwn(config.types, "output")
-    const output = config.types.output ?? pythonTypesConfig?.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    const openapiFallback = userProvidedOutput ? defaults.openapiPath : (pythonTypesConfig?.openapiPath ?? defaults.openapiPath)
-    const routesFallback = userProvidedOutput ? defaults.routesPath : (pythonTypesConfig?.routesPath ?? defaults.routesPath)
-    const pagePropsFallback = userProvidedOutput ? defaults.pagePropsPath : (pythonTypesConfig?.pagePropsPath ?? defaults.pagePropsPath)
-    const schemasFallback = userProvidedOutput ? defaults.schemasTsPath : (pythonTypesConfig?.schemasTsPath ?? defaults.schemasTsPath)
-
-    typesConfig = {
-      enabled: config.types.enabled ?? true,
-      output,
-      openapiPath: config.types.openapiPath ?? openapiFallback,
-      routesPath: config.types.routesPath ?? routesFallback,
-      pagePropsPath: config.types.pagePropsPath ?? pagePropsFallback,
-      schemasTsPath: config.types.schemasTsPath ?? schemasFallback,
-      generateZod: config.types.generateZod ?? pythonTypesConfig?.generateZod ?? false,
-      generateSdk: config.types.generateSdk ?? pythonTypesConfig?.generateSdk ?? true,
-      generateRoutes: config.types.generateRoutes ?? pythonTypesConfig?.generateRoutes ?? true,
-      generatePageProps: config.types.generatePageProps ?? pythonTypesConfig?.generatePageProps ?? true,
-      generateSchemas: config.types.generateSchemas ?? pythonTypesConfig?.generateSchemas ?? true,
-      globalRoute: config.types.globalRoute ?? pythonTypesConfig?.globalRoute ?? false,
-      failOnError: config.types.failOnError ?? pythonTypesConfig?.failOnError,
-      debounce: config.types.debounce ?? DEBOUNCE_MS,
-    }
-  } else if (config.types !== false && pythonTypesConfig?.enabled) {
-    // No explicit Vite config but Python has types enabled - use Python config
-    const output = pythonTypesConfig.output ?? defaultTypesOutput
-    const defaults = buildTypeDefaults(output)
-    typesConfig = {
-      enabled: true,
-      output,
-      openapiPath: pythonTypesConfig.openapiPath ?? defaults.openapiPath,
-      routesPath: pythonTypesConfig.routesPath ?? defaults.routesPath,
-      pagePropsPath: pythonTypesConfig.pagePropsPath ?? defaults.pagePropsPath,
-      schemasTsPath: pythonTypesConfig.schemasTsPath ?? defaults.schemasTsPath,
-      generateZod: pythonTypesConfig.generateZod ?? false,
-      generateSdk: pythonTypesConfig.generateSdk ?? true,
-      generateRoutes: pythonTypesConfig.generateRoutes ?? true,
-      generatePageProps: pythonTypesConfig.generatePageProps ?? true,
-      generateSchemas: pythonTypesConfig.generateSchemas ?? true,
-      globalRoute: pythonTypesConfig.globalRoute ?? false,
-      failOnError: pythonTypesConfig.failOnError,
-      debounce: DEBOUNCE_MS,
-    }
-  }
 
   return {
     apiProxy: config.apiProxy ?? "http://localhost:8000",

--- a/src/js/tests/helpers/htmx.test.ts
+++ b/src/js/tests/helpers/htmx.test.ts
@@ -120,6 +120,24 @@ describe("htmx extension", () => {
         expect(container.querySelector("a")?.getAttribute("href")).toBe("/path")
       })
 
+      it("removes dangerous URL protocols from href bindings", () => {
+        container.innerHTML = '<a :href="url">Link</a>'
+        swapJson(container, { url: "javascript:alert(1)" })
+        expect(container.querySelector("a")?.hasAttribute("href")).toBe(false)
+      })
+
+      it("removes dangerous URL protocols from src bindings", () => {
+        container.innerHTML = '<img :src="url">'
+        swapJson(container, { url: "javascript:alert(1)" })
+        expect(container.querySelector("img")?.hasAttribute("src")).toBe(false)
+      })
+
+      it("removes dangerous URL protocols from action bindings", () => {
+        container.innerHTML = '<form :action="url"></form>'
+        swapJson(container, { url: "javascript:alert(1)" })
+        expect(container.querySelector("form")?.hasAttribute("action")).toBe(false)
+      })
+
       it("binds id with template literal", () => {
         container.innerHTML = '<div :id="`item-${id}`"></div>'
         swapJson(container, { id: 42 })
@@ -528,6 +546,27 @@ describe("htmx extension", () => {
 
     it("rejects import() expressions", () => {
       expect(__compileExpressionForTest("import('evil-module')")).toBeNull()
+    })
+
+    it("rejects blocked globals reconstructed by string concatenation", () => {
+      expect(__compileExpressionForTest("'doc' + 'ument'")).toBeNull()
+      expect(__compileExpressionForTest('"Fun" + "ction"')).toBeNull()
+      expect(__compileExpressionForTest("'con' + 'structor'")).toBeNull()
+    })
+
+    it("rejects blocked globals reconstructed with escaped string segments", () => {
+      expect(__compileExpressionForTest('"con\\u0073" + "tructor"')).toBeNull()
+      expect(__compileExpressionForTest('"doc\\x75" + "\\u006d" + "ent"')).toBeNull()
+    })
+
+    it("rejects blocked globals reconstructed across comments", () => {
+      expect(__compileExpressionForTest("'con' /* hidden */ + 'structor'")).toBeNull()
+      expect(__compileExpressionForTest("'Fun' // line break\n + 'ction'")).toBeNull()
+    })
+
+    it("allows safe string concatenation", () => {
+      expect(__compileExpressionForTest("'doc' + 'umentation'")).toBeTypeOf("function")
+      expect(__compileExpressionForTest("'Hello, ' + name")).toBeTypeOf("function")
     })
 
     it("rejects self/top/parent global access", () => {

--- a/src/js/tests/shared/typegen-plugin.test.ts
+++ b/src/js/tests/shared/typegen-plugin.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../src/shared/typegen-core.js", () => ({
   runTypeGeneration: mocks.runTypeGeneration,
 }))
 
-import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig } from "../../src/shared/typegen-plugin"
+import { createLitestarTypeGenPlugin, type RequiredTypeGenConfig, resolveTypesConfig } from "../../src/shared/typegen-plugin"
 
 const baseConfig: RequiredTypeGenConfig = {
   enabled: true,
@@ -83,6 +83,58 @@ function createResolvedConfig(command: "build" | "serve") {
     },
   }
 }
+
+describe("resolveTypesConfig", () => {
+  it("disables auto mode when Python did not enable type generation", () => {
+    expect(resolveTypesConfig({ requested: "auto", defaultOutput: "src/generated" })).toBe(false)
+  })
+
+  it("keeps explicit core JS object config authoritative", () => {
+    const resolved = resolveTypesConfig({
+      requested: { output: "js/generated" },
+      pythonConfig: { ...baseConfig, output: "python/generated", generateZod: true },
+      defaultOutput: "src/generated",
+    })
+
+    expect(resolved).toMatchObject({
+      output: "js/generated",
+      openapiPath: "js/generated/openapi.json",
+      generateZod: false,
+      generateSdk: true,
+    })
+  })
+
+  it("merges Python defaults for adapter object config", () => {
+    const resolved = resolveTypesConfig({
+      requested: { generateSdk: false },
+      pythonConfig: { ...baseConfig, output: "python/generated", generateZod: true },
+      defaultOutput: "src/generated",
+      mergePythonForObject: true,
+    })
+
+    expect(resolved).toMatchObject({
+      output: "python/generated",
+      openapiPath: "src/generated/openapi.json",
+      generateZod: true,
+      generateSdk: false,
+    })
+  })
+
+  it("merges Python defaults for adapter true config", () => {
+    const resolved = resolveTypesConfig({
+      requested: true,
+      pythonConfig: { ...baseConfig, output: "python/generated", generateZod: true },
+      defaultOutput: "src/generated",
+      mergePythonWhenTrue: true,
+    })
+
+    expect(resolved).toMatchObject({
+      output: "python/generated",
+      openapiPath: "src/generated/openapi.json",
+      generateZod: true,
+    })
+  })
+})
 
 describe("createLitestarTypeGenPlugin", () => {
   beforeEach(() => {

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -215,7 +215,7 @@ def _prepare_and_build(config: ViteConfig, root_dir: Path, console: Any, app: "L
             raise SystemExit(1)
 
     if config.set_environment:
-        set_environment(config=config, asset_url_override=config.asset_url)
+        set_environment(config=config)
     os.environ.setdefault("VITE_BASE_URL", config.base_url or "/")
 
     ext = config.runtime.external_dev_server
@@ -1090,7 +1090,7 @@ def _resolve_js_cli(
             return local
 
 
-def _run_extra_commands(config: Any, verbose: bool) -> bool:
+def _run_extra_commands(config: ViteConfig, verbose: bool) -> bool:
     """Run additional code-generation commands configured in TypeGenConfig.
 
     These execute after metadata export but before the typegen CLI, giving
@@ -1113,7 +1113,7 @@ def _run_extra_commands(config: Any, verbose: bool) -> bool:
         True if all commands succeeded, False if any failed.
     """
     types_config = config.types
-    if not hasattr(types_config, "extra_commands") or not types_config.extra_commands:
+    if not isinstance(types_config, TypeGenConfig) or not types_config.extra_commands:
         return True
 
     root_dir = config.root_dir or Path.cwd()
@@ -1149,7 +1149,7 @@ def _run_extra_commands(config: Any, verbose: bool) -> bool:
     return all_ok
 
 
-def _invoke_typegen_cli(config: Any, verbose: bool) -> None:
+def _invoke_typegen_cli(config: ViteConfig, verbose: bool) -> None:
     """Invoke the unified TypeScript type generation CLI.
 
     This is the single entry point for TypeScript type generation, used by

--- a/src/py/litestar_vite/doctor.py
+++ b/src/py/litestar_vite/doctor.py
@@ -210,7 +210,6 @@ class ViteDoctor:
 
         self._run_static_checks()
         if runtime_checks:
-            self._check_hotfile_presence()
             self._check_vite_server_reachable()
 
         self._print_report()

--- a/src/py/litestar_vite/handler/_app.py
+++ b/src/py/litestar_vite/handler/_app.py
@@ -32,6 +32,7 @@ from litestar_vite.utils import get_static_resource_path, read_hotfile_url
 
 if TYPE_CHECKING:
     from litestar.connection import Request
+    from litestar.handlers.http_handlers import HTTPRouteHandler
     from litestar.types import Guard  # pyright: ignore[reportUnknownVariableType]
 
     from litestar_vite.config import SPAConfig, ViteConfig
@@ -276,10 +277,7 @@ class AppHandler:
         Returns:
             Absolute path to the manifest file location.
         """
-        bundle_dir = self._config.bundle_dir
-        if not bundle_dir.is_absolute():
-            bundle_dir = self._config.root_dir / bundle_dir
-        return bundle_dir / self._config.manifest_name
+        return self._config.resolve_manifest_path()
 
     async def _load_manifest_async(self) -> None:
         """Asynchronously load the Vite manifest for asset URL transformation."""
@@ -619,7 +617,7 @@ class AppHandler:
 
         return f"{self._config.protocol}://{self._config.host}:{self._config.port}"
 
-    def create_route_handler(self) -> Any:
+    def create_route_handler(self) -> "HTTPRouteHandler":
         """Create a Litestar route handler for the SPA.
 
         Returns:

--- a/src/py/litestar_vite/handler/_routing.py
+++ b/src/py/litestar_vite/handler/_routing.py
@@ -11,6 +11,8 @@ from litestar_vite.plugin import is_litestar_route
 if TYPE_CHECKING:
     from litestar.connection import Request
 
+    from litestar_vite.handler._app import AppHandler
+
 
 _HTML_MEDIA_TYPE = "text/html; charset=utf-8"
 
@@ -58,7 +60,7 @@ def get_route_asset_prefix(request: "Request[Any, Any, Any]") -> str | None:
     return None
 
 
-def get_spa_handler_from_request(request: "Request[Any, Any, Any]") -> Any:
+def get_spa_handler_from_request(request: "Request[Any, Any, Any]") -> "AppHandler":
     """Resolve the SPA handler instance for the current request.
 
     This is stored on the SPA route handler's ``opt`` when the route is created.
@@ -74,14 +76,10 @@ def get_spa_handler_from_request(request: "Request[Any, Any, Any]") -> Any:
     """
     opt = get_route_opt(request)
     handler = opt.get("_vite_spa_handler") if opt is not None else None
-    if handler is not None:
-        try:
-            _ = handler.get_html
-            _ = handler.get_bytes
-        except AttributeError:
-            pass
-        else:
-            return handler
+    from litestar_vite.handler._app import AppHandler
+
+    if isinstance(handler, AppHandler):
+        return handler
     msg = "SPA handler is not available for this route. Ensure AppHandler.create_route_handler() was used."
     raise ImproperlyConfiguredException(msg)
 

--- a/src/py/litestar_vite/inertia/_utils.py
+++ b/src/py/litestar_vite/inertia/_utils.py
@@ -109,12 +109,8 @@ def get_headers(inertia_headers: "InertiaHeaderType") -> "dict[str, Any]":
     }
 
     header: "dict[str, Any]" = {}
-    response: "dict[str, Any]"
-    key: "str"
-    value: "Any"
-
     for key, value in inertia_headers.items():
-        if value is not None:
-            response = inertia_headers_dict[key](value)
-            header.update(response)
+        get_header = inertia_headers_dict.get(key)
+        if value is not None and get_header is not None:
+            header.update(get_header(value))
     return header

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -29,7 +29,7 @@ DEFAULT_DEFERRED_GROUP = "default"
 
 
 @overload
-def lazy(key: str, value_or_callable: "None") -> "StaticProp[str, None]": ...
+def lazy(key: str, value_or_callable: "None" = None) -> "StaticProp[str, None]": ...  # pyright: ignore[reportOverlappingOverload]
 
 
 @overload

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -14,7 +14,7 @@ from litestar.enums import ScopeType
 from litestar.exceptions import WebSocketDisconnect
 from litestar.middleware import AbstractMiddleware
 
-from litestar_vite.plugin._utils import console, is_litestar_route, is_proxy_debug, normalize_prefix
+from litestar_vite.plugin._utils import check_h2_available, console, is_litestar_route, is_proxy_debug, normalize_prefix
 from litestar_vite.utils import read_hotfile_url
 
 if TYPE_CHECKING:
@@ -165,16 +165,6 @@ def _extract_request_headers(
     return filtered
 
 
-def _extract_proxy_response(upstream_resp: "httpx.Response") -> tuple[int, list[tuple[bytes, bytes]], bytes]:  # pyright: ignore[reportUnusedFunction]
-    """Extract status, headers, and body from an httpx response for proxying.
-
-    Returns:
-        A tuple of (status_code, headers, body).
-    """
-    headers = _extract_proxy_response_headers(upstream_resp.headers)
-    return upstream_resp.status_code, headers, upstream_resp.content
-
-
 def _extract_proxy_response_headers(headers: "httpx.Headers") -> list[tuple[bytes, bytes]]:
     """Extract response headers while preserving duplicates and filtering hop-by-hop headers.
 
@@ -272,8 +262,7 @@ class ViteProxyMiddleware(AbstractMiddleware):
     ) -> None:
         super().__init__(app)
         self.hotfile_path = hotfile_path
-        self._cached_target: str | None = None
-        self._cached_target_mtime_ns: int | None = None
+        self._get_target_url = create_target_url_getter(None, hotfile_path, [None], debug_label="vite-proxy")
         self.asset_prefix = normalize_prefix(asset_url) if asset_url else "/"
         self.http2 = http2
         self._plugin = plugin
@@ -300,28 +289,7 @@ class ViteProxyMiddleware(AbstractMiddleware):
         Returns:
             The Vite server URL or None if unavailable.
         """
-        try:
-            hotfile_stat = self.hotfile_path.stat()
-        except (FileNotFoundError, OSError):
-            self._cached_target = None
-            self._cached_target_mtime_ns = None
-            return None
-
-        if self._cached_target is not None and self._cached_target_mtime_ns == hotfile_stat.st_mtime_ns:
-            return self._cached_target.rstrip("/") if self._cached_target else None
-
-        try:
-            hotfile_url = read_hotfile_url(self.hotfile_path)
-        except (FileNotFoundError, OSError):
-            self._cached_target = None
-            self._cached_target_mtime_ns = None
-            return None
-
-        self._cached_target = hotfile_url
-        self._cached_target_mtime_ns = hotfile_stat.st_mtime_ns
-        if is_proxy_debug():
-            console.print(f"[dim][vite-proxy] Target: {hotfile_url}[/]")
-        return hotfile_url.rstrip("/")
+        return self._get_target_url()
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         scope_dict = cast("dict[str, Any]", scope)
@@ -621,12 +589,7 @@ def check_http2_support(enable: bool) -> bool:
     """
     if not enable:
         return False
-    try:
-        import h2  # noqa: F401  # pyright: ignore[reportMissingImports,reportUnusedImport]
-    except ImportError:
-        return False
-    else:
-        return True
+    return check_h2_available()
 
 
 def build_proxy_url(target_url: str, path: str, query: str) -> str:
@@ -640,7 +603,11 @@ def build_proxy_url(target_url: str, path: str, query: str) -> str:
 
 
 def create_target_url_getter(
-    target: "str | None", hotfile_path: "Path | None", cached_target: list["str | None"]
+    target: "str | None",
+    hotfile_path: "Path | None",
+    cached_target: list["str | None"],
+    *,
+    debug_label: str = "ssr-proxy",
 ) -> "Callable[[], str | None]":
     """Create a function that returns the current target URL with mtime-revalidated caching.
 
@@ -670,7 +637,7 @@ def create_target_url_getter(
             cached_target[0] = url
             cached_mtime_ns[0] = hotfile_stat.st_mtime_ns
             if is_proxy_debug():
-                console.print(f"[dim][ssr-proxy] Dynamic target: {url}[/]")
+                console.print(f"[dim][{debug_label}] Dynamic target: {url}[/]")
             return url.rstrip("/")
         except (FileNotFoundError, OSError):
             cached_target[0] = None
@@ -768,6 +735,32 @@ async def _handle_ssr_websocket_proxy(
         pass
 
 
+async def _proxy_ssr_websocket_from_socket(
+    socket: Any, get_target_url: "Callable[[], str | None]", get_hmr_target_url: "Callable[[], str | None]"
+) -> None:
+    """Resolve and proxy an SSR HMR WebSocket from a Litestar socket."""
+    target_url = get_hmr_target_url() or get_target_url()
+    if target_url is None:
+        await socket.close(code=1011, reason="SSR server not running")
+        return
+
+    ws_target = target_url.replace("http://", "ws://").replace("https://", "wss://")
+    scope_dict = dict(socket.scope)
+    ws_path = str(scope_dict.get("path", "/"))
+    query_bytes = cast("bytes", scope_dict.get("query_string", b""))
+    ws_url = build_proxy_url(ws_target, ws_path, query_bytes.decode("utf-8") if query_bytes else "")
+
+    if is_proxy_debug():
+        console.print(f"[dim][ssr-proxy-ws] {ws_path} → {ws_url}[/]")
+
+    headers = extract_forward_headers(scope_dict)
+    subprotocols = extract_subprotocols(scope_dict)
+    typed_subprotocols: list[Subprotocol] = [cast("Subprotocol", p) for p in subprotocols]
+    accept_subprotocol: str | None = subprotocols[0] if subprotocols else None
+    await socket.accept(subprotocols=accept_subprotocol)
+    await _handle_ssr_websocket_proxy(socket, ws_url, headers, typed_subprotocols)
+
+
 class SSRProxyMiddleware(AbstractMiddleware):
     """ASGI middleware that proxies HTTP traffic to an SSR framework dev server.
 
@@ -792,10 +785,9 @@ class SSRProxyMiddleware(AbstractMiddleware):
         plugin: "VitePlugin | None" = None,
     ) -> None:
         super().__init__(app)
-        self._static_target = target
-        self._hotfile_path = hotfile_path
         self._http2 = http2
         self._plugin = plugin
+        self._get_target_url = create_target_url_getter(target, hotfile_path, [target])
 
     def _get_target_base_url(self) -> "str | None":
         """Resolve the framework dev server URL.
@@ -803,17 +795,7 @@ class SSRProxyMiddleware(AbstractMiddleware):
         Returns:
             The framework dev server URL, or None when unavailable.
         """
-        if self._static_target is not None:
-            return self._static_target.rstrip("/")
-        if self._hotfile_path is None:
-            return None
-        try:
-            url = read_hotfile_url(self._hotfile_path)
-            if is_proxy_debug():
-                console.print(f"[dim][ssr-proxy] Target: {url}[/]")
-            return url.rstrip("/")
-        except FileNotFoundError:
-            return None
+        return self._get_target_url()
 
     def _should_proxy(self, scope: "Scope") -> bool:
         """Return True when the request should be proxied to the framework dev server.
@@ -1055,26 +1037,7 @@ def create_ssr_ws_proxy_handler(
     @websocket(path=paths, name="ssr_proxy_ws", opt={"exclude_from_auth": True})
     async def ws_proxy(socket: "WebSocket[Any, Any, Any]") -> None:
         """Proxy WebSocket connections to the SSR framework dev server (HMR)."""
-        target_url = get_hmr_target_url() or get_target_url()
-        if target_url is None:
-            await socket.close(code=1011, reason="SSR server not running")
-            return
-
-        ws_target = target_url.replace("http://", "ws://").replace("https://", "wss://")
-        scope_dict = dict(socket.scope)
-        ws_path = str(scope_dict.get("path", "/"))
-        query_bytes = cast("bytes", scope_dict.get("query_string", b""))
-        ws_url = build_proxy_url(ws_target, ws_path, query_bytes.decode("utf-8") if query_bytes else "")
-
-        if is_proxy_debug():
-            console.print(f"[dim][ssr-proxy-ws] {ws_path} → {ws_url}[/]")
-
-        headers = extract_forward_headers(scope_dict)
-        subprotocols = extract_subprotocols(scope_dict)
-        typed_subprotocols: list[Subprotocol] = [cast("Subprotocol", p) for p in subprotocols]
-        accept_subprotocol: str | None = subprotocols[0] if subprotocols else None
-        await socket.accept(subprotocols=accept_subprotocol)
-        await _handle_ssr_websocket_proxy(socket, ws_url, headers, typed_subprotocols)
+        await _proxy_ssr_websocket_from_socket(socket, get_target_url, get_hmr_target_url)
 
     return ws_proxy
 
@@ -1110,26 +1073,7 @@ def create_ssr_websocket_handler(target: "str | None" = None, hotfile_path: "Pat
         @websocket(path=["/", "/{path:path}"], name="ssr_proxy_ws")
         async def ws_proxy(self, socket: "WebSocket[Any, Any, Any]") -> None:
             """Proxy WebSocket connections to the SSR framework dev server (HMR)."""
-            target_url = get_hmr_target_url() or get_target_url()
-            if target_url is None:
-                await socket.close(code=1011, reason="SSR server not running")
-                return
-
-            ws_target = target_url.replace("http://", "ws://").replace("https://", "wss://")
-            scope_dict = dict(socket.scope)
-            ws_path = str(scope_dict.get("path", "/"))
-            query_bytes = cast("bytes", scope_dict.get("query_string", b""))
-            ws_url = build_proxy_url(ws_target, ws_path, query_bytes.decode("utf-8") if query_bytes else "")
-
-            if is_proxy_debug():
-                console.print(f"[dim][ssr-proxy-ws] {ws_path} → {ws_url}[/]")
-
-            headers = extract_forward_headers(scope_dict)
-            subprotocols = extract_subprotocols(scope_dict)
-            typed_subprotocols: list[Subprotocol] = [cast("Subprotocol", p) for p in subprotocols]
-            accept_subprotocol: str | None = subprotocols[0] if subprotocols else None
-            await socket.accept(subprotocols=accept_subprotocol)
-            await _handle_ssr_websocket_proxy(socket, ws_url, headers, typed_subprotocols)
+            await _proxy_ssr_websocket_from_socket(socket, get_target_url, get_hmr_target_url)
 
     return SSRProxyWebSocketHandler
 

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -105,6 +105,11 @@ def _check_h2_available() -> bool:
     return _h2_available
 
 
+def check_h2_available() -> bool:
+    """Check whether optional HTTP/2 support is available."""
+    return _check_h2_available()
+
+
 def create_proxy_client(
     http2: bool = True,
     timeout: float = 30.0,
@@ -495,7 +500,7 @@ def set_environment(config: "ViteConfig", asset_url_override: str | None = None)
     if config.is_dev_mode:
         os.environ.setdefault("VITE_DEV_MODE", str(config.is_dev_mode))
 
-    config_path = write_runtime_config_file(config, asset_url_override=asset_url_override)
+    config_path = write_runtime_config_file(config)
     os.environ["LITESTAR_VITE_CONFIG_PATH"] = config_path
 
 

--- a/src/py/litestar_vite/utils.py
+++ b/src/py/litestar_vite/utils.py
@@ -1,7 +1,5 @@
 """Utility helpers for litestar-vite."""
 
-from __future__ import annotations
-
 import os
 from importlib.util import find_spec
 from pathlib import Path

--- a/src/py/tests/unit/inertia/test_types.py
+++ b/src/py/tests/unit/inertia/test_types.py
@@ -1,9 +1,18 @@
 """Tests for Inertia types module."""
 
 from dataclasses import dataclass
+from typing import cast
 
+from litestar_vite.inertia._utils import get_headers
 from litestar_vite.inertia.helpers import extract_pagination_scroll_props, is_pagination_container
-from litestar_vite.inertia.types import to_camel_case
+from litestar_vite.inertia.types import InertiaHeaderType, to_camel_case
+
+
+def test_get_headers_ignores_unhandled_optional_keys() -> None:
+    """Unknown optional typed keys should not raise when absent from the header map."""
+    headers = get_headers(cast("InertiaHeaderType", {"enabled": True, "reset": "users"}))
+
+    assert headers == {"X-Inertia": "true"}
 
 
 def test_to_camel_case_simple() -> None:

--- a/src/py/tests/unit/test_doctor.py
+++ b/src/py/tests/unit/test_doctor.py
@@ -321,7 +321,8 @@ def test_doctor_hotfile_missing(doctor: ViteDoctor, tmp_path: Path) -> None:
     ):
         doctor.run(fix=False, runtime_checks=True)
 
-    assert any(i.check == "Hotfile Missing" for i in doctor.issues)
+    hotfile_issues = [i for i in doctor.issues if i.check == "Hotfile Missing"]
+    assert len(hotfile_issues) == 1
 
 
 def test_doctor_env_mismatch(doctor: ViteDoctor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -845,6 +845,31 @@ def test_load_index_html_sync_missing_raises(tmp_path: Path) -> None:
         handler._load_index_html_sync()
 
 
+def test_app_handler_loads_manifest_from_vite_dir(tmp_path: Path) -> None:
+    from litestar_vite.config import PathConfig, RuntimeConfig
+
+    resource_dir = tmp_path / "resources"
+    resource_dir.mkdir()
+    (resource_dir / "index.html").write_text(
+        "<html><body><script type='module' src='/src/main.ts'></script></body></html>"
+    )
+    bundle_dir = tmp_path / "public"
+    manifest_dir = bundle_dir / ".vite"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "manifest.json").write_text('{"src/main.ts":{"file":"assets/main.js"}}')
+
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(root=tmp_path, resource_dir="resources", bundle_dir="public", static_dir="public"),
+        runtime=RuntimeConfig(dev_mode=False),
+    )
+    handler = AppHandler(config)
+
+    handler.initialize_sync()
+
+    assert handler._manifest == {"src/main.ts": {"file": "assets/main.js"}}
+
+
 def test_transform_asset_urls_in_html_uses_manifest(spa_config: ViteConfig) -> None:
     handler = AppHandler(spa_config)
     handler._manifest = {"entry": {"file": "assets/main.js"}}

--- a/src/py/tests/unit/test_http2_proxy.py
+++ b/src/py/tests/unit/test_http2_proxy.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -43,31 +42,30 @@ async def test_proxy_uses_http2_by_default(monkeypatch: pytest.MonkeyPatch, hotf
 
     monkeypatch.setattr(proxy_module.httpx, "AsyncClient", MockAsyncClient)
 
-    # Mock h2 as available
-    mock_h2 = MagicMock()
-    with patch.dict("sys.modules", {"h2": mock_h2}):
-        sent: list[dict[str, object]] = []
+    monkeypatch.setattr(proxy_module, "check_h2_available", lambda: True)
 
-        async def receive() -> dict[str, object]:
-            return {"type": "http.request", "body": b"", "more_body": False}
+    sent: list[dict[str, object]] = []
 
-        async def send(message: dict[str, object]) -> None:
-            sent.append(message)
+    async def receive() -> dict[str, object]:
+        return {"type": "http.request", "body": b"", "more_body": False}
 
-        scope = {
-            "type": "http",
-            "path": "/@vite/client",
-            "raw_path": b"/@vite/client",
-            "query_string": b"",
-            "headers": [],
-            "method": "GET",
-        }
+    async def send(message: dict[str, object]) -> None:
+        sent.append(message)
 
-        async def downstream(_scope: Scope, _receive: Receive, _send: Send) -> None:
-            return None
+    scope = {
+        "type": "http",
+        "path": "/@vite/client",
+        "raw_path": b"/@vite/client",
+        "query_string": b"",
+        "headers": [],
+        "method": "GET",
+    }
 
-        middleware = ViteProxyMiddleware(downstream, hotfile_path=hotfile, http2=True)
-        await middleware(scope, receive, send)  # type: ignore[arg-type]
+    async def downstream(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        return None
+
+    middleware = ViteProxyMiddleware(downstream, hotfile_path=hotfile, http2=True)
+    await middleware(scope, receive, send)  # type: ignore[arg-type]
 
     # HTTP/2 should be enabled
     assert captured_http2 == [True]
@@ -89,17 +87,7 @@ async def test_proxy_falls_back_when_h2_not_installed(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(proxy_module.httpx, "AsyncClient", MockAsyncClient)
 
-    # Mock h2 as NOT available by making import fail
-    import builtins
-
-    original_import = builtins.__import__
-
-    def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
-        if name == "h2":
-            raise ImportError("No module named 'h2'")
-        return original_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", mock_import)
+    monkeypatch.setattr(proxy_module, "check_h2_available", lambda: False)
 
     sent: list[dict[str, object]] = []
 

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -14,7 +14,7 @@ from litestar_vite.plugin import VitePlugin
 from litestar_vite.plugin._proxy import (
     SSRProxyMiddleware,
     ViteProxyMiddleware,
-    _extract_proxy_response,
+    _extract_proxy_response_headers,
     _proxy_stream_response,
     _stream_request_body,
     build_hmr_target_url,
@@ -126,7 +126,7 @@ async def test_proxy_stream_response_streams_chunks_and_closes() -> None:
 pytestmark = pytest.mark.anyio
 
 
-def test_extract_proxy_response_filters_headers() -> None:
+def test_extract_proxy_response_headers_filters_headers() -> None:
     response = httpx.Response(
         200,
         headers=[
@@ -137,13 +137,11 @@ def test_extract_proxy_response_filters_headers() -> None:
         ],
         content=b"ok",
     )
-    status, headers, body = _extract_proxy_response(response)
-    assert status == 200
+    headers = _extract_proxy_response_headers(response.headers)
     assert (b"content-type", b"text/plain") in headers
     assert all(key != b"connection" for key, _ in headers)
     assert headers.count((b"set-cookie", b"a=1")) == 1
     assert headers.count((b"set-cookie", b"b=2")) == 1
-    assert body == b"ok"
 
 
 def test_build_hmr_target_url_includes_query(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- consolidate framework-specific JS integration behavior through shared typegen helpers
- simplify Python proxy/routing utility internals and related typing
- harden HTMX expression filtering for reconstructed blocked globals

## Validation

- `uv run pytest src/py/tests/unit/test_proxy_helpers.py src/py/tests/unit/test_doctor.py src/py/tests/unit/test_handler.py src/py/tests/unit/inertia/test_types.py -q`
- `npm test -- src/js/tests/helpers/htmx.test.ts src/js/tests/shared/typegen-plugin.test.ts`
- `make lint`
- `git diff --check`

Full local test suite intentionally not run; remote CI should cover the complete matrix.
