### PR TITLE
feat(dev-server): restart vite and configure route prefixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,10 @@ Litestar Vite Changelog
 - Fixed Vite dev-server resilience by revalidating hotfile targets by mtime, recovering after missing or replaced hotfiles, tolerating additive/corrupt bridge config files, aligning TLS certificate env vars, and preserving static-files defaults when user overrides leave fields unset. (#312, #314)
 - Fixed ``litestar assets init`` scaffold correctness for framework variants without dedicated directories, Tailwind CSS/PostCSS dependencies and entry inputs, current hey-api/TanStack/Vite template APIs, transactional writes, and non-interactive collision handling. (#313, #314)
 - Updated npm publishing to use trusted publishing with provenance and no npm token. (#314)
+- Fixed Vite dev-server lifecycle handling so unexpected exits are restarted with capped backoff and intentional shutdowns do not trigger restarts.
+- Changed SPA/proxy route-prefix fallbacks so ``/docs`` is no longer reserved unless Litestar actually registers docs there or ``RuntimeConfig.extra_route_prefixes`` includes it.
 - Added ``ViteConfig(enabled=...)`` and ``VITE_ENABLED`` so Vite routes and lifespans can be disabled in CLI, worker, and test contexts while keeping asset CLI commands available. (#301, #310)
+- Added ``RuntimeConfig.extra_route_prefixes`` for deliberately reserving custom backend prefixes from SPA/proxy fallbacks.
 - Fixed ``getCsrfToken()`` so SPA and HTMX helpers can fall back to the ``csrftoken`` or ``XSRF-TOKEN`` cookie when injected page-state sources are absent. (#299, #310)
 
 0.25.0 - 2026-06-25

--- a/docs/usage/development.rst
+++ b/docs/usage/development.rst
@@ -26,6 +26,8 @@ When `use_server_lifespan` is set to `True` (default when `dev_mode=True`), the 
 
     litestar run
 
+If the managed Vite process exits unexpectedly, Litestar Vite restarts it with capped backoff. If the command keeps failing, the restart loop stops and logs the command plus a ``litestar assets doctor`` hint. Normal shutdown through Litestar does not restart the process.
+
 Proxy vs Direct Modes
 ---------------------
 
@@ -33,6 +35,19 @@ Proxy vs Direct Modes
 - **Direct:** classic two-port setup; Vite is exposed on `VITE_HOST:VITE_PORT` and Litestar does not proxy it.
 
 Switch with `VITE_PROXY_MODE=proxy|direct` (or `ViteConfig.runtime.proxy_mode`).
+
+Route Prefix Fallbacks
+----------------------
+
+In SPA and framework proxy modes, backend route prefixes are excluded from the frontend fallback. Litestar Vite always preserves registered Litestar routes and OpenAPI paths, and keeps ``/api`` and ``/schema`` as fallback backend prefixes. ``/docs`` is not reserved by default; it is only excluded when Litestar registers docs there or when you opt in:
+
+.. code-block:: python
+
+    from litestar_vite import RuntimeConfig, ViteConfig
+
+    config = ViteConfig(
+        runtime=RuntimeConfig(extra_route_prefixes=("/docs", "/admin")),
+    )
 
 Origin Behavior in Development
 ------------------------------

--- a/docs/usage/vite.rst
+++ b/docs/usage/vite.rst
@@ -327,6 +327,9 @@ You configure the Litestar backend using the `ViteConfig` object passed to the `
    * - `spa_handler`
      - `bool`
      - Auto-register catch-all SPA route when mode="spa". Defaults to `True`.
+   * - `extra_route_prefixes`
+     - `tuple[str, ...]`
+     - Additional backend prefixes excluded from SPA/proxy fallbacks. Use this to reserve custom paths or deliberately re-add ``"/docs"`` when your backend serves docs there. Defaults to ``()``.
    * - `set_environment`
      - `bool`
      - Set Vite-related environment variables and write `.litestar.json` on startup. Defaults to `True`.

--- a/src/py/litestar_vite/config/_runtime.py
+++ b/src/py/litestar_vite/config/_runtime.py
@@ -160,6 +160,7 @@ class RuntimeConfig:
         spa_handler: Auto-register catch-all SPA route when mode="spa".
         http2: Enable HTTP/2 for proxy HTTP requests (better multiplexing).
             WebSocket traffic (HMR) uses a separate connection and is unaffected.
+        extra_route_prefixes: Additional backend route prefixes excluded from SPA/proxy fallbacks.
     """
 
     dev_mode: bool = field(default_factory=lambda: os.getenv("VITE_DEV_MODE", "False") in TRUE_VALUES)
@@ -210,9 +211,20 @@ class RuntimeConfig:
 
     Environment Variable: LITESTAR_TRUSTED_PROXIES
     """
+    extra_route_prefixes: tuple[str, ...] = ()
+    """Additional backend route prefixes for dev proxy and SPA fallback exclusion.
+
+    Use this to deliberately reserve custom backend paths such as ``"/admin"`` or
+    to re-add ``"/docs"`` when your app serves documentation there.
+    """
 
     def __post_init__(self) -> None:
         """Normalize runtime settings and apply derived defaults."""
+        if isinstance(self.extra_route_prefixes, str):
+            self.extra_route_prefixes = (self.extra_route_prefixes,)
+        else:
+            self.extra_route_prefixes = tuple(self.extra_route_prefixes)
+
         if isinstance(self.external_dev_server, str):
             self.external_dev_server = ExternalDevServer(target=self.external_dev_server)
 

--- a/src/py/litestar_vite/plugin/__init__.py
+++ b/src/py/litestar_vite/plugin/__init__.py
@@ -20,7 +20,7 @@ Example::
 """
 
 import os
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager, contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -631,6 +631,8 @@ class VitePlugin(InitPlugin, CLIPlugin):
             log_info("VitePlugin inert; skipping asset and route wiring")
             return app_config
 
+        self._set_route_prefix_state(app_config.state)
+
         from litestar import Response
         from litestar.connection import Request as LitestarRequest
 
@@ -697,6 +699,14 @@ class VitePlugin(InitPlugin, CLIPlugin):
         app_config.lifespan.append(self.lifespan)  # pyright: ignore[reportUnknownMemberType]
 
         return app_config
+
+    def _set_route_prefix_state(self, state: Any) -> None:
+        """Store route-prefix config on Litestar state for request-time helpers."""
+        extra_prefixes = self._config.runtime.extra_route_prefixes
+        if getattr(state, "litestar_vite_extra_route_prefixes", None) != extra_prefixes:
+            with suppress(AttributeError):
+                del state.litestar_vite_route_prefixes
+        state.litestar_vite_extra_route_prefixes = extra_prefixes
 
     def _check_health(self) -> None:
         """Check if the Vite dev server is running and ready.
@@ -813,6 +823,8 @@ class VitePlugin(InitPlugin, CLIPlugin):
             yield
             return
 
+        self._set_route_prefix_state(app.state)
+
         if self._config.is_dev_mode:
             self._ensure_proxy_target()
 
@@ -902,6 +914,8 @@ class VitePlugin(InitPlugin, CLIPlugin):
             None
         """
         from litestar_vite.loader import ViteAssetLoader
+
+        self._set_route_prefix_state(app.state)
 
         if self._config.set_environment:
             set_environment(config=self._config)

--- a/src/py/litestar_vite/plugin/_process.py
+++ b/src/py/litestar_vite/plugin/_process.py
@@ -4,9 +4,10 @@ import os
 import signal
 import subprocess
 import threading
+import time
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from litestar_vite.exceptions import ViteProcessError
 from litestar_vite.plugin._utils import console
@@ -27,6 +28,7 @@ class ViteProcess:
     _instances: "list[ViteProcess]" = []
     _signals_registered: bool = False
     _original_handlers: "dict[int, Any]" = {}
+    _RESTART_BACKOFFS: ClassVar[tuple[float, ...]] = (1.0, 2.0, 4.0)
 
     def __init__(self, executor: "JSExecutor") -> None:
         """Initialize the Vite process manager.
@@ -35,8 +37,14 @@ class ViteProcess:
             executor: The JavaScript executor to use for running Vite.
         """
         self.process: "subprocess.Popen[Any] | None" = None
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._executor = executor
+        self._restart_command: "list[str] | None" = None
+        self._restart_cwd: "Path | None" = None
+        self._restart_error: "ViteProcessError | None" = None
+        self._stopping = False
+        self._watcher_generation = 0
+        self._watcher_thread: "threading.Thread | None" = None
 
         ViteProcess._instances.append(self)
 
@@ -100,23 +108,14 @@ class ViteProcess:
                     return
 
                 if cwd:
-                    self.process = self._executor.run(command, cwd)
-                    if self.process and self.process.poll() is not None:
-                        stdout, stderr = self.process.communicate()
-                        out_str = stdout.decode(errors="ignore") if stdout else ""
-                        err_str = stderr.decode(errors="ignore") if stderr else ""
-                        console.print(
-                            "[red]Vite process exited immediately.[/]\n"
-                            f"[red]Command:[/] {' '.join(command)}\n"
-                            f"[red]Exit code:[/] {self.process.returncode}\n"
-                            f"[red]Stdout:[/]\n{out_str or '<empty>'}\n"
-                            f"[red]Stderr:[/]\n{err_str or '<empty>'}\n"
-                            "[yellow]Hint: Run `litestar assets doctor` to diagnose configuration issues.[/]"
-                        )
-                        msg = f"Vite process failed to start (exit {self.process.returncode})"
-                        raise ViteProcessError(  # noqa: TRY301
-                            msg, command=command, exit_code=self.process.returncode, stderr=err_str, stdout=out_str
-                        )
+                    self._ensure_tracked()
+                    self._stopping = False
+                    self._restart_error = None
+                    self._restart_command = list(command)
+                    self._restart_cwd = cwd
+                    self.process = self._spawn_process(command, cwd, raise_immediate_exit=True)
+                    self._watcher_generation += 1
+                    self._start_watcher(self._watcher_generation)
         except Exception as e:
             if isinstance(e, ViteProcessError):
                 raise
@@ -138,6 +137,8 @@ class ViteProcess:
         """
         try:
             with self._lock:
+                self._stopping = True
+                self._watcher_generation += 1
                 self._terminate_process_group(timeout)
         except Exception as e:
             console.print(f"[red]Failed to stop Vite process: {e!s}[/]")
@@ -147,6 +148,122 @@ class ViteProcess:
             with suppress(ValueError):
                 ViteProcess._instances.remove(self)
 
+    def _ensure_tracked(self) -> None:
+        """Ensure this process manager participates in global signal cleanup."""
+        if self not in ViteProcess._instances:
+            ViteProcess._instances.append(self)
+
+    def _spawn_process(self, command: list[str], cwd: Path, *, raise_immediate_exit: bool) -> "subprocess.Popen[Any]":
+        """Start a child process and optionally fail fast for immediate exits."""
+        process = self._executor.run(command, cwd)
+        if process and process.poll() is not None:
+            error = self._build_immediate_exit_error(process, command)
+            self._restart_error = error
+            if raise_immediate_exit:
+                raise error
+        return process
+
+    def _build_immediate_exit_error(self, process: "subprocess.Popen[Any]", command: list[str]) -> ViteProcessError:
+        stdout, stderr = process.communicate()
+        out_str = stdout.decode(errors="ignore") if stdout else ""
+        err_str = stderr.decode(errors="ignore") if stderr else ""
+        console.print(
+            "[red]Vite process exited immediately.[/]\n"
+            f"[red]Command:[/] {' '.join(command)}\n"
+            f"[red]Exit code:[/] {process.returncode}\n"
+            f"[red]Stdout:[/]\n{out_str or '<empty>'}\n"
+            f"[red]Stderr:[/]\n{err_str or '<empty>'}\n"
+            "[yellow]Hint: Run `litestar assets doctor` to diagnose configuration issues.[/]"
+        )
+        msg = f"Vite process failed to start (exit {process.returncode})"
+        return ViteProcessError(msg, command=command, exit_code=process.returncode, stderr=err_str, stdout=out_str)
+
+    def _start_watcher(self, generation: int) -> None:
+        """Start a daemon watcher for unexpected process exits."""
+        if self.process is None:
+            return
+        self._watcher_thread = threading.Thread(
+            target=self._watch_process, args=(generation,), name="litestar-vite-process-watchdog", daemon=True
+        )
+        self._watcher_thread.start()
+
+    def _watch_process(self, generation: int) -> None:
+        """Restart the child process after unexpected exits with capped backoff."""
+        attempts = 0
+        last_error: BaseException | None = None
+
+        while True:
+            with self._lock:
+                if self._watcher_generation != generation or self._stopping or self.process is None:
+                    return
+                process = self.process
+                command = self._restart_command
+                cwd = self._restart_cwd
+
+            exit_code = process.wait()
+            self._terminate_exited_process_group(process, timeout=0.5)
+
+            with self._lock:
+                if self._watcher_generation != generation or self._stopping or process is not self.process:
+                    return
+                self.process = None
+                if command is None or cwd is None:
+                    return
+
+            restarted = False
+            while attempts < len(self._RESTART_BACKOFFS):
+                backoff = self._RESTART_BACKOFFS[attempts]
+                attempts += 1
+                console.print(
+                    "[yellow]Vite process exited unexpectedly "
+                    f"(exit {exit_code}). Restarting in {backoff:g}s "
+                    f"(attempt {attempts}/{len(self._RESTART_BACKOFFS)}).[/]"
+                )
+                time.sleep(backoff)
+
+                with self._lock:
+                    if self._watcher_generation != generation or self._stopping:
+                        return
+
+                try:
+                    next_process = self._spawn_process(command, cwd, raise_immediate_exit=False)
+                except BaseException as exc:  # noqa: BLE001
+                    last_error = exc
+                    continue
+
+                with self._lock:
+                    if self._watcher_generation != generation or self._stopping:
+                        self._terminate_specific_process_group(next_process, 0.1)
+                        return
+                    self.process = next_process
+                restarted = True
+                break
+
+            if restarted:
+                continue
+
+            self._record_restart_failure(command, exit_code, last_error)
+            return
+
+    def _record_restart_failure(
+        self, command: list[str], exit_code: int | None, last_error: BaseException | None
+    ) -> None:
+        """Store and log the terminal restart failure."""
+        detail = f"Last restart error: {last_error!s}. " if last_error is not None else ""
+        msg = (
+            f"Vite process exited unexpectedly after {len(self._RESTART_BACKOFFS)} restart attempts "
+            f"(last exit {exit_code}). {detail}"
+            f"Command: {' '.join(command)}. Run `litestar assets doctor` to diagnose configuration issues."
+        )
+        error = ViteProcessError(msg, command=command, exit_code=exit_code)
+        with self._lock:
+            self._restart_error = error
+            self._stopping = True
+            self.process = None
+            with suppress(ValueError):
+                ViteProcess._instances.remove(self)
+        console.print(f"[red]{msg}[/]")
+
     def _terminate_process_group(self, timeout: float) -> None:
         """Terminate the process group, waiting and killing if needed.
 
@@ -155,31 +272,51 @@ class ViteProcess:
         ``start_new_session=True`` so the process id is the group id.
         """
         if not self.process or self.process.poll() is not None:
+            self.process = None
             return
-        pid = self.process.pid
+        process = self.process
+        self._terminate_specific_process_group(process, timeout)
+        self.process = None
+
+    def _terminate_specific_process_group(self, process: "subprocess.Popen[Any]", timeout: float) -> None:
+        """Terminate one process group without changing manager state."""
+        pid = process.pid
         try:
             os.killpg(pid, signal.SIGTERM)
         except AttributeError:
-            self.process.terminate()
+            process.terminate()
         except ProcessLookupError:
             pass
         try:
-            self.process.wait(timeout=timeout)
+            process.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
-            self._force_kill_process_group()
-            self.process.wait(timeout=1.0)
-        finally:
-            self.process = None
+            self._force_kill_specific_process_group(process)
+            process.wait(timeout=1.0)
+
+    def _terminate_exited_process_group(self, process: "subprocess.Popen[Any]", *, timeout: float) -> None:
+        """Best-effort cleanup for child processes left in an exited process group."""
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except AttributeError:
+            return
+        except ProcessLookupError:
+            return
+        time.sleep(timeout)
+        self._force_kill_specific_process_group(process)
 
     def _force_kill_process_group(self) -> None:
         """Force kill the process group if still alive."""
         if not self.process:
             return
-        pid = self.process.pid
+        self._force_kill_specific_process_group(self.process)
+
+    def _force_kill_specific_process_group(self, process: "subprocess.Popen[Any]") -> None:
+        """Force kill a specific process group if still alive."""
+        pid = process.pid
         try:
             os.killpg(pid, signal.SIGKILL)
         except AttributeError:
-            self.process.kill()
+            process.kill()
         except ProcessLookupError:
             pass
 

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -543,6 +543,18 @@ def normalize_prefix(prefix: str) -> str:
 
 class _RoutePrefixesState(Protocol):
     litestar_vite_route_prefixes: tuple[str, ...]
+    litestar_vite_extra_route_prefixes: tuple[str, ...]
+
+
+def _normalize_route_prefix(prefix: str) -> str | None:
+    """Normalize route prefixes for SPA/proxy route exclusion."""
+    normalized = prefix.strip()
+    if not normalized:
+        return None
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    normalized = normalized.rstrip("/")
+    return normalized or None
 
 
 def _route_is_vite_spa(route: Any) -> bool:
@@ -571,8 +583,9 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
 
     Includes:
     - All registered Litestar route paths
-    - OpenAPI schema path (customizable via openapi_config.path)
-    - Common API prefixes as fallback (/api, /schema, /docs)
+    - OpenAPI schema/docs paths registered by Litestar
+    - Common API prefixes as fallback (/api, /schema)
+    - RuntimeConfig.extra_route_prefixes values attached by VitePlugin
 
     Args:
         app: The Litestar application instance.
@@ -603,8 +616,8 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
         # _vite_spa_handler marker AppHandler.create_route_handler sets on opt.
         if _route_is_vite_spa(route):
             continue
-        prefix = route.path.rstrip("/")
-        if prefix:
+        prefix = _normalize_route_prefix(route.path)
+        if prefix is not None:
             prefixes.append(prefix)
         elif route.path == "/":
             has_root_route = True
@@ -613,9 +626,16 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
     if openapi_config is not None:
         schema_path = openapi_config.path
         if schema_path:
-            prefixes.append(schema_path.rstrip("/"))
+            prefix = _normalize_route_prefix(schema_path)
+            if prefix is not None:
+                prefixes.append(prefix)
 
-    prefixes.extend(["/api", "/schema", "/docs"])
+    prefixes.extend(["/api", "/schema"])
+    prefixes.extend(
+        prefix
+        for raw_prefix in getattr(state, "litestar_vite_extra_route_prefixes", ())
+        if (prefix := _normalize_route_prefix(raw_prefix)) is not None
+    )
 
     unique_prefixes = sorted(set(prefixes), key=len, reverse=True)
     if has_root_route:

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -1,8 +1,11 @@
 """Tests for VitePlugin functionality and integration."""
 
 import gc
+import signal
 import sys
-from collections.abc import Generator
+import threading
+import time
+from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock, patch
@@ -459,6 +462,54 @@ def test_vite_plugin_lifespan_defers_vite_process_initialization_until_needed(tm
 # =====================================================
 
 
+class _FakeProcess:
+    _next_pid = 32000
+
+    def __init__(self, *, returncode: int = 1, auto_exit_on_wait: bool = False) -> None:
+        type(self)._next_pid += 1
+        self.pid = type(self)._next_pid
+        self.returncode: int | None = None
+        self._target_returncode = returncode
+        self._auto_exit_on_wait = auto_exit_on_wait
+        self._exited = threading.Event()
+        self.wait_calls: list[float | None] = []
+
+    def poll(self) -> int | None:
+        return self.returncode if self._exited.is_set() else None
+
+    def wait(self, timeout: float | None = None) -> int | None:
+        self.wait_calls.append(timeout)
+        if self._auto_exit_on_wait and not self._exited.is_set():
+            self.exit(self._target_returncode)
+        elif timeout is None:
+            self._exited.wait()
+        elif not self._exited.is_set():
+            self.exit(0)
+        return self.returncode
+
+    def communicate(self) -> tuple[bytes, bytes]:
+        return b"", b""
+
+    def terminate(self) -> None:
+        self.exit(0)
+
+    def kill(self) -> None:
+        self.exit(-9)
+
+    def exit(self, returncode: int | None = None) -> None:
+        self.returncode = self._target_returncode if returncode is None else returncode
+        self._exited.set()
+
+
+def _wait_until(condition: Callable[[], bool], *, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return
+        time.sleep(0.01)
+    assert condition()
+
+
 def test_vite_process_initialization() -> None:
     """Test ViteProcess initialization."""
     executor = Mock()
@@ -466,6 +517,134 @@ def test_vite_process_initialization() -> None:
 
     assert process.process is None
     assert process._lock is not None
+
+
+def test_vite_process_uses_reentrant_lock_for_signal_cleanup() -> None:
+    """Signal cleanup can re-enter stop() while the same thread already holds the process lock."""
+    executor = Mock()
+    process = ViteProcess(executor)
+
+    assert isinstance(process._lock, type(threading.RLock()))
+
+
+def test_vite_process_start_creates_daemon_watcher() -> None:
+    """Successful starts create a private daemon watcher for process exits."""
+    mock_process = _FakeProcess()
+    executor = Mock()
+    executor.run.return_value = mock_process
+
+    process = ViteProcess(executor)
+    process.start(["npm", "run", "dev"], "/test/path")
+
+    watcher = process._watcher_thread
+    assert watcher is not None
+    assert watcher.daemon is True
+
+    process.stop()
+
+
+@patch("litestar_vite.plugin.os.killpg")
+def test_vite_process_restarts_unexpected_exit(mock_killpg: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unexpected process exits are restarted with the original command and cwd."""
+    monkeypatch.setattr(ViteProcess, "_RESTART_BACKOFFS", (0.0, 0.0, 0.0), raising=False)
+    first = _FakeProcess()
+    restarted = _FakeProcess()
+    executor = Mock()
+    executor.run.side_effect = [first, restarted]
+
+    process = ViteProcess(executor)
+    command = ["npm", "run", "dev"]
+    cwd = Path("/test/path")
+    process.start(command, cwd)
+
+    first.exit(1)
+    _wait_until(lambda: executor.run.call_count == 2 and process.process is restarted)
+
+    assert executor.run.call_args_list[1].args == (command, cwd)
+    assert process.process is restarted
+
+    process.stop()
+    assert mock_killpg.called
+
+
+@patch("litestar_vite.plugin._process.time.sleep", return_value=None)
+@patch("litestar_vite.plugin.os.killpg")
+def test_vite_process_crash_cleanup_escalates_before_restart(
+    mock_killpg: Mock, mock_sleep: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected-exit cleanup terminates leftover process-group children before restart."""
+    monkeypatch.setattr(ViteProcess, "_RESTART_BACKOFFS", (0.0,), raising=False)
+    first = _FakeProcess()
+    restarted = _FakeProcess()
+    executor = Mock()
+    executor.run.side_effect = [first, restarted]
+
+    process = ViteProcess(executor)
+    process.start(["npm", "run", "dev"], "/test/path")
+
+    first.exit(1)
+    _wait_until(lambda: executor.run.call_count == 2 and process.process is restarted)
+
+    assert mock_killpg.call_args_list[0].args == (first.pid, signal.SIGTERM)
+    assert any(call.args == (0.5,) for call in mock_sleep.call_args_list)
+    assert any(call.args == (first.pid, signal.SIGKILL) for call in mock_killpg.call_args_list)
+
+    process.stop()
+
+
+@patch("litestar_vite.plugin._process.console")
+def test_vite_process_stops_after_capped_restart_retries(mock_console: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A permanently failing dev server stops after the capped retry sequence."""
+    monkeypatch.setattr(ViteProcess, "_RESTART_BACKOFFS", (0.0, 0.0, 0.0), raising=False)
+    executor = Mock()
+    executor.run.side_effect = [_FakeProcess(auto_exit_on_wait=True) for _ in range(4)]
+
+    process = ViteProcess(executor)
+    process.start(["npm", "run", "dev"], "/test/path")
+
+    _wait_until(lambda: executor.run.call_count == 4 and process.process is None)
+
+    assert process._restart_error is not None
+    assert "Vite process exited unexpectedly after 3 restart attempts" in str(process._restart_error)
+    assert mock_console.print.called
+
+
+@patch("litestar_vite.plugin.os.killpg")
+def test_vite_process_intentional_stop_does_not_restart(mock_killpg: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Intentional stop() must not be treated as a crash by the watcher."""
+    monkeypatch.setattr(ViteProcess, "_RESTART_BACKOFFS", (0.0, 0.0, 0.0), raising=False)
+    mock_process = _FakeProcess()
+    executor = Mock()
+    executor.run.return_value = mock_process
+
+    process = ViteProcess(executor)
+    process.start(["npm", "run", "dev"], "/test/path")
+    process.stop()
+    time.sleep(0.05)
+
+    executor.run.assert_called_once()
+    assert mock_killpg.called
+
+
+def test_vite_process_start_after_stop_is_tracked_for_cleanup() -> None:
+    """A stopped ViteProcess can be started again without losing global cleanup tracking."""
+    first = _FakeProcess()
+    second = _FakeProcess()
+    executor = Mock()
+    executor.run.side_effect = [first, second]
+
+    process = ViteProcess(executor)
+    process.start(["npm", "run", "dev"], "/test/path")
+    process.stop()
+
+    assert process not in ViteProcess._instances
+
+    process.start(["npm", "run", "dev"], "/test/path")
+
+    assert process in ViteProcess._instances
+    assert process.process is second
+
+    process.stop()
 
 
 @patch("litestar_vite.plugin.os.killpg")
@@ -478,7 +657,7 @@ def test_vite_process_stop_removes_stopped_instance(mock_killpg: Mock) -> None:
 
     executor = Mock()
     process = ViteProcess(executor)
-    process.process = mock_process
+    process.process = cast("Any", mock_process)
 
     assert process in ViteProcess._instances
 
@@ -490,8 +669,7 @@ def test_vite_process_stop_removes_stopped_instance(mock_killpg: Mock) -> None:
 
 def test_vite_process_start_success() -> None:
     """Test successful Vite process start."""
-    mock_process = Mock()
-    mock_process.poll.return_value = None  # Process is running
+    mock_process = _FakeProcess()
 
     executor = Mock()
     executor.run.return_value = mock_process
@@ -505,15 +683,16 @@ def test_vite_process_start_success() -> None:
     assert process.process == mock_process
     executor.run.assert_called_once_with(command, Path(cwd))
 
+    process.stop()
+
 
 def test_vite_process_start_already_running() -> None:
     """Test starting Vite process when already running."""
-    mock_process = Mock()
-    mock_process.poll.return_value = None  # Process is running
+    mock_process = _FakeProcess()
 
     executor = Mock()
     process = ViteProcess(executor)
-    process.process = mock_process
+    process.process = cast("Any", mock_process)
 
     command = ["npm", "run", "dev"]
     process.start(command, None)
@@ -1058,7 +1237,7 @@ def test_get_litestar_route_prefixes_with_multiple_routes() -> None:
     # Should include common API prefixes as fallback
     assert "/api" in prefixes
     assert "/schema" in prefixes
-    assert "/docs" in prefixes
+    assert "/docs" not in prefixes
 
 
 def test_get_litestar_route_prefixes_includes_openapi_config_path() -> None:
@@ -1123,7 +1302,7 @@ def test_get_litestar_route_prefixes_with_no_openapi() -> None:
     # Should still include fallback prefixes
     assert "/api" in prefixes
     assert "/schema" in prefixes
-    assert "/docs" in prefixes
+    assert "/docs" not in prefixes
 
 
 def test_get_litestar_route_prefixes_strips_trailing_slashes() -> None:
@@ -1142,6 +1321,43 @@ def test_get_litestar_route_prefixes_strips_trailing_slashes() -> None:
     # Should strip trailing slash
     assert "/users" in prefixes
     assert "/users/" not in prefixes
+
+
+def test_get_litestar_route_prefixes_preserves_configured_openapi_docs_path() -> None:
+    """Configured OpenAPI docs/schema paths remain Litestar prefixes without the fallback /docs."""
+    from litestar.openapi import OpenAPIConfig
+
+    from litestar_vite.plugin import get_litestar_route_prefixes, is_litestar_route
+
+    app = Litestar(route_handlers=[], openapi_config=OpenAPIConfig(title="Test API", version="1.0.0", path="/docs"))
+
+    prefixes = get_litestar_route_prefixes(app)
+
+    assert "/docs" in prefixes
+    assert "/docs/openapi.json" in prefixes
+    assert is_litestar_route("/docs/swagger", app) is True
+
+
+def test_get_litestar_route_prefixes_includes_extra_runtime_prefixes() -> None:
+    """RuntimeConfig.extra_route_prefixes deliberately re-adds custom backend prefixes."""
+    from litestar_vite.plugin import get_litestar_route_prefixes, is_litestar_route
+
+    config = ViteConfig(
+        runtime=RuntimeConfig(dev_mode=False, extra_route_prefixes=("/docs/", "admin", "", "/api", "/admin/reports/"))
+    )
+    plugin = VitePlugin(config=config)
+    app = Litestar(route_handlers=[], plugins=[plugin], openapi_config=None)
+
+    prefixes = get_litestar_route_prefixes(app)
+
+    assert "/admin/reports" in prefixes
+    assert "/docs" in prefixes
+    assert "/admin" in prefixes
+    assert prefixes.count("/api") == 1
+    assert "" not in prefixes
+    assert prefixes.index("/admin/reports") < prefixes.index("/admin")
+    assert is_litestar_route("/docs", app) is True
+    assert is_litestar_route("/docs/client-page", app) is True
 
 
 def test_get_litestar_route_prefixes_sorted_by_length() -> None:
@@ -1336,7 +1552,7 @@ def test_get_litestar_route_prefixes_with_empty_app() -> None:
     # Should still include common fallback prefixes
     assert "/api" in prefixes
     assert "/schema" in prefixes
-    assert "/docs" in prefixes
+    assert "/docs" not in prefixes
 
 
 # =====================================================

--- a/src/py/tests/unit/test_runtime_config.py
+++ b/src/py/tests/unit/test_runtime_config.py
@@ -3,8 +3,24 @@ from pathlib import Path
 import pytest
 from litestar.serialization import decode_json
 
-from litestar_vite.config import PathConfig, ViteConfig
+from litestar_vite.config import PathConfig, RuntimeConfig, ViteConfig
 from litestar_vite.plugin._utils import _path_for_bridge, write_runtime_config_file
+
+
+def test_runtime_config_extra_route_prefixes_default_is_immutable() -> None:
+    first = RuntimeConfig()
+    second = RuntimeConfig()
+
+    assert first.extra_route_prefixes == ()
+    assert second.extra_route_prefixes == ()
+    assert isinstance(first.extra_route_prefixes, tuple)
+
+
+def test_runtime_config_extra_route_prefixes_normalizes_to_tuple() -> None:
+    config = RuntimeConfig(extra_route_prefixes=["/docs", "admin"])  # type: ignore[arg-type]
+
+    assert config.extra_route_prefixes == ("/docs", "admin")
+    assert isinstance(config.extra_route_prefixes, tuple)
 
 
 def test_runtime_config_includes_litestar_version(tmp_path: Path, monkeypatch: object) -> None:


### PR DESCRIPTION
## Summary

- add configurable Litestar route prefixes for dev-server proxy decisions
- restart the managed Vite process after unexpected exits
- clean up crashed process groups before restart and document the new development behavior