### PR TITLE
fix: address 0.26.0 release review regressions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,20 +10,32 @@ Litestar Vite Changelog
 0.26.0 - 2026-07-05
 -------------------
 
+Migration notes
+~~~~~~~~~~~~~~~
+
+- Inertia asset-version mismatches now follow the protocol more strictly: stale ``GET`` visits receive the ``409`` refresh response, while stale non-``GET`` submissions continue to their handlers. Review handlers that relied on non-``GET`` mismatch short-circuiting.
+- Inertia infinite-scroll metadata is now emitted as ``scrollProps`` keyed by data prop name. Frontend code that read a single flat scroll config should read ``scrollProps.<propName>`` instead.
+- Type generation now fails production builds by default when generation fails. Set ``TypeGenConfig(fail_on_error=False)`` or ``types.failOnError = false`` to keep warn-only build behavior.
+
 - Fixed Inertia asset-version mismatch handling so only ``GET`` requests can return the protocol ``409`` refresh response; non-GET submissions now continue to their handlers instead of being downgraded and losing the request body. (#306)
 - Fixed ``share()`` with Inertia redirects so top-level sync special props are materialized before session storage and async special props are skipped instead of crashing session serialization. (#306)
+- Fixed request-scope Inertia shared props so they are still rendered on routes without session middleware.
 - Fixed Inertia infinite-scroll ``scrollProps`` to emit a record keyed by data prop name, matching the official client protocol. (#306)
+- Fixed explicit Inertia ``scroll_props=`` responses so metadata is keyed by the returned data prop when there is a single route prop.
 - Fixed auto-wrapped Inertia responses so non-Inertia JSON handlers preserve Litestar's resolved ``201``/``204`` status codes while user-created ``InertiaResponse`` statuses still win. (#306)
 - Fixed Precognition validation success handling for handlers without an explicit ``request`` parameter by using the middleware request context. (#306)
 - Fixed Inertia SSR serialization so app, handler, and response type encoders are honored for custom page prop values. (#306)
 - Fixed Inertia partial reloads so ``deferredProps`` metadata is omitted on partial responses while initial responses still advertise deferred props. (#306)
+- Fixed Inertia partial reloads so plain dict route props honor ``X-Inertia-Partial-Data`` and ``X-Inertia-Partial-Except`` independently.
 - Fixed ``litestar assets init`` so generated ``package.json`` files no longer emit duplicate dependency keys. (#302, #303)
 - Fixed type generation so the JS plugin resolves local ``@hey-api/openapi-ts`` installs first, uses a pinned package-manager fallback when needed, fails production builds loudly by default, and lets ``TypeGenConfig(fail_on_error=False)`` or ``types.failOnError = false`` opt out. (#311, #314)
+- Fixed Deno type-generation fallback execution when the providing npm package exposes a binary with a different name.
 - Fixed type generation reliability for generated outputs by preserving queued dev regenerations, checking that expected output files exist before reusing caches, watching ``routes.json``, emitting ``static-props.ts`` from the shared CLI path, and handling semantic aliases and nested hey-api operation types. (#311, #314)
 - Fixed Vite dev-server resilience by revalidating hotfile targets by mtime, recovering after missing or replaced hotfiles, tolerating additive/corrupt bridge config files, aligning TLS certificate env vars, and preserving static-files defaults when user overrides leave fields unset. (#312, #314)
 - Fixed ``litestar assets init`` scaffold correctness for framework variants without dedicated directories, Tailwind CSS/PostCSS dependencies and entry inputs, current hey-api/TanStack/Vite template APIs, transactional writes, and non-interactive collision handling. (#313, #314)
 - Updated npm publishing to use trusted publishing with provenance and no npm token. (#314)
 - Fixed Vite dev-server lifecycle handling so unexpected exits are restarted with capped backoff and intentional shutdowns do not trigger restarts. (#317)
+- Fixed Vite dev-server auto-restart so each recovered crash gets a fresh retry budget instead of exhausting the lifetime budget.
 - Changed SPA/proxy route-prefix fallbacks so ``/docs`` is no longer reserved unless Litestar actually registers docs there or ``RuntimeConfig.extra_route_prefixes`` includes it. (#317)
 - Added ``ViteConfig(enabled=...)`` and ``VITE_ENABLED`` so Vite routes and lifespans can be disabled in CLI, worker, and test contexts while keeping asset CLI commands available. (#301, #310)
 - Added ``RuntimeConfig.extra_route_prefixes`` for deliberately reserving custom backend prefixes from SPA/proxy fallbacks. (#317)

--- a/src/js/src/install-hint.ts
+++ b/src/js/src/install-hint.ts
@@ -106,6 +106,23 @@ export interface PackageExecutorArgvOptions {
   binName?: string
 }
 
+function getPackageNameFromSpec(packageSpec: string): string {
+  if (packageSpec.startsWith("@")) {
+    const versionIndex = packageSpec.indexOf("@", packageSpec.indexOf("/") + 1)
+    return versionIndex === -1 ? packageSpec : packageSpec.slice(0, versionIndex)
+  }
+  const versionIndex = packageSpec.indexOf("@")
+  return versionIndex === -1 ? packageSpec : packageSpec.slice(0, versionIndex)
+}
+
+function resolveDenoPackageSpec(packageSpec: string, binName?: string): string {
+  if (!binName) return packageSpec
+
+  const packageName = getPackageNameFromSpec(packageSpec)
+  const defaultBinName = packageName.split("/").pop()
+  return defaultBinName === binName ? packageSpec : `${packageSpec}/${binName}`
+}
+
 export function resolvePackageExecutorArgv(args: string[], executor?: string, options: PackageExecutorArgvOptions = {}): string[] {
   const runtime = executor || detectExecutor()
   const { packageSpec, binName } = options
@@ -113,7 +130,7 @@ export function resolvePackageExecutorArgv(args: string[], executor?: string, op
     case "bun":
       return ["bunx", ...(packageSpec ? [packageSpec, ...args] : args)]
     case "deno":
-      return ["deno", "run", "-A", ...(packageSpec ? [`npm:${packageSpec}`, ...args] : args)]
+      return ["deno", "run", "-A", ...(packageSpec ? [`npm:${resolveDenoPackageSpec(packageSpec, binName)}`, ...args] : args)]
     case "pnpm":
       return ["pnpm", "dlx", ...(packageSpec ? [packageSpec, ...args] : args)]
     case "yarn":

--- a/src/js/tests/install-hint.test.ts
+++ b/src/js/tests/install-hint.test.ts
@@ -387,5 +387,14 @@ describe("install-hint", () => {
         "openapi-ts.config.ts",
       ])
     })
+
+    it("uses the package binary path for deno when package name and bin differ", () => {
+      expect(
+        resolvePackageExecutorArgv(["--verbose"], "deno", {
+          packageSpec: "litestar-vite-plugin",
+          binName: "litestar-vite-typegen",
+        }),
+      ).toEqual(["deno", "run", "-A", "npm:litestar-vite-plugin/litestar-vite-typegen", "--verbose"])
+    })
   })
 })

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -1013,7 +1013,8 @@ def _get_package_executor_cmd(executor: "str | None", binary: str, *, package_na
         case "bun":
             return ["bunx", "--package", package, binary] if package_name else ["bunx", binary]
         case "deno":
-            return ["deno", "run", "-A", f"npm:{package}"]
+            deno_package = f"{package}/{binary}" if package != binary else package
+            return ["deno", "run", "-A", f"npm:{deno_package}"]
         case "yarn":
             return ["yarn", "dlx", "--package", package, binary] if package_name else ["yarn", "dlx", binary]
         case "pnpm":

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1375,15 +1375,28 @@ def get_shared_props(
     once_props_entries: "list[_OncePropEntry]" = []
     error_bag = request.headers.get("X-Inertia-Error-Bag", None)
 
+    session_available = True
+    session_shared_props: Mapping[str, Any] = {}
+    scope_shared_props = cast("dict[str, Any]", request.scope).pop(_RAW_SHARED_SCOPE_KEY, {})
     try:
         errors = request.session.pop("_errors", {})
-        session_shared_props = request.session.pop("_shared", {})
-        scope_shared_props = cast("dict[str, Any]", request.scope).pop(_RAW_SHARED_SCOPE_KEY, {})
-        shared_props = (
-            {**cast("Mapping[str, Any]", session_shared_props), **cast("Mapping[str, Any]", scope_shared_props)}
-            if isinstance(session_shared_props, Mapping) and isinstance(scope_shared_props, Mapping)
-            else cast("dict[str,Any]", session_shared_props)
+        raw_session_shared_props = request.session.pop("_shared", {})
+    except (AttributeError, ImproperlyConfiguredException):
+        session_available = False
+        msg = "Unable to generate all shared props.  A valid session was not found for this request."
+        request.logger.warning(msg)
+    else:
+        session_shared_props = (
+            cast("Mapping[str, Any]", raw_session_shared_props) if isinstance(raw_session_shared_props, Mapping) else {}
         )
+
+    shared_props = (
+        {**session_shared_props, **cast("Mapping[str, Any]", scope_shared_props)}
+        if isinstance(scope_shared_props, Mapping)
+        else dict(session_shared_props)
+    )
+
+    try:
         inertia_plugin = cast("InertiaPlugin", request.app.plugins.get("InertiaPlugin"))
 
         once_props_entries = _extract_once_prop_entries(shared_props, partial_data, partial_except)
@@ -1407,20 +1420,22 @@ def get_shared_props(
             else:
                 props[key] = value
 
-        for message in cast("list[dict[str,Any]]", request.session.pop("_messages", [])):
-            flash[message["category"]].append(message["message"])
+        if session_available:
+            for message in cast("list[dict[str,Any]]", request.session.pop("_messages", [])):
+                flash[message["category"]].append(message["message"])
 
         for key, value in inertia_plugin.config.extra_static_page_props.items():
             if should_render(value, partial_data, partial_except, key=key):
                 props[key] = value
 
-        for session_prop in inertia_plugin.config.extra_session_page_props:
-            if (
-                session_prop not in props
-                and session_prop in request.session
-                and should_render(None, partial_data, partial_except, key=session_prop)
-            ):
-                props[session_prop] = request.session.get(session_prop)
+        if session_available:
+            for session_prop in inertia_plugin.config.extra_session_page_props:
+                if (
+                    session_prop not in props
+                    and session_prop in request.session
+                    and should_render(None, partial_data, partial_except, key=session_prop)
+                ):
+                    props[session_prop] = request.session.get(session_prop)
 
     except (AttributeError, ImproperlyConfiguredException):
         msg = "Unable to generate all shared props.  A valid session was not found for this request."

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -208,6 +208,7 @@ class InertiaResponse(Response[T]):
         content: Any = self.content
         route_content: Any | None = None
         route_once_props: "list[tuple[str, str]]" = []
+        route_prop_keys: list[str] = []
 
         # v2.2+ protocol: Extract deferred props metadata before filtering.
         # Route props override shared props with the same key, so discard any
@@ -225,7 +226,7 @@ class InertiaResponse(Response[T]):
             filtered_content: Any = lazy_render(cast("Any", content), partial_data, partial_except, except_once_props)
             if filtered_content is not None:
                 route_content = filtered_content
-        elif isinstance(content, Mapping) and partial_data and partial_except:
+        elif isinstance(content, Mapping) and (partial_data or partial_except):
             route_content = lazy_render(
                 cast("Mapping[str, Any]", content), partial_data, partial_except, except_once_props
             )
@@ -239,11 +240,14 @@ class InertiaResponse(Response[T]):
                     if self.prop_filter is not None and not self.prop_filter.should_include(str(key)):
                         continue
                     shared_props[key] = value
+                    route_prop_keys.append(str(key))
             elif is_pagination_container(route_content):
                 prop_key = _get_route_prop_key(route_handler)
                 shared_props[prop_key] = route_content
+                route_prop_keys.append(prop_key)
             else:
                 shared_props["content"] = route_content
+                route_prop_keys.append("content")
 
         # Drop keys this partial reload just resolved, or the client loops on loadDeferredProps.
         deferred_props = _resolve_deferred_props(deferred_props_map, partial_data, is_partial_render)
@@ -259,7 +263,10 @@ class InertiaResponse(Response[T]):
             shared_props = unwrap_merge_props(shared_props)
 
         scroll_props = _apply_pagination_props(
-            shared_props, route_handler=route_handler, explicit_scroll_props=self.scroll_props
+            shared_props,
+            route_handler=route_handler,
+            explicit_scroll_props=self.scroll_props,
+            explicit_scroll_props_key=_get_explicit_scroll_props_key(route_prop_keys, route_handler),
         )
 
         encrypt_history = _resolve_encrypt_history(self.encrypt_history, inertia_plugin)
@@ -1057,12 +1064,22 @@ def _get_route_prop_key(route_handler: Any) -> str:
     return (route_handler.opt.get("key", "items") if route_handler else "items") or "items"
 
 
+def _get_explicit_scroll_props_key(route_prop_keys: list[str], route_handler: Any) -> str:
+    if len(route_prop_keys) == 1:
+        return route_prop_keys[0]
+    return _get_route_prop_key(route_handler)
+
+
 def _apply_pagination_props(
-    shared_props: "dict[str, Any]", *, route_handler: Any, explicit_scroll_props: "ScrollPropsConfig | None"
+    shared_props: "dict[str, Any]",
+    *,
+    route_handler: Any,
+    explicit_scroll_props: "ScrollPropsConfig | None",
+    explicit_scroll_props_key: str,
 ) -> "dict[str, ScrollPropsConfig] | None":
     scroll_props_map: "dict[str, ScrollPropsConfig]" = {}
     if explicit_scroll_props is not None:
-        scroll_props_map[_get_route_prop_key(route_handler)] = explicit_scroll_props
+        scroll_props_map[explicit_scroll_props_key] = explicit_scroll_props
 
     infinite_scroll_enabled = bool(route_handler and route_handler.opt.get("infinite_scroll", False))
     for key in tuple(shared_props):

--- a/src/py/litestar_vite/plugin/_process.py
+++ b/src/py/litestar_vite/plugin/_process.py
@@ -29,6 +29,7 @@ class ViteProcess:
     _signals_registered: bool = False
     _original_handlers: "dict[int, Any]" = {}
     _RESTART_BACKOFFS: ClassVar[tuple[float, ...]] = (1.0, 2.0, 4.0)
+    _RESTART_STABILITY_SECONDS: ClassVar[float] = 5.0
 
     def __init__(self, executor: "JSExecutor") -> None:
         """Initialize the Vite process manager.
@@ -200,7 +201,9 @@ class ViteProcess:
                 command = self._restart_command
                 cwd = self._restart_cwd
 
+            wait_started = time.monotonic()
             exit_code = process.wait()
+            process_runtime = time.monotonic() - wait_started
             self._terminate_exited_process_group(process, timeout=0.5)
 
             with self._lock:
@@ -209,6 +212,10 @@ class ViteProcess:
                 self.process = None
                 if command is None or cwd is None:
                     return
+
+            if process_runtime >= self._RESTART_STABILITY_SECONDS:
+                attempts = 0
+                last_error = None
 
             restarted = False
             while attempts < len(self._RESTART_BACKOFFS):

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from litestar import Request, get
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
@@ -40,6 +41,27 @@ def test_get_shared_props_includes_csrf_token_from_scope() -> None:
     shared_props = get_shared_props(request)
 
     assert shared_props["csrf_token"] == "scope-csrf-token"
+
+
+def test_get_shared_props_includes_scope_props_when_session_is_unavailable() -> None:
+    """Request-scope shared props should survive requests excluded from session middleware."""
+    from litestar_vite.inertia.helpers import _RAW_SHARED_SCOPE_KEY, get_shared_props
+
+    request = MagicMock()
+    request.headers.get.return_value = None
+    request.session.pop.side_effect = ImproperlyConfiguredException("No session")
+    request.scope = {_RAW_SHARED_SCOPE_KEY: {"auth": {"user": "Ada"}}}
+    request.logger = MagicMock()
+
+    inertia_plugin = MagicMock()
+    inertia_plugin.config.extra_static_page_props = {}
+    inertia_plugin.config.extra_session_page_props = []
+    request.app.plugins.get.return_value = inertia_plugin
+
+    shared_props = get_shared_props(request)
+
+    assert shared_props["auth"] == {"user": "Ada"}
+    assert _RAW_SHARED_SCOPE_KEY not in request.scope
 
 
 def test_scroll_props_helper_creates_config() -> None:
@@ -255,7 +277,7 @@ async def test_partial_reload_filters_shared_props(
         share(request, "user", {"name": "Alice"})
         share(request, "settings", {"theme": "dark"})
         share(request, "notifications", ["msg1", "msg2"])
-        # Route handler props are always included
+        # Route handler props are filtered by the same partial-data keys
         return {"posts": [1, 2, 3], "comments": [4, 5, 6]}
 
     with create_test_client(
@@ -286,9 +308,9 @@ async def test_partial_reload_filters_shared_props(
         partial_props = partial_response.json()["props"]
         # user is requested and present in shared props
         assert "user" in partial_props
-        # Route handler props are always included (posts, comments)
+        # Route handler props follow partial-data filtering
         assert "posts" in partial_props
-        assert "comments" in partial_props
+        assert "comments" not in partial_props
         # Shared props not requested are filtered out
         assert "settings" not in partial_props
         assert "notifications" not in partial_props

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -101,6 +101,38 @@ async def test_component_inertia_header_enabled(
         assert "content" not in data["props"]
 
 
+async def test_component_inertia_partial_except_excludes_plain_route_content(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Partial-except reloads should filter plain dict route props, not only lazy/shared props."""
+
+    @get("/", component="Dashboard")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {"stats": {"views": 100}, "posts": [1, 2, 3]}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get(
+            "/",
+            headers={
+                InertiaHeaders.ENABLED.value: "true",
+                InertiaHeaders.PARTIAL_COMPONENT.value: "Dashboard",
+                InertiaHeaders.PARTIAL_EXCEPT.value: "stats",
+            },
+        )
+
+    props = response.json()["props"]
+    assert props["posts"] == [1, 2, 3]
+    assert "stats" not in props
+
+
 async def test_response_skips_merge_unwrap_when_no_merge_props(
     inertia_plugin: InertiaPlugin,
     vite_plugin: VitePlugin,
@@ -1797,6 +1829,36 @@ async def test_scroll_props_parameter(
         assert scroll_config["currentPage"] == 2
         assert scroll_config["previousPage"] == 1
         assert scroll_config["nextPage"] == 3
+
+
+async def test_scroll_props_parameter_uses_route_content_key_without_route_opt(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Explicit scroll props should be keyed by the data prop the client reads."""
+    from litestar_vite.inertia.helpers import scroll_props
+    from litestar_vite.inertia.response import InertiaResponse
+
+    @get("/feed", component="Feed")
+    async def handler(request: Request[Any, Any, Any]) -> InertiaResponse[dict[str, list[str]]]:
+        return InertiaResponse(
+            {"posts": ["post1", "post2"]}, scroll_props=scroll_props(current_page=2, previous_page=1, next_page=3)
+        )
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/feed", headers={InertiaHeaders.ENABLED.value: "true"})
+        data = response.json()
+
+    assert data["props"]["posts"] == ["post1", "post2"]
+    assert "items" not in data["scrollProps"]
+    assert data["scrollProps"]["posts"] == {"pageName": "page", "currentPage": 2, "previousPage": 1, "nextPage": 3}
 
 
 async def test_scroll_props_first_page(

--- a/src/py/tests/unit/test_cli.py
+++ b/src/py/tests/unit/test_cli.py
@@ -599,6 +599,12 @@ def test_cli_get_package_executor_cmd_variants() -> None:
 
 
 def test_cli_get_package_executor_cmd_uses_package_flag_for_typegen() -> None:
+    assert _get_package_executor_cmd("deno", "litestar-vite-typegen", package_name="litestar-vite-plugin") == [
+        "deno",
+        "run",
+        "-A",
+        "npm:litestar-vite-plugin/litestar-vite-typegen",
+    ]
     assert _get_package_executor_cmd("pnpm", "litestar-vite-typegen", package_name="litestar-vite-plugin") == [
         "pnpm",
         "--package",
@@ -639,6 +645,9 @@ def test_cli_resolve_js_cli_fallback_names_plugin_package(tmp_path: Path) -> Non
 
     assert command == ["npx", "--package", "litestar-vite-plugin", "litestar-vite-typegen"]
     assert command != ["npx", "litestar-vite-typegen"]
+
+    deno_command = _resolve_js_cli(tmp_path, "deno", "litestar-vite-typegen", package_name="litestar-vite-plugin")
+    assert deno_command == ["deno", "run", "-A", "npm:litestar-vite-plugin/litestar-vite-typegen"]
 
 
 def test_cli_resolve_js_cli_bun_wraps_local_bin(tmp_path: Path) -> None:

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -601,6 +601,35 @@ def test_vite_process_restarts_unexpected_exit(mock_killpg: Mock, monkeypatch: p
     assert mock_killpg.called
 
 
+@patch("litestar_vite.plugin.os.killpg")
+def test_vite_process_resets_restart_attempts_after_recovered_crash(
+    mock_killpg: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each independent crash after a successful restart should get a fresh retry budget."""
+    monkeypatch.setattr(ViteProcess, "_RESTART_BACKOFFS", (0.0,), raising=False)
+    monkeypatch.setattr(ViteProcess, "_RESTART_STABILITY_SECONDS", 0.0, raising=False)
+    first = _FakeProcess()
+    second = _FakeProcess()
+    third = _FakeProcess()
+    executor = Mock()
+    executor.run.side_effect = [first, second, third]
+
+    process = ViteProcess(executor)
+    command = ["npm", "run", "dev"]
+    cwd = Path("/test/path")
+    process.start(command, cwd)
+
+    first.exit(1)
+    _wait_until(lambda: executor.run.call_count == 2 and process.process is second)
+    second.exit(1)
+    _wait_until(lambda: executor.run.call_count == 3 and process.process is third)
+
+    assert process._restart_error is None
+
+    process.stop()
+    assert mock_killpg.called
+
+
 @patch("litestar_vite.plugin._process.time.sleep", return_value=None)
 @patch("litestar_vite.plugin.os.killpg")
 def test_vite_process_crash_cleanup_escalates_before_restart(


### PR DESCRIPTION
Summary
- Fix Inertia partial reload filtering for plain dict route props, explicit scrollProps keying, and sessionless scope shared props.
- Fix Deno package/bin fallback argv for typegen and JS install-hint execution.
- Fix Vite dev-server auto-restart retry accounting so stable restarts reset the retry budget while crash loops still cap out.
- Add 0.26.0 changelog migration notes and release-review fix entries.