### PR TITLE
fix: post-release hardening for 0.28.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,10 @@ Litestar Vite Changelog
 - Changed SPA/proxy route derivation so ``/api`` and ``/schema`` are reserved only when registered
   Litestar routes, OpenAPI configuration, or ``RuntimeConfig.extra_route_prefixes`` claim them. Add
   ``extra_route_prefixes=("/api",)`` if an application relied on the old guessed fallback.
+- Changed Inertia ``share()`` so top-level ``defer()``, ``optional()``, ``once()``, and ``always()``
+  callables run only when the current response renders them or when a redirect needs to persist
+  them. The ``True``/``False`` return contract is unchanged, and async special props still return
+  ``False`` because they cannot be persisted synchronously across redirects.
 
 0.26.1 - 2026-07-06
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,27 @@ Notable changes to this project are documented in this file.
 Litestar Vite Changelog
 ^^^^^^^^^^^^^^^^^^^^^^^
 
+0.28.1 - 2026-07-25
+-------------------
+
+- Added ``csrfCookieName`` and ``csrfHeaderName`` to the ``.litestar.json`` bridge and injected browser
+  state. ``getCsrfToken()``, ``getCsrfHeaderName()``, ``csrfHeaders()``, ``csrfFetch()``, and the HTMX
+  extension now follow custom ``CSRFConfig(cookie_name=..., header_name=...)`` values automatically.
+- Changed SPA/proxy route derivation so ``/api`` and ``/schema`` are reserved only when registered
+  Litestar routes, OpenAPI configuration, or ``RuntimeConfig.extra_route_prefixes`` claim them. Add
+  ``extra_route_prefixes=("/api",)`` if an application relied on the old guessed fallback.
+- Changed Inertia ``share()`` so top-level ``defer()``, ``optional()``, ``once()``, and ``always()``
+  callables run only when the current response renders them or when a redirect needs to persist
+  them. The ``True``/``False`` return contract is unchanged, and async special props still return
+  ``False`` because they cannot be persisted synchronously across redirects.
+- Replaced HTMX JSON-template expression evaluation with a CSP-safe allowlist interpreter. Assignment,
+  ``new``, functions/arrows, computed indexing, array literals, and globals other than ``JSON`` and
+  ``Math`` are no longer supported. Reserved data-field names include ``constructor``, ``__proto__``,
+  ``prototype``, ``apply``, ``call``, ``bind``, ``arguments``, ``callee``, ``caller``, and the
+  ``__define*``/``__lookup*`` names; rename those fields before using them in expressions.
+  ``@event`` now exposes a sanitized ``$event`` wrapper instead of the raw DOM event. Applications may
+  remove CSP ``script-src 'unsafe-eval'`` when no other code requires it.
+
 0.28.0 - 2026-07-25
 -------------------
 
@@ -29,23 +50,6 @@ Litestar Vite Changelog
 - Hardened Vite 8.1 HMR compatibility by emitting network options under ``server.ws.*`` on Vite 8.1+,
   retaining ``server.hmr.*`` emission for Vite 7 / 8.0, and continuing to read either shape from user
   configuration.
-- Added ``csrfCookieName`` and ``csrfHeaderName`` to the ``.litestar.json`` bridge and injected browser
-  state. ``getCsrfToken()``, ``getCsrfHeaderName()``, ``csrfHeaders()``, ``csrfFetch()``, and the HTMX
-  extension now follow custom ``CSRFConfig(cookie_name=..., header_name=...)`` values automatically.
-- Changed SPA/proxy route derivation so ``/api`` and ``/schema`` are reserved only when registered
-  Litestar routes, OpenAPI configuration, or ``RuntimeConfig.extra_route_prefixes`` claim them. Add
-  ``extra_route_prefixes=("/api",)`` if an application relied on the old guessed fallback.
-- Changed Inertia ``share()`` so top-level ``defer()``, ``optional()``, ``once()``, and ``always()``
-  callables run only when the current response renders them or when a redirect needs to persist
-  them. The ``True``/``False`` return contract is unchanged, and async special props still return
-  ``False`` because they cannot be persisted synchronously across redirects.
-- Replaced HTMX JSON-template expression evaluation with a CSP-safe allowlist interpreter. Assignment,
-  ``new``, functions/arrows, computed indexing, array literals, and globals other than ``JSON`` and
-  ``Math`` are no longer supported. Reserved data-field names include ``constructor``, ``__proto__``,
-  ``prototype``, ``apply``, ``call``, ``bind``, ``arguments``, ``callee``, ``caller``, and the
-  ``__define*``/``__lookup*`` names; rename those fields before using them in expressions.
-  ``@event`` now exposes a sanitized ``$event`` wrapper instead of the raw DOM event. Applications may
-  remove CSP ``script-src 'unsafe-eval'`` when no other code requires it.
 
 0.26.1 - 2026-07-06
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,9 @@ Litestar Vite Changelog
 - Added ``csrfCookieName`` and ``csrfHeaderName`` to the ``.litestar.json`` bridge and injected browser
   state. ``getCsrfToken()``, ``getCsrfHeaderName()``, ``csrfHeaders()``, ``csrfFetch()``, and the HTMX
   extension now follow custom ``CSRFConfig(cookie_name=..., header_name=...)`` values automatically.
+- Changed SPA/proxy route derivation so ``/api`` and ``/schema`` are reserved only when registered
+  Litestar routes, OpenAPI configuration, or ``RuntimeConfig.extra_route_prefixes`` claim them. Add
+  ``extra_route_prefixes=("/api",)`` if an application relied on the old guessed fallback.
 
 0.26.1 - 2026-07-06
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,9 @@ Litestar Vite Changelog
 - Hardened Vite 8.1 HMR compatibility by emitting network options under ``server.ws.*`` on Vite 8.1+,
   retaining ``server.hmr.*`` emission for Vite 7 / 8.0, and continuing to read either shape from user
   configuration.
+- Added ``csrfCookieName`` and ``csrfHeaderName`` to the ``.litestar.json`` bridge and injected browser
+  state. ``getCsrfToken()``, ``getCsrfHeaderName()``, ``csrfHeaders()``, ``csrfFetch()``, and the HTMX
+  extension now follow custom ``CSRFConfig(cookie_name=..., header_name=...)`` values automatically.
 
 0.26.1 - 2026-07-06
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,13 @@ Litestar Vite Changelog
   callables run only when the current response renders them or when a redirect needs to persist
   them. The ``True``/``False`` return contract is unchanged, and async special props still return
   ``False`` because they cannot be persisted synchronously across redirects.
+- Replaced HTMX JSON-template expression evaluation with a CSP-safe allowlist interpreter. Assignment,
+  ``new``, functions/arrows, computed indexing, array literals, and globals other than ``JSON`` and
+  ``Math`` are no longer supported. Reserved data-field names include ``constructor``, ``__proto__``,
+  ``prototype``, ``apply``, ``call``, ``bind``, ``arguments``, ``callee``, ``caller``, and the
+  ``__define*``/``__lookup*`` names; rename those fields before using them in expressions.
+  ``@event`` now exposes a sanitized ``$event`` wrapper instead of the raw DOM event. Applications may
+  remove CSP ``script-src 'unsafe-eval'`` when no other code requires it.
 
 0.26.1 - 2026-07-06
 -------------------

--- a/docs/frameworks/htmx.rst
+++ b/docs/frameworks/htmx.rst
@@ -164,10 +164,23 @@ Template directives:
 - ``ls-key="item.id"`` - Unique key for efficient updates
 - ``ls-if="condition"`` - Conditional rendering
 - ``ls-else`` - Else branch for conditionals
-- ``${expression}`` - Interpolate values (JavaScript template literal syntax)
+- ``${expression}`` - Interpolate values with the fixed expression grammar
 
 This enables hybrid rendering: server-side HTML for initial load, client-side
 templating for dynamic updates from JSON APIs.
+
+The expression grammar supports property access, arithmetic, comparisons,
+logical and ternary operators, string template and object literals, method
+calls on values, calls to context functions, and the ``JSON`` and ``Math``
+namespaces. Assignment, ``new``, function and arrow expressions, computed
+indexing such as ``obj[key]``, array literals, and arbitrary browser globals
+are intentionally unsupported.
+
+In ``@event`` handlers, ``$event`` is a sanitized plain object rather than the
+raw DOM event. It exposes ``type``, ``target.value``, ``target.name``,
+``target.checked``, ``target.id``, ``target.type``, ``preventDefault()``, and
+``stopPropagation()``. Host-object paths such as ``$event.view`` and
+``$event.target.ownerDocument`` are intentionally unavailable.
 
 HTMX Patterns
 -------------

--- a/docs/frameworks/inertia/csrf-protection.rst
+++ b/docs/frameworks/inertia/csrf-protection.rst
@@ -38,7 +38,9 @@ reads the token from injected page state instead of the cookie itself.
 .. note::
    If you intentionally use a client library that reads the CSRF cookie directly,
    such as a legacy Axios XSRF-cookie setup, keep ``cookie_httponly=False`` and
-   align the cookie/header names explicitly for that client.
+   align the cookie/header names explicitly for that client. Consumers of
+   ``litestar-vite-plugin/helpers`` do not need manual alignment: configured names
+   are injected into browser state and used automatically.
 
 Token in Templates
 ------------------
@@ -119,12 +121,18 @@ The ``litestar-vite-plugin/helpers`` package provides utility functions for CSRF
 
 .. code-block:: typescript
 
-   import { getCsrfToken, csrfHeaders, csrfFetch } from 'litestar-vite-plugin/helpers';
+   import {
+     csrfFetch,
+     csrfHeaders,
+     getCsrfHeaderName,
+     getCsrfToken,
+   } from 'litestar-vite-plugin/helpers';
 
    // Get CSRF token (from window.__LITESTAR_CSRF__, meta tag, or Inertia props)
    const token = getCsrfToken();
 
-   // Get headers object with Litestar's default X-CSRFToken header
+   // Get the configured header name and a ready-to-use headers object
+   const headerName = getCsrfHeaderName();
    const headers = csrfHeaders();
 
    // Make a fetch request with CSRF token automatically included
@@ -133,7 +141,11 @@ The ``litestar-vite-plugin/helpers`` package provides utility functions for CSRF
      body: JSON.stringify(data),
    });
 
-These helpers work in both SPA and template modes, automatically detecting the token source.
+These helpers work in both SPA and template modes, automatically detecting the
+token source. When ``CSRFConfig`` customizes ``cookie_name`` or ``header_name``,
+the HTML handler injects ``window.__LITESTAR_CSRF_COOKIE_NAME__`` and
+``window.__LITESTAR_CSRF_HEADER_NAME__`` alongside the token, so no separate
+JavaScript configuration is required.
 
 Legacy Cookie-Readable Clients
 ------------------------------
@@ -149,6 +161,10 @@ configure the middleware for that flow explicitly:
        header_name="X-XSRF-TOKEN",
        cookie_httponly=False,
    )
+
+The Litestar Vite helpers automatically follow those configured names. Manual
+cookie/header alignment is still required for clients that bypass the helpers,
+such as a raw Axios XSRF-cookie configuration.
 
 Excluding Routes
 ----------------
@@ -170,7 +186,10 @@ Troubleshooting
 1. Verify the request sends Litestar's default CSRF header (``x-csrftoken`` / ``X-CSRFToken``)
 2. Verify the CSRF cookie is set on the correct domain/path
 3. If you use a cookie-readable client, verify ``cookie_httponly=False``
-4. If you customized ``header_name``, make sure your client sends the same header
+4. If you customized ``header_name``, the provided helpers follow it
+   automatically. For hand-written fetch/XHR clients that do not use
+   ``csrfHeaders()`` or ``csrfFetch()``, make sure the client sends the same
+   header.
 
 **Token not found**:
 

--- a/docs/usage/development.rst
+++ b/docs/usage/development.rst
@@ -39,14 +39,18 @@ Switch with `VITE_PROXY_MODE=proxy|direct` (or `ViteConfig.runtime.proxy_mode`).
 Route Prefix Fallbacks
 ----------------------
 
-In SPA and framework proxy modes, backend route prefixes are excluded from the frontend fallback. Litestar Vite always preserves registered Litestar routes and OpenAPI paths, and keeps ``/api`` and ``/schema`` as fallback backend prefixes. ``/docs`` is not reserved by default; it is only excluded when Litestar registers docs there or when you opt in:
+In SPA and framework proxy modes, backend route prefixes are excluded from the
+frontend fallback. Litestar Vite derives those prefixes from registered
+Litestar routes and the configured OpenAPI path. It does not guess that
+``/api``, ``/schema``, or ``/docs`` belong to the backend. Reserve an otherwise
+unclaimed prefix explicitly when another backend component owns it:
 
 .. code-block:: python
 
     from litestar_vite import RuntimeConfig, ViteConfig
 
     config = ViteConfig(
-        runtime=RuntimeConfig(extra_route_prefixes=("/docs", "/admin")),
+        runtime=RuntimeConfig(extra_route_prefixes=("/api", "/docs", "/admin")),
     )
 
 Origin Behavior in Development

--- a/docs/usage/vite.rst
+++ b/docs/usage/vite.rst
@@ -330,7 +330,7 @@ You configure the Litestar backend using the `ViteConfig` object passed to the `
      - Auto-register catch-all SPA route when mode="spa". Defaults to `True`.
    * - `extra_route_prefixes`
      - `tuple[str, ...]`
-     - Additional backend prefixes excluded from SPA/proxy fallbacks. Use this to reserve custom paths or deliberately re-add ``"/docs"`` when your backend serves docs there. Defaults to ``()``.
+     - Additional backend prefixes excluded from SPA/proxy fallbacks. Registered routes and the configured OpenAPI path are derived automatically. Use this only to reserve an otherwise unclaimed path such as ``"/api"`` or ``"/docs"``. Defaults to ``()``.
    * - `set_environment`
      - `bool`
      - Set Vite-related environment variables and write `.litestar.json` on startup. Defaults to `True`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litestar-vite-plugin",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "type": "module",
   "description": "Litestar plugin for Vite.",
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ license = { text = "MIT" }
 name = "litestar-vite"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.28.0"
+version = "0.28.1"
 
 [project.urls]
 Changelog = "https://litestar-org.github.io/litestar-vite/latest/changelog"
@@ -102,7 +102,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.28.0"
+current_version = "0.28.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/src/js/src/helpers/csrf.ts
+++ b/src/js/src/helpers/csrf.ts
@@ -13,6 +13,8 @@
 declare global {
   interface Window {
     __LITESTAR_CSRF__?: string
+    __LITESTAR_CSRF_HEADER_NAME__?: string
+    __LITESTAR_CSRF_COOKIE_NAME__?: string
   }
 }
 
@@ -26,6 +28,13 @@ interface CsrfTokenCache {
 
 let csrfTokenCache: CsrfTokenCache | null = null
 export const DEFAULT_CSRF_HEADER_NAME = "X-CSRFToken"
+
+export function getCsrfHeaderName(): string {
+  if (typeof window !== "undefined" && typeof window.__LITESTAR_CSRF_HEADER_NAME__ === "string" && window.__LITESTAR_CSRF_HEADER_NAME__.length > 0) {
+    return window.__LITESTAR_CSRF_HEADER_NAME__
+  }
+  return DEFAULT_CSRF_HEADER_NAME
+}
 
 function getWindowToken(): string | undefined {
   if (typeof window !== "undefined") {
@@ -88,6 +97,12 @@ function getCookie(name: string): string | undefined {
 }
 
 function getCookieToken(): string | undefined {
+  if (typeof window !== "undefined" && typeof window.__LITESTAR_CSRF_COOKIE_NAME__ === "string" && window.__LITESTAR_CSRF_COOKIE_NAME__.length > 0) {
+    const configured = getCookie(window.__LITESTAR_CSRF_COOKIE_NAME__)
+    if (configured !== undefined) {
+      return configured
+    }
+  }
   return getCookie("csrftoken") ?? getCookie("XSRF-TOKEN")
 }
 
@@ -156,20 +171,20 @@ export function getCsrfToken(): string {
   return token
 }
 
-function hasCsrfHeader(headers: HeadersInit | undefined): boolean {
+function hasCsrfHeader(headers: HeadersInit | undefined, headerName: string): boolean {
   if (headers == null) {
     return false
   }
 
   if (headers instanceof Headers) {
-    return headers.has(DEFAULT_CSRF_HEADER_NAME)
+    return headers.has(headerName)
   }
 
   if (Array.isArray(headers)) {
-    return headers.some((entry) => Array.isArray(entry) && entry.length >= 2 && typeof entry[0] === "string" && entry[0].toLowerCase() === DEFAULT_CSRF_HEADER_NAME.toLowerCase())
+    return headers.some((entry) => Array.isArray(entry) && entry.length >= 2 && typeof entry[0] === "string" && entry[0].toLowerCase() === headerName.toLowerCase())
   }
 
-  return Object.keys(headers as Record<string, string>).some((key) => key.toLowerCase() === DEFAULT_CSRF_HEADER_NAME.toLowerCase())
+  return Object.keys(headers as Record<string, string>).some((key) => key.toLowerCase() === headerName.toLowerCase())
 }
 
 /**
@@ -195,14 +210,15 @@ export function csrfHeaders(additionalHeaders: Record<string, string> = {}): Rec
     return additionalHeaders
   }
 
-  const existingTokenHeader = Object.keys(additionalHeaders).find((key) => key.toLowerCase() === DEFAULT_CSRF_HEADER_NAME.toLowerCase())
+  const headerName = getCsrfHeaderName()
+  const existingTokenHeader = Object.keys(additionalHeaders).find((key) => key.toLowerCase() === headerName.toLowerCase())
   if (existingTokenHeader !== undefined) {
     return additionalHeaders
   }
 
   return {
     ...additionalHeaders,
-    [DEFAULT_CSRF_HEADER_NAME]: token,
+    [headerName]: token,
   }
 }
 
@@ -231,11 +247,12 @@ export function csrfFetch(input: RequestInfo | URL, init?: RequestInit): Promise
     return fetch(input, init)
   }
 
-  if (!hasCsrfHeader(init?.headers)) {
+  const headerName = getCsrfHeaderName()
+  if (!hasCsrfHeader(init?.headers, headerName)) {
     if (!init || typeof init.headers === "undefined") {
       return fetch(input, {
         ...init,
-        headers: { [DEFAULT_CSRF_HEADER_NAME]: token },
+        headers: { [headerName]: token },
       })
     }
 
@@ -243,7 +260,7 @@ export function csrfFetch(input: RequestInfo | URL, init?: RequestInit): Promise
       if (Array.isArray(init.headers)) {
         return fetch(input, {
           ...init,
-          headers: [...init.headers, [DEFAULT_CSRF_HEADER_NAME, token]],
+          headers: [...init.headers, [headerName, token]],
         })
       }
 
@@ -251,14 +268,14 @@ export function csrfFetch(input: RequestInfo | URL, init?: RequestInit): Promise
         ...init,
         headers: {
           ...init.headers,
-          [DEFAULT_CSRF_HEADER_NAME]: token,
+          [headerName]: token,
         },
       })
     }
 
     if (init.headers instanceof Headers) {
       const headers = new Headers(init.headers)
-      headers.set(DEFAULT_CSRF_HEADER_NAME, token)
+      headers.set(headerName, token)
       return fetch(input, {
         ...init,
         headers,

--- a/src/js/src/helpers/expression.ts
+++ b/src/js/src/helpers/expression.ts
@@ -1,0 +1,487 @@
+type ExpressionContext = Record<string, unknown>
+
+type TemplateToken = {
+  expressions: string[]
+  strings: string[]
+}
+
+type Token = { kind: "ident" | "num" | "punct" | "str"; value: string } | { kind: "template"; template: TemplateToken }
+
+type Node =
+  | { type: "Literal"; value: unknown }
+  | { type: "Ident"; name: string }
+  | { type: "Member"; object: Node; name: string }
+  | { type: "Call"; callee: Node; args: Node[] }
+  | { type: "Unary"; operator: string; value: Node }
+  | { type: "Binary"; operator: string; left: Node; right: Node }
+  | { type: "Ternary"; condition: Node; yes: Node; no: Node }
+  | { type: "Object"; entries: Array<[string, Node]> }
+  | { type: "Template"; strings: string[]; expressions: Node[] }
+
+const ALLOWED_GLOBALS: Readonly<Record<string, unknown>> = Object.freeze({ JSON, Math })
+const STOP_PROTOS: ReadonlySet<unknown> = new Set([Object.prototype, Array.prototype, Function.prototype, String.prototype, Number.prototype, Boolean.prototype])
+const BANNED_PROPS = new Set([
+  "constructor",
+  "__proto__",
+  "prototype",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "caller",
+  "callee",
+  "arguments",
+  "apply",
+  "call",
+  "bind",
+])
+const RESERVED = new Set(["function", "this", "new", "import", "delete", "void", "typeof", "instanceof", "in", "class", "return", "var", "let", "const", "async", "await", "yield"])
+const BINARY_PRECEDENCE: Readonly<Record<string, number>> = Object.freeze({
+  "??": 1,
+  "||": 2,
+  "&&": 3,
+  "==": 4,
+  "!=": 4,
+  "===": 4,
+  "!==": 4,
+  "<": 5,
+  "<=": 5,
+  ">": 5,
+  ">=": 5,
+  "+": 6,
+  "-": 6,
+  "*": 7,
+  "/": 7,
+  "%": 7,
+})
+const PUNCTUATION = ["===", "!==", "&&", "||", "??", "<=", ">=", "==", "!=", ".", "(", ")", "{", "}", ",", "?", ":", "!", "+", "-", "*", "/", "%", "<", ">"]
+
+function readEscape(source: string, start: number): { end: number; value: string } | null {
+  const character = source[start]
+  if (character === undefined) return null
+  if (character === "u") {
+    if (source[start + 1] === "{") {
+      const close = source.indexOf("}", start + 2)
+      if (close === -1) return null
+      const digits = source.slice(start + 2, close)
+      if (!/^[0-9a-f]+$/i.test(digits)) return null
+      const codePoint = Number.parseInt(digits, 16)
+      if (!Number.isFinite(codePoint) || codePoint > 0x10ffff) return null
+      return { end: close + 1, value: String.fromCodePoint(codePoint) }
+    }
+    const digits = source.slice(start + 1, start + 5)
+    if (!/^[0-9a-f]{4}$/i.test(digits)) return null
+    return { end: start + 5, value: String.fromCharCode(Number.parseInt(digits, 16)) }
+  }
+  if (character === "x") {
+    const digits = source.slice(start + 1, start + 3)
+    if (!/^[0-9a-f]{2}$/i.test(digits)) return null
+    return { end: start + 3, value: String.fromCharCode(Number.parseInt(digits, 16)) }
+  }
+  const escapes: Readonly<Record<string, string>> = {
+    b: "\b",
+    f: "\f",
+    n: "\n",
+    r: "\r",
+    t: "\t",
+    v: "\v",
+  }
+  return { end: start + 1, value: escapes[character] ?? character }
+}
+
+function readString(source: string, start: number): { end: number; value: string } | null {
+  const quote = source[start]
+  if (quote !== "'" && quote !== '"') return null
+  let value = ""
+  for (let index = start + 1; index < source.length; index += 1) {
+    const character = source[index]
+    if (character === quote) return { end: index + 1, value }
+    if (character === "\\") {
+      const escaped = readEscape(source, index + 1)
+      if (!escaped) return null
+      value += escaped.value
+      index = escaped.end - 1
+      continue
+    }
+    if (character === "\n" || character === "\r") return null
+    value += character
+  }
+  return null
+}
+
+function findTemplateExpressionEnd(source: string, start: number): number | null {
+  let depth = 1
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index]
+    if (character === "'" || character === '"') {
+      const quoted = readString(source, index)
+      if (!quoted) return null
+      index = quoted.end - 1
+      continue
+    }
+    if (character === "`") {
+      const nested = readTemplate(source, index)
+      if (!nested) return null
+      index = nested.end - 1
+      continue
+    }
+    if (character === "{") depth += 1
+    if (character === "}") {
+      depth -= 1
+      if (depth === 0) return index
+    }
+  }
+  return null
+}
+
+function readTemplate(source: string, start: number): { end: number; template: TemplateToken } | null {
+  if (source[start] !== "`") return null
+  const strings: string[] = []
+  const expressions: string[] = []
+  let value = ""
+  for (let index = start + 1; index < source.length; index += 1) {
+    const character = source[index]
+    if (character === "\\") {
+      const escaped = readEscape(source, index + 1)
+      if (!escaped) return null
+      value += escaped.value
+      index = escaped.end - 1
+      continue
+    }
+    if (character === "`") {
+      strings.push(value)
+      return { end: index + 1, template: { expressions, strings } }
+    }
+    if (character === "$" && source[index + 1] === "{") {
+      strings.push(value)
+      value = ""
+      const close = findTemplateExpressionEnd(source, index + 2)
+      if (close === null) return null
+      expressions.push(source.slice(index + 2, close))
+      index = close
+      continue
+    }
+    value += character
+  }
+  return null
+}
+
+function isIdentifierStart(character: string | undefined): boolean {
+  return character !== undefined && /[A-Za-z_$]/.test(character)
+}
+
+function isIdentifierPart(character: string | undefined): boolean {
+  return character !== undefined && /[A-Za-z0-9_$]/.test(character)
+}
+
+function tokenize(source: string): Token[] | null {
+  const tokens: Token[] = []
+  for (let index = 0; index < source.length; ) {
+    const character = source[index]
+    if (/\s/.test(character)) {
+      index += 1
+      continue
+    }
+    if (character === "'" || character === '"') {
+      const quoted = readString(source, index)
+      if (!quoted) return null
+      tokens.push({ kind: "str", value: quoted.value })
+      index = quoted.end
+      continue
+    }
+    if (character === "`") {
+      const template = readTemplate(source, index)
+      if (!template) return null
+      tokens.push({ kind: "template", template: template.template })
+      index = template.end
+      continue
+    }
+    if (/\d/.test(character)) {
+      const match = source.slice(index).match(/^(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?/i)
+      if (!match) return null
+      tokens.push({ kind: "num", value: match[0] })
+      index += match[0].length
+      continue
+    }
+    if (isIdentifierStart(character)) {
+      let end = index + 1
+      while (isIdentifierPart(source[end])) end += 1
+      tokens.push({ kind: "ident", value: source.slice(index, end) })
+      index = end
+      continue
+    }
+    if (character === "[" || character === "]" || source.startsWith("=>", index)) return null
+    if (source.startsWith("//", index) || source.startsWith("/*", index)) return null
+    const punctuation = PUNCTUATION.find((candidate) => source.startsWith(candidate, index))
+    if (!punctuation) return null
+    tokens.push({ kind: "punct", value: punctuation })
+    index += punctuation.length
+  }
+  return tokens
+}
+
+class Parser {
+  private index = 0
+
+  constructor(private readonly tokens: Token[]) {}
+
+  parse(): Node | null {
+    const node = this.parseExpression()
+    return node && this.index === this.tokens.length ? node : null
+  }
+
+  private peek(): Token | undefined {
+    return this.tokens[this.index]
+  }
+
+  private takePunctuation(value: string): boolean {
+    const token = this.peek()
+    if (token?.kind !== "punct" || token.value !== value) return false
+    this.index += 1
+    return true
+  }
+
+  private parseExpression(minimumPrecedence = 0): Node | null {
+    let left = this.parseUnary()
+    if (!left) return null
+    while (true) {
+      const token = this.peek()
+      if (token?.kind !== "punct") break
+      const precedence = BINARY_PRECEDENCE[token.value]
+      if (precedence === undefined || precedence < minimumPrecedence) break
+      this.index += 1
+      const right = this.parseExpression(precedence + 1)
+      if (!right) return null
+      left = { type: "Binary", operator: token.value, left, right }
+    }
+    if (minimumPrecedence === 0 && this.takePunctuation("?")) {
+      const yes = this.parseExpression()
+      if (!yes || !this.takePunctuation(":")) return null
+      const no = this.parseExpression()
+      if (!no) return null
+      left = { type: "Ternary", condition: left, yes, no }
+    }
+    return left
+  }
+
+  private parseUnary(): Node | null {
+    const token = this.peek()
+    if (token?.kind === "punct" && (token.value === "!" || token.value === "+" || token.value === "-")) {
+      this.index += 1
+      const value = this.parseUnary()
+      return value ? { type: "Unary", operator: token.value, value } : null
+    }
+    return this.parsePostfix()
+  }
+
+  private parsePostfix(): Node | null {
+    let node = this.parsePrimary()
+    if (!node) return null
+    while (true) {
+      if (this.takePunctuation(".")) {
+        const property = this.peek()
+        if (property?.kind !== "ident" || BANNED_PROPS.has(property.value) || RESERVED.has(property.value)) {
+          return null
+        }
+        this.index += 1
+        node = { type: "Member", object: node, name: property.value }
+        continue
+      }
+      if (this.takePunctuation("(")) {
+        const args: Node[] = []
+        if (!this.takePunctuation(")")) {
+          while (true) {
+            const argument = this.parseExpression()
+            if (!argument) return null
+            args.push(argument)
+            if (this.takePunctuation(")")) break
+            if (!this.takePunctuation(",")) return null
+          }
+        }
+        node = { type: "Call", callee: node, args }
+        continue
+      }
+      return node
+    }
+  }
+
+  private parsePrimary(): Node | null {
+    const token = this.peek()
+    if (!token) return null
+    if (token.kind === "num") {
+      this.index += 1
+      return { type: "Literal", value: Number(token.value) }
+    }
+    if (token.kind === "str") {
+      this.index += 1
+      return { type: "Literal", value: token.value }
+    }
+    if (token.kind === "template") {
+      this.index += 1
+      const expressions: Node[] = []
+      for (const source of token.template.expressions) {
+        const expression = parseSource(source)
+        if (!expression) return null
+        expressions.push(expression)
+      }
+      return { type: "Template", strings: token.template.strings, expressions }
+    }
+    if (token.kind === "ident") {
+      this.index += 1
+      if (token.value === "true") return { type: "Literal", value: true }
+      if (token.value === "false") return { type: "Literal", value: false }
+      if (token.value === "null") return { type: "Literal", value: null }
+      if (token.value === "undefined") return { type: "Literal", value: undefined }
+      if (RESERVED.has(token.value) || BANNED_PROPS.has(token.value)) return null
+      return { type: "Ident", name: token.value }
+    }
+    if (this.takePunctuation("(")) {
+      const expression = this.parseExpression()
+      return expression && this.takePunctuation(")") ? expression : null
+    }
+    if (this.takePunctuation("{")) return this.parseObject()
+    return null
+  }
+
+  private parseObject(): Node | null {
+    const entries: Array<[string, Node]> = []
+    if (this.takePunctuation("}")) return { type: "Object", entries }
+    while (true) {
+      const keyToken = this.peek()
+      if (!keyToken || (keyToken.kind !== "ident" && keyToken.kind !== "str")) return null
+      const key = keyToken.value
+      if (BANNED_PROPS.has(key)) return null
+      this.index += 1
+      if (!this.takePunctuation(":")) return null
+      const value = this.parseExpression()
+      if (!value) return null
+      entries.push([key, value])
+      if (this.takePunctuation("}")) return { type: "Object", entries }
+      if (!this.takePunctuation(",")) return null
+    }
+  }
+}
+
+function parseSource(source: string): Node | null {
+  const tokens = tokenize(source)
+  return tokens ? new Parser(tokens).parse() : null
+}
+
+function resolveIdent(name: string, context: ExpressionContext): unknown {
+  let object: unknown = context
+  while (object !== null && object !== undefined && !STOP_PROTOS.has(object)) {
+    if (Object.prototype.hasOwnProperty.call(object, name)) {
+      return (object as Record<string, unknown>)[name]
+    }
+    object = Object.getPrototypeOf(object)
+  }
+  return Object.prototype.hasOwnProperty.call(ALLOWED_GLOBALS, name) ? ALLOWED_GLOBALS[name] : undefined
+}
+
+function isPlainReceiver(value: unknown): boolean {
+  const valueType = typeof value
+  if (valueType === "string" || valueType === "number" || valueType === "boolean" || valueType === "function") {
+    return true
+  }
+  if (value === null || valueType !== "object") return false
+  const firstPrototype = Object.getPrototypeOf(value)
+  if (firstPrototype === null || STOP_PROTOS.has(firstPrototype)) return true
+  const secondPrototype = Object.getPrototypeOf(firstPrototype)
+  return secondPrototype === null || STOP_PROTOS.has(secondPrototype)
+}
+
+function readMember(object: unknown, name: string): unknown {
+  if (object === null || object === undefined || !isPlainReceiver(object)) return undefined
+  return (object as Record<string, unknown>)[name]
+}
+
+function add(left: unknown, right: unknown): unknown {
+  if (typeof left === "string" || typeof right === "string") return String(left) + String(right)
+  return Number(left) + Number(right)
+}
+
+function looselyEqual(left: unknown, right: unknown): boolean {
+  if (left === right) return true
+  if (left == null && right == null) return true
+  if (typeof left === "boolean" || typeof right === "boolean") return Number(left) === Number(right)
+  if ((typeof left === "number" && typeof right === "string") || (typeof left === "string" && typeof right === "number")) {
+    return Number(left) === Number(right)
+  }
+  return false
+}
+
+function compare(left: unknown, right: unknown, operator: string): boolean {
+  const comparableLeft = typeof left === "string" && typeof right === "string" ? left : Number(left)
+  const comparableRight = typeof left === "string" && typeof right === "string" ? right : Number(right)
+  if (operator === "<") return comparableLeft < comparableRight
+  if (operator === "<=") return comparableLeft <= comparableRight
+  if (operator === ">") return comparableLeft > comparableRight
+  return comparableLeft >= comparableRight
+}
+
+function evaluateBinary(node: Extract<Node, { type: "Binary" }>, context: ExpressionContext): unknown {
+  const left = evaluate(node.left, context)
+  if (node.operator === "&&") return left ? evaluate(node.right, context) : left
+  if (node.operator === "||") return left ? left : evaluate(node.right, context)
+  if (node.operator === "??") return left === null || left === undefined ? evaluate(node.right, context) : left
+  const right = evaluate(node.right, context)
+  if (node.operator === "+") return add(left, right)
+  if (node.operator === "-") return Number(left) - Number(right)
+  if (node.operator === "*") return Number(left) * Number(right)
+  if (node.operator === "/") return Number(left) / Number(right)
+  if (node.operator === "%") return Number(left) % Number(right)
+  if (node.operator === "===") return left === right
+  if (node.operator === "!==") return left !== right
+  if (node.operator === "==") return looselyEqual(left, right)
+  if (node.operator === "!=") return !looselyEqual(left, right)
+  return compare(left, right, node.operator)
+}
+
+function evaluate(node: Node, context: ExpressionContext): unknown {
+  if (node.type === "Literal") return node.value
+  if (node.type === "Ident") return resolveIdent(node.name, context)
+  if (node.type === "Member") return readMember(evaluate(node.object, context), node.name)
+  if (node.type === "Call") {
+    const args = node.args.map((argument) => evaluate(argument, context))
+    if (node.callee.type === "Member") {
+      const receiver = evaluate(node.callee.object, context)
+      const callable = readMember(receiver, node.callee.name)
+      return typeof callable === "function" ? Reflect.apply(callable, receiver, args) : undefined
+    }
+    const callable = evaluate(node.callee, context)
+    return typeof callable === "function" ? Reflect.apply(callable, undefined, args) : undefined
+  }
+  if (node.type === "Unary") {
+    const value = evaluate(node.value, context)
+    if (node.operator === "!") return !value
+    if (node.operator === "-") return -Number(value)
+    return Number(value)
+  }
+  if (node.type === "Binary") return evaluateBinary(node, context)
+  if (node.type === "Ternary") {
+    return evaluate(node.condition, context) ? evaluate(node.yes, context) : evaluate(node.no, context)
+  }
+  if (node.type === "Object") {
+    const result: Record<string, unknown> = {}
+    for (const [key, value] of node.entries) result[key] = evaluate(value, context)
+    return result
+  }
+  let result = node.strings[0] ?? ""
+  for (let index = 0; index < node.expressions.length; index += 1) {
+    result += String(evaluate(node.expressions[index], context))
+    result += node.strings[index + 1] ?? ""
+  }
+  return result
+}
+
+export function compileExpression(source: string): ((context: ExpressionContext) => unknown) | null {
+  const syntaxTree = parseSource(source)
+  if (!syntaxTree) return null
+  return (context) => {
+    try {
+      return evaluate(syntaxTree, context)
+    } catch {
+      return undefined
+    }
+  }
+}

--- a/src/js/src/helpers/htmx.ts
+++ b/src/js/src/helpers/htmx.ts
@@ -29,6 +29,7 @@
  */
 
 import { getCsrfHeaderName, getCsrfToken } from "./csrf.js"
+import { compileExpression } from "./expression.js"
 
 /** Type for route function - matches generated routes.ts */
 type RouteFn = (name: string, params?: Record<string, string | number>) => string
@@ -72,7 +73,7 @@ interface Ctx {
   $parent?: Ctx
   $index?: number
   $key?: string
-  $event?: Event
+  $event?: Readonly<Record<string, unknown>>
   route?: RouteFn
   navigate?: (name: string, params?: Record<string, string | number>) => void
   [key: string]: unknown
@@ -257,6 +258,28 @@ interface Dir {
   create: (el: Element, a: Attr) => Handler | null
 }
 
+function wrapEvent(event: Event): Readonly<Record<string, unknown>> {
+  const eventTarget = event.target
+  let target: Readonly<Record<string, unknown>> | null = null
+  if (eventTarget instanceof HTMLInputElement || eventTarget instanceof HTMLSelectElement || eventTarget instanceof HTMLTextAreaElement) {
+    target = Object.freeze({
+      value: eventTarget.value,
+      name: eventTarget.name,
+      checked: eventTarget instanceof HTMLInputElement ? eventTarget.checked : false,
+      id: eventTarget.id,
+      type: eventTarget instanceof HTMLInputElement ? eventTarget.type : "",
+    })
+  } else if (eventTarget instanceof Element) {
+    target = Object.freeze({ value: "", name: "", checked: false, id: eventTarget.id, type: "" })
+  }
+  return Object.freeze({
+    type: event.type,
+    target,
+    preventDefault: () => event.preventDefault(),
+    stopPropagation: () => event.stopPropagation(),
+  })
+}
+
 const directives: Dir[] = [
   // :attr="expr" - attribute binding
   {
@@ -306,7 +329,7 @@ const directives: Dir[] = [
           const current = memoStore.get(el)?.[ctxKey] as Ctx | undefined
           if (!current) return
           const eventCtx = Object.create(current) as Ctx
-          eventCtx.$event = e
+          eventCtx.$event = wrapEvent(e)
           g(eventCtx)
         })
       }
@@ -524,133 +547,6 @@ function childCtx(parent: Ctx, data: unknown, index?: number, key?: string): Ctx
 // Expression Compiler
 // =============================================================================
 
-/** Identifiers that must never appear as standalone words in expressions */
-const BLOCKED_GLOBALS = [
-  "window",
-  "document",
-  "globalThis",
-  "self",
-  "top",
-  "frames",
-  "Function",
-  "eval",
-  "setTimeout",
-  "setInterval",
-  "constructor",
-  "__proto__",
-  "prototype",
-  "import",
-  "require",
-]
-
-/** Build a single regex: matches any blocked word at a word boundary */
-const BLOCKED_RE = new RegExp(`\\b(${BLOCKED_GLOBALS.join("|")})\\b`)
-
-/** Strip string literals and template strings before checking for blocked patterns */
-function stripStrings(s: string): string {
-  return s
-    .replace(/`(?:[^`\\]|\\.)*`/g, "") // template literals
-    .replace(/"(?:[^"\\]|\\.)*"/g, "") // double-quoted strings
-    .replace(/'(?:[^'\\]|\\.)*'/g, "") // single-quoted strings
-}
-
-function readQuotedLiteral(s: string, start: number): { end: number; value: string } | null {
-  const quote = s[start]
-  if (quote !== "'" && quote !== '"' && quote !== "`") return null
-
-  let value = ""
-  for (let i = start + 1; i < s.length; i++) {
-    const ch = s[i]
-    if (ch === "\\") {
-      if (i + 1 >= s.length) return null
-      const escaped = readEscapedCharacter(s, i + 1)
-      if (!escaped) return null
-      value += escaped.value
-      i = escaped.end - 1
-      continue
-    }
-    if (quote === "`" && ch === "$" && s[i + 1] === "{") {
-      return null
-    }
-    if (ch === quote) {
-      return { end: i + 1, value }
-    }
-    value += ch
-  }
-  return null
-}
-
-function readEscapedCharacter(s: string, start: number): { end: number; value: string } | null {
-  const ch = s[start]
-  if (ch === "u") {
-    if (s[start + 1] === "{") {
-      const close = s.indexOf("}", start + 2)
-      if (close === -1) return null
-      const codePoint = Number.parseInt(s.slice(start + 2, close), 16)
-      return Number.isFinite(codePoint) ? { end: close + 1, value: String.fromCodePoint(codePoint) } : null
-    }
-    const codePoint = Number.parseInt(s.slice(start + 1, start + 5), 16)
-    return Number.isFinite(codePoint) ? { end: start + 5, value: String.fromCharCode(codePoint) } : null
-  }
-  if (ch === "x") {
-    const codePoint = Number.parseInt(s.slice(start + 1, start + 3), 16)
-    return Number.isFinite(codePoint) ? { end: start + 3, value: String.fromCharCode(codePoint) } : null
-  }
-  const escapes: Record<string, string> = { b: "\b", f: "\f", n: "\n", r: "\r", t: "\t", v: "\v" }
-  return { end: start + 1, value: escapes[ch] ?? ch }
-}
-
-function skipTrivia(s: string, start: number): number {
-  let i = start
-  while (i < s.length) {
-    while (/\s/.test(s[i] ?? "")) i += 1
-    if (s[i] === "/" && s[i + 1] === "/") {
-      i = s.indexOf("\n", i + 2)
-      if (i === -1) return s.length
-      continue
-    }
-    if (s[i] === "/" && s[i + 1] === "*") {
-      const close = s.indexOf("*/", i + 2)
-      if (close === -1) return s.length
-      i = close + 2
-      continue
-    }
-    break
-  }
-  return i
-}
-
-function hasBlockedStringConcatenation(s: string): boolean {
-  for (let i = 0; i < s.length; i++) {
-    const first = readQuotedLiteral(s, i)
-    if (!first) continue
-
-    const parts = [first.value]
-    let cursor = skipTrivia(s, first.end)
-    while (s[cursor] === "+") {
-      const nextStart = skipTrivia(s, cursor + 1)
-      const next = readQuotedLiteral(s, nextStart)
-      if (!next) break
-      parts.push(next.value)
-      cursor = skipTrivia(s, next.end)
-    }
-
-    if (parts.length > 1 && BLOCKED_GLOBALS.includes(parts.join(""))) {
-      return true
-    }
-    i = first.end - 1
-  }
-  return false
-}
-
-function isExpressionSafe(s: string): boolean {
-  if (hasBlockedStringConcatenation(s)) {
-    return false
-  }
-  const stripped = stripStrings(s)
-  return !BLOCKED_RE.test(stripped)
-}
-
 function expr(s: string | null): ((c: Ctx) => unknown) | null {
   if (!s) return null
   const cached = expressionCache.get(s)
@@ -661,21 +557,15 @@ function expr(s: string | null): ((c: Ctx) => unknown) | null {
     return cached
   }
 
-  if (!isExpressionSafe(s)) {
+  const compiled = compileExpression(s)
+  if (!compiled) {
     if (debug) console.warn(`[litestar] blocked expression: ${s}`)
     cacheExpression(s, null)
     return null
   }
-
-  try {
-    // Expression validated by isExpressionSafe() above — dangerous globals/constructors blocked
-    const fn = new Function("ctx", `with(ctx){return(${s})}`) as (c: Ctx) => unknown
-    cacheExpression(s, fn)
-    return fn
-  } catch {
-    cacheExpression(s, null)
-    return null
-  }
+  const fn = (context: Ctx) => compiled(context)
+  cacheExpression(s, fn)
+  return fn
 }
 
 /** Compile text with ${expr} interpolation - escapes backticks and backslashes */

--- a/src/js/src/helpers/htmx.ts
+++ b/src/js/src/helpers/htmx.ts
@@ -28,7 +28,7 @@
  * @module
  */
 
-import { DEFAULT_CSRF_HEADER_NAME, getCsrfToken } from "./csrf.js"
+import { getCsrfHeaderName, getCsrfToken } from "./csrf.js"
 
 /** Type for route function - matches generated routes.ts */
 type RouteFn = (name: string, params?: Record<string, string | number>) => string
@@ -124,10 +124,11 @@ export function registerHtmxExtension(): void {
     onEvent(name, evt) {
       if (name === "htmx:configRequest") {
         const token = getCsrfToken()
+        const headerName = getCsrfHeaderName()
         const headers = getHeadersFromConfigRequestEvent(evt)
         if (token && headers) {
-          if (headers instanceof Headers) headers.set(DEFAULT_CSRF_HEADER_NAME, token)
-          else headers[DEFAULT_CSRF_HEADER_NAME] = token
+          if (headers instanceof Headers) headers.set(headerName, token)
+          else headers[headerName] = token
         }
       }
       return true

--- a/src/js/src/helpers/index.ts
+++ b/src/js/src/helpers/index.ts
@@ -40,7 +40,7 @@
  */
 
 // CSRF utilities
-export { csrfFetch, csrfHeaders, getCsrfToken } from "./csrf.js"
+export { csrfFetch, csrfHeaders, getCsrfHeaderName, getCsrfToken } from "./csrf.js"
 // Litestar Channels utilities
 export { createChannelsStream, type ChannelName, type ChannelsStreamOptions } from "./channels.js"
 // HTMX utilities

--- a/src/js/src/install-hint.ts
+++ b/src/js/src/install-hint.ts
@@ -75,20 +75,7 @@ export function resolveInstallHint(pkg: string | readonly string[] = "@hey-api/o
  * @returns The full command string (e.g., "npx @hey-api/openapi-ts ..." or "bunx @hey-api/openapi-ts ...")
  */
 export function resolvePackageExecutor(pkg: string, executor?: string): string {
-  // Use || to treat empty string as falsy, triggering detection
-  const runtime = executor || detectExecutor()
-  switch (runtime) {
-    case "bun":
-      return `bunx ${pkg}`
-    case "deno":
-      return `deno run -A npm:${pkg}`
-    case "pnpm":
-      return `pnpm dlx ${pkg}`
-    case "yarn":
-      return `yarn dlx ${pkg}`
-    default:
-      return `npx ${pkg}`
-  }
+  return resolvePackageExecutorArgv(pkg.split(" "), executor).join(" ")
 }
 
 /**
@@ -141,9 +128,14 @@ export function resolvePackageExecutorArgv(args: string[], executor?: string, op
     case "bun":
       if (requiresMultiplePackages) return []
       return ["bunx", ...(packageSpec ? [packageSpec, ...args] : args)]
-    case "deno":
+    case "deno": {
       if (requiresMultiplePackages) return []
-      return ["deno", "run", "-A", ...(packageSpec ? [`npm:${resolveDenoPackageSpec(packageSpec, binName)}`, ...args] : args)]
+      if (packageSpec) {
+        return ["deno", "run", "-A", `npm:${resolveDenoPackageSpec(packageSpec, binName)}`, ...args]
+      }
+      const [firstArg, ...restArgs] = args
+      return firstArg ? ["deno", "run", "-A", `npm:${firstArg}`, ...restArgs] : ["deno", "run", "-A"]
+    }
     case "pnpm":
       if (requiresMultiplePackages && binName) {
         return ["pnpm", "dlx", ...packageSpecs.map((spec) => `--package=${spec}`), binName, ...args]

--- a/src/js/src/shared/bridge-schema.ts
+++ b/src/js/src/shared/bridge-schema.ts
@@ -42,6 +42,8 @@ export interface BridgeSchema {
   assetUrl: string
   deployAssetUrl: string | null
   appUrl: string | null
+  csrfCookieName: string | null
+  csrfHeaderName: string | null
   /**
    * Litestar dev server port. Used by framework integrations to set
    * `vite.server.ws.clientPort` on Vite 8.1+ (`vite.server.hmr.clientPort` on
@@ -89,6 +91,8 @@ const allowedTopLevelKeys: ReadonlySet<string> = new Set([
   "assetUrl",
   "deployAssetUrl",
   "appUrl",
+  "csrfCookieName",
+  "csrfHeaderName",
   "litestarPort",
   "bundleDir",
   "resourceDir",
@@ -287,6 +291,8 @@ export function parseBridgeSchema(value: unknown): BridgeSchema {
   const assetUrl = assertString(obj, "assetUrl")
   const deployAssetUrl = assertNullableString(obj, "deployAssetUrl")
   const appUrl = assertOptionalNullableString(obj, "appUrl")
+  const csrfCookieName = assertOptionalNullableString(obj, "csrfCookieName")
+  const csrfHeaderName = assertOptionalNullableString(obj, "csrfHeaderName")
   const litestarPort = assertOptionalNullableInteger(obj, "litestarPort")
   const bundleDir = assertString(obj, "bundleDir")
   const resourceDir = assertString(obj, "resourceDir")
@@ -312,6 +318,8 @@ export function parseBridgeSchema(value: unknown): BridgeSchema {
     assetUrl,
     deployAssetUrl,
     appUrl,
+    csrfCookieName,
+    csrfHeaderName,
     litestarPort,
     bundleDir,
     resourceDir,

--- a/src/js/tests/__fixtures__/executor-argv-parity.json
+++ b/src/js/tests/__fixtures__/executor-argv-parity.json
@@ -1,0 +1,60 @@
+{
+  "cases": [
+    {
+      "label": "bare_binary_npm",
+      "executor": "node",
+      "binary": "vite",
+      "package_name": null,
+      "python": ["npx", "vite"],
+      "js": ["npx", "vite"]
+    },
+    {
+      "label": "bare_binary_bun",
+      "executor": "bun",
+      "binary": "vite",
+      "package_name": null,
+      "python": ["bunx", "vite"],
+      "js": ["bunx", "vite"]
+    },
+    {
+      "label": "bare_binary_deno",
+      "executor": "deno",
+      "binary": "vite",
+      "package_name": null,
+      "python": ["deno", "run", "-A", "npm:vite"],
+      "js": ["deno", "run", "-A", "npm:vite"]
+    },
+    {
+      "label": "bare_binary_yarn",
+      "executor": "yarn",
+      "binary": "vite",
+      "package_name": null,
+      "python": ["yarn", "dlx", "vite"],
+      "js": ["yarn", "dlx", "vite"]
+    },
+    {
+      "label": "bare_binary_pnpm",
+      "executor": "pnpm",
+      "binary": "vite",
+      "package_name": null,
+      "python": ["pnpm", "dlx", "vite"],
+      "js": ["pnpm", "dlx", "vite"]
+    },
+    {
+      "label": "deno_default_bin_matches_scoped_package",
+      "executor": "deno",
+      "binary": "openapi-ts",
+      "package_name": "@hey-api/openapi-ts@0.98.2",
+      "python": ["deno", "run", "-A", "npm:@hey-api/openapi-ts@0.98.2"],
+      "js": ["deno", "run", "-A", "npm:@hey-api/openapi-ts@0.98.2"]
+    },
+    {
+      "label": "deno_default_bin_differs",
+      "executor": "deno",
+      "binary": "litestar-vite-typegen",
+      "package_name": "litestar-vite-plugin",
+      "python": ["deno", "run", "-A", "npm:litestar-vite-plugin/litestar-vite-typegen"],
+      "js": ["deno", "run", "-A", "npm:litestar-vite-plugin/litestar-vite-typegen"]
+    }
+  ]
+}

--- a/src/js/tests/helpers/csrf.test.ts
+++ b/src/js/tests/helpers/csrf.test.ts
@@ -47,6 +47,40 @@ describe("csrf helpers", () => {
     vi.restoreAllMocks()
   })
 
+  describe("configured CSRF names from injected runtime state", () => {
+    it("uses the configured header name in csrfHeaders", () => {
+      globalThis.window.__LITESTAR_CSRF__ = "tok"
+      ;(globalThis.window as unknown as Record<string, unknown>).__LITESTAR_CSRF_HEADER_NAME__ = "x-custom-header"
+
+      expect(csrfHeaders()).toEqual({ "x-custom-header": "tok" })
+    })
+
+    it("falls back to the default header name when no global is injected", () => {
+      globalThis.window.__LITESTAR_CSRF__ = "tok"
+
+      expect(csrfHeaders()).toEqual({ "X-CSRFToken": "tok" })
+    })
+
+    it("uses the configured header name in csrfFetch", async () => {
+      globalThis.window.__LITESTAR_CSRF__ = "tok"
+      ;(globalThis.window as unknown as Record<string, unknown>).__LITESTAR_CSRF_HEADER_NAME__ = "x-custom-header"
+      ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(new Response())
+
+      await csrfFetch("/api/submit")
+
+      const callArgs = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
+      expect(getHeaderValue(callArgs[1].headers, "x-custom-header")).toBe("tok")
+    })
+
+    it("uses the configured cookie name as the first cookie fallback", () => {
+      globalThis.window.__LITESTAR_CSRF__ = undefined
+      ;(globalThis.window as unknown as Record<string, unknown>).__LITESTAR_CSRF_COOKIE_NAME__ = "custom_cookie"
+      ;(globalThis.document as unknown as { cookie: string }).cookie = "custom_cookie=custom-cookie-value; csrftoken=default-value"
+
+      expect(getCsrfToken()).toBe("custom-cookie-value")
+    })
+  })
+
   describe("getCsrfToken", () => {
     it("returns token from window.__LITESTAR_CSRF__ (SPA mode)", () => {
       globalThis.window.__LITESTAR_CSRF__ = "spa-csrf-token-123"

--- a/src/js/tests/helpers/htmx.test.ts
+++ b/src/js/tests/helpers/htmx.test.ts
@@ -194,6 +194,21 @@ describe("htmx extension", () => {
         expect(second).toHaveBeenCalledWith(2)
         expect(first).toHaveBeenCalledTimes(1)
       })
+
+      it("exposes a sanitized plain-object event wrapper", () => {
+        container.innerHTML = '<input name="q" @input="capture($event)">'
+        const capture = vi.fn()
+        swapJson(container, { capture })
+
+        const input = container.querySelector("input") as HTMLInputElement
+        input.value = "search"
+        input.dispatchEvent(new Event("input"))
+
+        const event = capture.mock.calls[0]?.[0] as Record<string, unknown>
+        expect((event.target as Record<string, unknown>).value).toBe("search")
+        expect(event.preventDefault).toBeTypeOf("function")
+        expect(event.view).toBeUndefined()
+      })
     })
 
     describe("ls-show/ls-hide", () => {
@@ -469,7 +484,7 @@ describe("htmx extension", () => {
 
   // ===== Expression Security =====
 
-  describe("expression validation (injection prevention)", () => {
+  describe("expression sandbox (allowlist evaluator)", () => {
     beforeEach(() => {
       __clearExpressionCache()
     })
@@ -516,6 +531,28 @@ describe("htmx extension", () => {
       expect(__compileExpressionForTest("onClick(id)")).toBeTypeOf("function")
     })
 
+    it("blocks indirect-this IIFE reaching globals", () => {
+      expect(__compileExpressionForTest("(function(){return this})().fetch('/x')")).toBeNull()
+    })
+
+    it("blocks bare this reaching globalThis", () => {
+      expect(__compileExpressionForTest("this.fetch('/x')")).toBeNull()
+    })
+
+    it("blocks array and computed member access", () => {
+      expect(__compileExpressionForTest("['win','dow'].join('')")).toBeNull()
+      expect(__compileExpressionForTest("[].map.constructor")).toBeNull()
+      expect(__compileExpressionForTest("$data['constructor']")).toBeNull()
+    })
+
+    it("blocks reserved prototype identifiers and reflection paths", () => {
+      expect(__compileExpressionForTest("constructor")).toBeNull()
+      expect(__compileExpressionForTest("__proto__")).toBeNull()
+      expect(__compileExpressionForTest("prototype")).toBeNull()
+      expect(__compileExpressionForTest("constructor.defineProperty(constructor.getPrototypeOf({}), 'polluted', { value: true })")).toBeNull()
+      expect(__compileExpressionForTest("constructor.getOwnPropertyDescriptor(constructor.getPrototypeOf(constructor), 'constructor').value")).toBeNull()
+    })
+
     it("rejects constructor access", () => {
       expect(__compileExpressionForTest("constructor.constructor('alert(1)')()")).toBeNull()
     })
@@ -528,40 +565,8 @@ describe("htmx extension", () => {
       expect(__compileExpressionForTest("Object.prototype.x = 1")).toBeNull()
     })
 
-    it("rejects window access", () => {
-      expect(__compileExpressionForTest("window.location")).toBeNull()
-    })
-
-    it("rejects document access", () => {
-      expect(__compileExpressionForTest("document.cookie")).toBeNull()
-    })
-
-    it("rejects globalThis access", () => {
-      expect(__compileExpressionForTest("globalThis.fetch('/')")).toBeNull()
-    })
-
-    it("rejects Function constructor", () => {
-      expect(__compileExpressionForTest("Function('return this')()")).toBeNull()
-    })
-
     it("rejects import() expressions", () => {
       expect(__compileExpressionForTest("import('evil-module')")).toBeNull()
-    })
-
-    it("rejects blocked globals reconstructed by string concatenation", () => {
-      expect(__compileExpressionForTest("'doc' + 'ument'")).toBeNull()
-      expect(__compileExpressionForTest('"Fun" + "ction"')).toBeNull()
-      expect(__compileExpressionForTest("'con' + 'structor'")).toBeNull()
-    })
-
-    it("rejects blocked globals reconstructed with escaped string segments", () => {
-      expect(__compileExpressionForTest('"con\\u0073" + "tructor"')).toBeNull()
-      expect(__compileExpressionForTest('"doc\\x75" + "\\u006d" + "ent"')).toBeNull()
-    })
-
-    it("rejects blocked globals reconstructed across comments", () => {
-      expect(__compileExpressionForTest("'con' /* hidden */ + 'structor'")).toBeNull()
-      expect(__compileExpressionForTest("'Fun' // line break\n + 'ction'")).toBeNull()
     })
 
     it("allows safe string concatenation", () => {
@@ -569,9 +574,61 @@ describe("htmx extension", () => {
       expect(__compileExpressionForTest("'Hello, ' + name")).toBeTypeOf("function")
     })
 
-    it("rejects self/top/parent global access", () => {
-      expect(__compileExpressionForTest("self.location")).toBeNull()
-      expect(__compileExpressionForTest("top.location")).toBeNull()
+    for (const src of ["window.location", "document.cookie", "globalThis.fetch('/')", "self.location", "top.location", "Function('return this')()"]) {
+      it(`renders ${src} inert (no global reach)`, () => {
+        const fn = __compileExpressionForTest(src)
+        expect(fn).toBeTypeOf("function")
+        expect(fn?.({ $data: {} } as never)).toBeUndefined()
+      })
+    }
+
+    it("does not leak Object.prototype members through bare identifiers", () => {
+      for (const src of ["hasOwnProperty", "valueOf", "toString", "isPrototypeOf"]) {
+        const fn = __compileExpressionForTest(src)
+        expect(fn).toBeTypeOf("function")
+        expect(fn?.({ $data: {} } as never)).toBeUndefined()
+      }
+    })
+
+    it("treats string-reconstructed names as inert strings", () => {
+      const fn = __compileExpressionForTest("'doc' + 'ument'")
+      expect(fn?.({ $data: {} } as never)).toBe("document")
+    })
+
+    it("rejects member access on non-plain host receivers", () => {
+      const win = { eval: () => "PWNED", fetch: () => "PWNED", cookie: "secret" }
+      const eventTargetProto = {}
+      const eventProto = Object.create(eventTargetProto) as Record<string, unknown>
+      Object.defineProperty(eventProto, "view", { get: () => win })
+      Object.defineProperty(eventProto, "target", {
+        get: () => ({ ownerDocument: { defaultView: win, cookie: "secret" } }),
+      })
+      const hostLikeEvent = Object.create(eventProto) as Record<string, unknown>
+      const ctx = { $data: {}, $event: hostLikeEvent } as never
+      for (const src of ["$event.view", "$event.view.fetch", "$event.target.ownerDocument.defaultView", "$event.target.ownerDocument.cookie"]) {
+        const fn = __compileExpressionForTest(src)
+        expect(fn).toBeTypeOf("function")
+        expect(fn?.(ctx)).toBeUndefined()
+      }
+    })
+
+    it("preserves supported expression semantics", () => {
+      const ctx = {
+        $data: {},
+        a: 2,
+        b: "fallback",
+        user: { tags: ["one", "two"] },
+        isActive: true,
+      } as never
+      expect(__compileExpressionForTest("1 + 2 * 3 === 7")?.(ctx)).toBe(true)
+      expect(__compileExpressionForTest("false && missingFn()")?.(ctx)).toBe(false)
+      expect(__compileExpressionForTest("missing ?? b")?.(ctx)).toBe("fallback")
+      expect(__compileExpressionForTest("user.tags.join('/')")?.(ctx)).toBe("one/two")
+      expect(__compileExpressionForTest("{ active: isActive, hidden: false }")?.(ctx)).toEqual({
+        active: true,
+        hidden: false,
+      })
+      expect(__compileExpressionForTest("`x-${a}-${b}`")?.(ctx)).toBe("x-2-fallback")
     })
 
     it("does not false-positive on property names containing blocked words", () => {

--- a/src/js/tests/helpers/htmx.test.ts
+++ b/src/js/tests/helpers/htmx.test.ts
@@ -653,6 +653,25 @@ describe("htmx extension", () => {
       expect(detail.headers["X-CSRFToken"]).toBe("csrf-token")
     })
 
+    it("uses the configured header name when injected", () => {
+      const defineExtension = vi.fn()
+      ;(window as unknown as Record<string, unknown>).__LITESTAR_CSRF__ = "csrf-token"
+      ;(window as unknown as Record<string, unknown>).__LITESTAR_CSRF_HEADER_NAME__ = "x-custom-header"
+      ;(window as unknown as Record<string, unknown>).htmx = { defineExtension, process: vi.fn() }
+
+      registerHtmxExtension()
+
+      const ext = defineExtension.mock.calls[0]?.[1] as { onEvent?: (name: string, evt: CustomEvent) => void }
+      const detail = { headers: {} as Record<string, string> }
+      const evt = new CustomEvent("htmx:configRequest", { detail })
+      ext.onEvent?.("htmx:configRequest", evt)
+
+      expect(detail.headers["x-custom-header"]).toBe("csrf-token")
+      expect(detail.headers["X-CSRFToken"]).toBeUndefined()
+
+      delete (window as unknown as Record<string, unknown>).__LITESTAR_CSRF_HEADER_NAME__
+    })
+
     it("does not throw if event detail is missing/invalid", () => {
       const defineExtension = vi.fn()
       ;(window as unknown as Record<string, unknown>).__LITESTAR_CSRF__ = "csrf-token"

--- a/src/js/tests/index.test.ts
+++ b/src/js/tests/index.test.ts
@@ -2161,9 +2161,6 @@ describe("inertia-helpers", () => {
 
   beforeEach(() => {
     vi.resetModules()
-    vi.mock("./__data__/dummy.ts", () => ({
-      default: "Dummy File",
-    }))
   })
 
   it("pass glob value to resolvePageComponent", async () => {

--- a/src/js/tests/install-hint.test.ts
+++ b/src/js/tests/install-hint.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { detectExecutor, resolveInstallHint, resolvePackageExecutor, resolvePackageExecutorArgv } from "../src/install-hint"
+import fixtureData from "./__fixtures__/executor-argv-parity.json"
 
 // Mock fs module
 vi.mock("node:fs", () => ({
@@ -12,6 +13,14 @@ vi.mock("node:fs", () => ({
 }))
 
 import fs from "node:fs"
+
+describe("executor argv parity fixture", () => {
+  it.each(fixtureData.cases)("$label", (testCase) => {
+    const options = testCase.package_name ? { packageSpec: testCase.package_name, binName: testCase.binary } : {}
+    const args = testCase.package_name ? [] : [testCase.binary]
+    expect(resolvePackageExecutorArgv(args, testCase.executor, options)).toEqual(testCase.js)
+  })
+})
 
 describe("install-hint", () => {
   const originalEnv = { ...process.env }

--- a/src/js/tests/shared/bridge-schema.test.ts
+++ b/src/js/tests/shared/bridge-schema.test.ts
@@ -79,6 +79,34 @@ describe("bridge schema litestarPort", () => {
   })
 })
 
+describe("bridge schema csrf names", () => {
+  it("accepts string csrfCookieName/csrfHeaderName", () => {
+    const config = parseBridgeSchema({
+      ...baseBridgeConfig,
+      csrfCookieName: "custom_cookie",
+      csrfHeaderName: "x-custom-header",
+    })
+    expect(config.csrfCookieName).toBe("custom_cookie")
+    expect(config.csrfHeaderName).toBe("x-custom-header")
+  })
+
+  it("accepts null csrfCookieName/csrfHeaderName", () => {
+    const config = parseBridgeSchema({
+      ...baseBridgeConfig,
+      csrfCookieName: null,
+      csrfHeaderName: null,
+    })
+    expect(config.csrfCookieName).toBeNull()
+    expect(config.csrfHeaderName).toBeNull()
+  })
+
+  it("treats missing csrfCookieName/csrfHeaderName as null for older bridge files", () => {
+    const config = parseBridgeSchema(baseBridgeConfig)
+    expect(config.csrfCookieName).toBeNull()
+    expect(config.csrfHeaderName).toBeNull()
+  })
+})
+
 describe("bridge schema additive fields", () => {
   it("warns and ignores unknown top-level keys", () => {
     const config = parseBridgeSchema({ ...baseBridgeConfig, futureField: true })

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -422,7 +422,7 @@ def _find_scaffold_collisions(
     use_tailwind: bool,
 ) -> list[Path]:
     """Return existing paths that would make scaffold output unsafe without overwrite."""
-    from litestar_vite.scaffolding.generator import _resolve_framework_template_dir, get_template_dir
+    from litestar_vite.scaffolding.generator import get_template_dir, resolve_framework_template_dir
 
     template_dir = get_template_dir()
     root_files: set[str] = set()
@@ -438,7 +438,7 @@ def _find_scaffold_collisions(
 
     if framework.uses_vite:
         _add_root_files(template_dir / "base")
-    _add_root_files(_resolve_framework_template_dir(template_dir, framework.type.value))
+    _add_root_files(resolve_framework_template_dir(template_dir, framework.type.value))
     if use_tailwind:
         _add_root_files(template_dir / "addons" / "tailwindcss")
 
@@ -1272,6 +1272,9 @@ def generate_types(app: "Litestar", verbose: "bool") -> None:
     Args:
         app: The Litestar application instance.
         verbose: Whether to enable verbose output.
+
+    Raises:
+        SystemExit: If type generation fails or no files are exported.
     """
     from litestar_vite.codegen import export_integration_assets
     from litestar_vite.plugin._utils import write_runtime_config_file

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -1014,6 +1014,21 @@ def export_routes(
             raise LitestarCLIException(msg) from e
 
 
+def _default_bin_name_from_package_spec(package_spec: str) -> str:
+    """Return the default binary name for an npm package spec.
+
+    Returns:
+        The last package-name segment with any version suffix removed.
+    """
+    if package_spec.startswith("@"):
+        slash_index = package_spec.index("/")
+        at_index = package_spec.find("@", slash_index + 1)
+    else:
+        at_index = package_spec.find("@")
+    name = package_spec if at_index == -1 else package_spec[:at_index]
+    return name.rsplit("/", 1)[-1]
+
+
 def _get_package_executor_cmd(executor: "str | None", binary: str, *, package_name: "str | None" = None) -> "list[str]":
     """Build package executor command list.
 
@@ -1034,7 +1049,8 @@ def _get_package_executor_cmd(executor: "str | None", binary: str, *, package_na
         case "bun":
             return ["bunx", "--package", package, binary] if package_name else ["bunx", binary]
         case "deno":
-            deno_package = f"{package}/{binary}" if package != binary else package
+            default_bin = _default_bin_name_from_package_spec(package)
+            deno_package = package if default_bin == binary else f"{package}/{binary}"
             return ["deno", "run", "-A", f"npm:{deno_package}"]
         case "yarn":
             return ["yarn", "dlx", "--package", package, binary] if package_name else ["yarn", "dlx", binary]

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -24,10 +24,12 @@ from litestar_vite.doctor import ViteDoctor
 from litestar_vite.exceptions import ViteExecutionError
 from litestar_vite.plugin import VitePlugin, set_environment
 from litestar_vite.scaffolding import TemplateContext, generate_project, get_available_templates
-from litestar_vite.scaffolding.templates import FrameworkType, get_template
+from litestar_vite.scaffolding.templates import get_template
 
 if TYPE_CHECKING:
     from litestar import Litestar
+
+    from litestar_vite.scaffolding.templates import FrameworkTemplate
 
 
 FRAMEWORK_CHOICES = [
@@ -410,24 +412,43 @@ def _prompt_for_options(
     return enable_ssr or False, tailwind, enable_types, generate_zod, generate_client
 
 
-def _find_scaffold_collisions(base: Path, resource_dir: str, bundle_dir: str, static_dir: str) -> list[Path]:
+def _find_scaffold_collisions(
+    base: Path,
+    resource_dir: str,
+    bundle_dir: str,
+    static_dir: str,
+    *,
+    framework: "FrameworkTemplate",
+    use_tailwind: bool,
+) -> list[Path]:
     """Return existing paths that would make scaffold output unsafe without overwrite."""
-    generated_root_files = {
-        "angular.json",
-        "index.html",
-        "package.json",
-        "postcss.config.mjs",
-        "svelte.config.js",
-        "tsconfig.json",
-        "vite.config.ts",
-    }
-    candidates = {
-        base / resource_dir,
-        base / bundle_dir,
-        base / static_dir,
-        *(base / name for name in generated_root_files),
-    }
+    from litestar_vite.scaffolding.generator import _resolve_framework_template_dir, get_template_dir
+
+    template_dir = get_template_dir()
+    root_files: set[str] = set()
+
+    def _add_root_files(directory: Path) -> None:
+        if not directory.exists():
+            return
+        for template_file in directory.glob("**/*.j2"):
+            relative = template_file.relative_to(directory)
+            if relative.parts and relative.parts[0] in {"resources", "public"}:
+                continue
+            root_files.add(str(relative).removesuffix(".j2"))
+
+    if framework.uses_vite:
+        _add_root_files(template_dir / "base")
+    _add_root_files(_resolve_framework_template_dir(template_dir, framework.type.value))
+    if use_tailwind:
+        _add_root_files(template_dir / "addons" / "tailwindcss")
+
+    candidates = {base / resource_dir, base / bundle_dir, base / static_dir, *(base / name for name in root_files)}
     return sorted(path for path in candidates if path.exists())
+
+
+def _is_inertia_framework(framework: "FrameworkTemplate") -> bool:
+    """Return whether a framework template should default to Inertia mode."""
+    return framework.inertia_compatible and "inertia" in framework.type.value
 
 
 @vite_group.command(name="doctor", help="Diagnose and fix Vite configuration issues.")
@@ -626,16 +647,13 @@ def vite_init(
     static_path_str = str(static_path or config.static_dir)
 
     base = root_path / frontend_dir if frontend_dir != "." else root_path
-    collisions = _find_scaffold_collisions(base, resource_path_str, bundle_path_str, static_path_str)
+    collisions = _find_scaffold_collisions(
+        base, resource_path_str, bundle_path_str, static_path_str, framework=framework, use_tailwind=tailwind
+    )
     if (
         collisions
         and not overwrite
-        and (
-            no_prompt
-            or not Confirm.ask(
-                "Files were found in the paths specified. Are you sure you wish to overwrite the contents?"
-            )
-        )
+        and (no_prompt or not Confirm.ask("Files were found in the paths specified. Continue and skip existing files?"))
     ):
         console.print("Skipping Vite initialization")
         sys.exit(2)
@@ -645,16 +663,7 @@ def vite_init(
     )
 
     project_name = root_path.name or "my-project"
-    is_inertia = framework.type in {
-        FrameworkType.REACT_INERTIA,
-        FrameworkType.REACT_INERTIA_JINJA,
-        FrameworkType.VUE_INERTIA,
-        FrameworkType.VUE_INERTIA_SSR,
-        FrameworkType.VUE_INERTIA_JINJA,
-        FrameworkType.VUE_INERTIA_JINJA_SSR,
-        FrameworkType.SVELTE_INERTIA,
-        FrameworkType.SVELTE_INERTIA_JINJA,
-    }
+    is_inertia = _is_inertia_framework(framework)
     context = TemplateContext(
         project_name=project_name,
         framework=framework,

--- a/src/py/litestar_vite/cli.py
+++ b/src/py/litestar_vite/cli.py
@@ -217,7 +217,7 @@ def _build_deploy_config(
 def _prepare_and_build(config: ViteConfig, root_dir: Path, console: Any, app: "Litestar | None", verbose: bool) -> None:
     """Export metadata, run typegen, and execute the configured frontend build."""
     if config.set_environment:
-        set_environment(config=config)
+        set_environment(config=config, app=app)
 
     generated_assets = _generate_schema_and_routes(app, config, console) if app is not None else False
 
@@ -888,7 +888,7 @@ def vite_serve(app: "Litestar", verbose: "bool", quiet: "bool", production: "boo
 
     _apply_cli_log_level(plugin.config, verbose=verbose, quiet=quiet)
     if plugin.config.set_environment:
-        set_environment(config=plugin.config)
+        set_environment(config=plugin.config, app=app)
 
     use_production_server = production or not plugin.config.dev_mode
 

--- a/src/py/litestar_vite/codegen/_export.py
+++ b/src/py/litestar_vite/codegen/_export.py
@@ -48,9 +48,8 @@ def fmt_path(path: Path) -> str:
         return str(path)
 
 
-def typegen_outputs_requested(config: "ViteConfig", types_config: "TypeGenConfig") -> bool:
+def typegen_outputs_requested(types_config: "TypeGenConfig") -> bool:
     """Return whether the typegen config asks for any generated artifact."""
-    del config
     return any((
         types_config.generate_sdk,
         types_config.generate_zod,
@@ -95,7 +94,7 @@ def export_integration_assets(
         return result
 
     types_config = config.types
-    if not typegen_outputs_requested(config, types_config):
+    if not typegen_outputs_requested(types_config):
         return result
 
     # Check if OpenAPI is available

--- a/src/py/litestar_vite/codegen/_export.py
+++ b/src/py/litestar_vite/codegen/_export.py
@@ -11,6 +11,7 @@ Both CLI and Plugin should call this function to guarantee byte-identical output
 
 from dataclasses import dataclass, field
 from functools import partial
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -86,6 +87,7 @@ def export_integration_assets(
     from litestar.serialization import encode_json, get_serializer
 
     from litestar_vite.codegen._inertia import generate_inertia_pages_json
+    from litestar_vite.codegen._routes import extract_route_metadata
     from litestar_vite.config import InertiaConfig, InertiaTypeGenConfig, TypeGenConfig
 
     result = ExportResult()
@@ -134,8 +136,6 @@ def export_integration_assets(
 
     # Step 2: Export openapi.json
     export_openapi(schema_dict=schema_dict, types_config=types_config, serializer=serializer, result=result)
-
-    from litestar_vite.codegen._routes import extract_route_metadata
 
     routes_metadata = extract_route_metadata(app, openapi_schema=schema_dict)
 
@@ -201,10 +201,8 @@ def export_routes_json(
     from litestar_vite.codegen._utils import encode_deterministic_json, write_if_changed
 
     try:
-        from litestar import __version__ as _version
-
-        litestar_version = str(_version)
-    except ImportError:
+        litestar_version = version("litestar")
+    except PackageNotFoundError:
         litestar_version = "unknown"
 
     routes_path = types_config.routes_path

--- a/src/py/litestar_vite/codegen/_inertia.py
+++ b/src/py/litestar_vite/codegen/_inertia.py
@@ -179,6 +179,8 @@ def get_return_type_name(handler: HTTPRouteHandler) -> "str | None":
 
 def _filter_page_props_response_types(field_definition: FieldDefinition) -> FieldDefinition | None:
     """Filter response wrapper types out of a handler return annotation."""
+    from typing import Union
+
     if not field_definition.is_union:
         return field_definition
 
@@ -194,8 +196,6 @@ def _filter_page_props_response_types(field_definition: FieldDefinition) -> Fiel
         return None
     if len(props_types) == 1:
         return FieldDefinition.from_annotation(props_types[0])
-
-    from typing import Union
 
     props_types.sort(key=lambda t: getattr(t, "__qualname__", str(t)))
     union_type = Union[tuple(props_types)]  # type: ignore[valid-type] # noqa: UP007

--- a/src/py/litestar_vite/codegen/_openapi.py
+++ b/src/py/litestar_vite/codegen/_openapi.py
@@ -193,6 +193,8 @@ def _filter_response_types_from_union(field_definition: FieldDefinition) -> Fiel
     Returns:
         Filtered FieldDefinition with response types removed, or None if all types are responses.
     """
+    from typing import Union
+
     # Not a union - return as-is (caller handles response type check)
     if not field_definition.is_union:
         return field_definition
@@ -226,8 +228,6 @@ def _filter_response_types_from_union(field_definition: FieldDefinition) -> Fiel
     props_types.sort(key=lambda t: getattr(t, "__qualname__", str(t)))
 
     # Rebuild union type
-    from typing import Union
-
     union_type = Union[tuple(props_types)]  # type: ignore[valid-type] # noqa: UP007
     return FieldDefinition.from_annotation(union_type)
 

--- a/src/py/litestar_vite/codegen/_refs.py
+++ b/src/py/litestar_vite/codegen/_refs.py
@@ -1,0 +1,34 @@
+"""Shared OpenAPI reference resolution helpers."""
+
+from typing import Any
+
+_COMPONENTS_SCHEMAS_PREFIX = "#/components/schemas/"
+
+
+def extract_schema_ref_name(ref: str) -> "str | None":
+    """Return the schema name from a components-schemas reference.
+
+    Returns:
+        The trailing schema name, or ``None`` for another reference type.
+    """
+    if ref.startswith(_COMPONENTS_SCHEMAS_PREFIX):
+        return ref[len(_COMPONENTS_SCHEMAS_PREFIX) :]
+    return None
+
+
+def resolve_component_schema_name(name: str, components_schemas: "dict[str, Any]") -> "str | None":
+    """Resolve a mangled schema name to a key in ``components.schemas``.
+
+    Returns:
+        The resolved key, or ``None`` when no schema matches.
+    """
+    if name in components_schemas:
+        return name
+    if "_" not in name:
+        return None
+    parts = name.split("_")
+    for index in range(len(parts)):
+        candidate = "_".join(parts[index:])
+        if candidate in components_schemas:
+            return candidate
+    return None

--- a/src/py/litestar_vite/codegen/_routes.py
+++ b/src/py/litestar_vite/codegen/_routes.py
@@ -14,6 +14,7 @@ from litestar._openapi.parameters import (  # pyright: ignore[reportPrivateUsage
 from litestar.handlers import HTTPRouteHandler
 from litestar.routes import HTTPRoute
 
+from litestar_vite.codegen._refs import extract_schema_ref_name, resolve_component_schema_name
 from litestar_vite.codegen._ts import normalize_path, ts_type_from_openapi
 
 _PATH_PARAM_EXTRACT_PATTERN = re.compile(r"\{([^:}]+)(?::([^}]+))?\}")
@@ -71,22 +72,14 @@ def _resolve_component_schema(ref: str, components_schemas: dict[str, Any] | Non
     """Resolve an OpenAPI component schema reference."""
     if not components_schemas:
         return None
-
-    prefix = "#/components/schemas/"
-    if not ref.startswith(prefix):
+    ref_name = extract_schema_ref_name(ref)
+    if ref_name is None:
         return None
-
-    ref_name = ref[len(prefix) :]
-    if ref_name in components_schemas and isinstance(components_schemas[ref_name], dict):
-        return cast("dict[str, Any]", components_schemas[ref_name])
-
-    parts = ref_name.split("_")
-    for i in range(len(parts)):
-        candidate = "_".join(parts[i:])
-        schema = components_schemas.get(candidate)
-        if isinstance(schema, dict):
-            return cast("dict[str, Any]", schema)
-    return None
+    resolved_name = resolve_component_schema_name(ref_name, components_schemas)
+    if resolved_name is None:
+        return None
+    schema = components_schemas.get(resolved_name)
+    return cast("dict[str, Any]", schema) if isinstance(schema, dict) else None
 
 
 def _schema_contains_ref(schema: Any) -> bool:

--- a/src/py/litestar_vite/codegen/_ts.py
+++ b/src/py/litestar_vite/codegen/_ts.py
@@ -5,6 +5,9 @@ import re
 from pathlib import PurePosixPath
 from typing import Any, cast
 
+from litestar_vite.codegen._refs import extract_schema_ref_name as _extract_schema_ref_name
+from litestar_vite.codegen._refs import resolve_component_schema_name as _resolve_component_schema_name
+
 _PATH_PARAM_TYPE_PATTERN = re.compile(r"\{([^:}]+):[^}]+\}")
 
 _OPENAPI_STRING_FORMAT_TO_TS_ALIAS: dict[str, str] = {
@@ -35,43 +38,6 @@ def normalize_path(path: str) -> str:
     if not path or path == "/":
         return path
     return _PATH_PARAM_TYPE_PATTERN.sub(r"{\1}", str(PurePosixPath(path)))
-
-
-def _extract_schema_ref_name(ref: str) -> str | None:
-    """Return the schema name from a ``#/components/schemas/<name>`` ref or None.
-
-    Returns:
-        The trailing schema name when ``ref`` is a components-schemas pointer; None otherwise.
-    """
-    prefix = "#/components/schemas/"
-    if ref.startswith(prefix):
-        return ref[len(prefix) :]
-    return None
-
-
-def _resolve_component_schema_name(name: str, components_schemas: dict[str, Any]) -> str | None:
-    """Resolve Litestar's mangled schema names back to a key in ``components.schemas``.
-
-    Litestar emits fully-qualified module paths in ``$ref`` targets (e.g.
-    ``app_domain_insight_schemas__base_Granularity``) when nested types collide,
-    but ``components.schemas`` is keyed on the short name (``Granularity``).
-    Strip leading underscore-separated segments until a matching key is found.
-
-    Returns:
-        The resolved key from ``components_schemas``, or None when no match is found.
-    """
-    if name in components_schemas:
-        return name
-
-    if "_" not in name:
-        return None
-
-    parts = name.split("_")
-    for i in range(len(parts)):
-        candidate = "_".join(parts[i:])
-        if candidate in components_schemas:
-            return candidate
-    return None
 
 
 def ts_type_from_openapi(schema_dict: dict[str, Any], components_schemas: dict[str, Any] | None = None) -> str:

--- a/src/py/litestar_vite/commands.py
+++ b/src/py/litestar_vite/commands.py
@@ -41,11 +41,11 @@ def init_vite(
         MissingDependencyError: If Jinja2 is not installed.
         ValueError: If the specified framework template is not found.
     """
-    if not JINJA_INSTALLED:
-        raise MissingDependencyError(package="jinja2", install_package="jinja")
-
     from litestar_vite.scaffolding import TemplateContext, generate_project
     from litestar_vite.scaffolding.templates import FrameworkType, get_template
+
+    if not JINJA_INSTALLED:
+        raise MissingDependencyError(package="jinja2", install_package="jinja")
 
     template = get_template(framework)
     if template is None:

--- a/src/py/litestar_vite/config/_runtime.py
+++ b/src/py/litestar_vite/config/_runtime.py
@@ -199,6 +199,8 @@ class RuntimeConfig:
         http2: Enable HTTP/2 for proxy HTTP requests (better multiplexing).
             WebSocket traffic (HMR) uses a separate connection and is unaffected.
         extra_route_prefixes: Additional backend route prefixes excluded from SPA/proxy fallbacks.
+            Registered routes and the OpenAPI path are derived automatically. Use this only to
+            reserve an otherwise unclaimed prefix such as ``"/api"`` or ``"/docs"``.
     """
 
     dev_mode: bool = field(default_factory=lambda: os.getenv("VITE_DEV_MODE", "False") in TRUE_VALUES)

--- a/src/py/litestar_vite/deploy.py
+++ b/src/py/litestar_vite/deploy.py
@@ -6,6 +6,7 @@ DeployConfig is defined in litestar_vite.config and passed into ViteDeployer.
 
 # pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportMissingTypeStubs=false
 
+import importlib
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -55,8 +56,8 @@ def _import_fsspec(storage_backend: "str | None") -> tuple[Any, Callable[..., tu
         msg = "fsspec"
         raise MissingDependencyError(msg, install_package=_suggest_install_extra(storage_backend))
 
-    import fsspec  # pyright: ignore
-    from fsspec.core import url_to_fs  # pyright: ignore
+    fsspec = importlib.import_module("fsspec")
+    url_to_fs = importlib.import_module("fsspec.core").url_to_fs
 
     return fsspec, url_to_fs
 

--- a/src/py/litestar_vite/handler/_app.py
+++ b/src/py/litestar_vite/handler/_app.py
@@ -31,6 +31,7 @@ from litestar_vite.html_transform import (
 from litestar_vite.utils import get_static_resource_path, read_hotfile_url
 
 if TYPE_CHECKING:
+    from litestar.config.csrf import CSRFConfig
     from litestar.connection import Request
     from litestar.handlers.http_handlers import HTTPRouteHandler
     from litestar.types import Guard  # pyright: ignore[reportUnknownVariableType]
@@ -80,6 +81,8 @@ class AppHandler:
         "_cached_html",
         "_cached_transformed_html",
         "_config",
+        "_csrf_cookie_name",
+        "_csrf_header_name",
         "_http_client",
         "_http_client_sync",
         "_initialized",
@@ -88,14 +91,17 @@ class AppHandler:
         "_vite_url",
     )
 
-    def __init__(self, config: "ViteConfig") -> None:
+    def __init__(self, config: "ViteConfig", *, csrf_config: "CSRFConfig | None" = None) -> None:
         """Initialize the SPA handler.
 
         Args:
             config: The Vite configuration.
+            csrf_config: The app's Litestar CSRF configuration, if enabled.
         """
         self._config = config
         self._spa_config: "SPAConfig | None" = config.spa_config
+        self._csrf_cookie_name = csrf_config.cookie_name if csrf_config is not None else None
+        self._csrf_header_name = csrf_config.header_name if csrf_config is not None else None
         self._cached_html: "str | None" = None
         self._cached_bytes: "bytes | None" = None
         self._cached_transformed_html: "str | None" = None
@@ -198,7 +204,12 @@ class AppHandler:
             return html
 
         if self._spa_config.inject_csrf and csrf_token:
-            script = f'window.{self._spa_config.csrf_var_name} = "{csrf_token}";'
+            script_lines = [f'window.{self._spa_config.csrf_var_name} = "{csrf_token}";']
+            if self._csrf_header_name:
+                script_lines.append(f'window.__LITESTAR_CSRF_HEADER_NAME__ = "{self._csrf_header_name}";')
+            if self._csrf_cookie_name:
+                script_lines.append(f'window.__LITESTAR_CSRF_COOKIE_NAME__ = "{self._csrf_cookie_name}";')
+            script = "\n".join(script_lines)
             html = inject_head_script(html, script, escape=False, nonce=self._config.csp_nonce)
 
         if page_data is not None:

--- a/src/py/litestar_vite/handler/_app.py
+++ b/src/py/litestar_vite/handler/_app.py
@@ -28,6 +28,7 @@ from litestar_vite.html_transform import (
     set_data_attribute,
     transform_asset_urls,
 )
+from litestar_vite.plugin._utils import check_h2_available
 from litestar_vite.utils import get_static_resource_path, read_hotfile_url
 
 if TYPE_CHECKING:
@@ -162,12 +163,7 @@ class AppHandler:
         """Initialize HTTP clients for dev mode proxying."""
         self._vite_url = vite_url or self._resolve_vite_url()
 
-        http2_enabled = self._config.http2
-        if http2_enabled:
-            try:
-                import h2  # noqa: F401  # pyright: ignore[reportMissingImports,reportUnusedImport]
-            except ImportError:
-                http2_enabled = False
+        http2_enabled = self._config.http2 and check_h2_available()
 
         self._http_client = httpx.AsyncClient(timeout=httpx.Timeout(5.0), http2=http2_enabled)
         self._http_client_sync = httpx.Client(timeout=httpx.Timeout(5.0))

--- a/src/py/litestar_vite/handler/_app.py
+++ b/src/py/litestar_vite/handler/_app.py
@@ -120,17 +120,23 @@ class AppHandler:
         """
         return self._initialized
 
-    async def initialize_async(self, vite_url: "str | None" = None) -> None:
+    async def initialize_async(self, vite_url: "str | None" = None, manifest: "dict[str, Any] | None" = None) -> None:
         """Initialize the handler asynchronously.
 
         Args:
             vite_url: Optional Vite server URL to use for proxying.
+            manifest: Optional pre-parsed manifest from the shared asset loader. This avoids
+                reading and parsing the same file again during worker startup. It is ignored
+                when hot development or an external development server skips manifest loading.
         """
         if self._initialized:
             return
 
         if self._config.is_dev_mode and self._config.hot_reload:
             self._init_http_clients(vite_url)
+        elif manifest is not None and self._config.runtime.external_dev_server is None:
+            self._manifest = manifest
+            await self._load_index_html_async()
         else:
             await self._load_production_assets_async()
 

--- a/src/py/litestar_vite/handler/_routing.py
+++ b/src/py/litestar_vite/handler/_routing.py
@@ -74,9 +74,10 @@ def get_spa_handler_from_request(request: "Request[Any, Any, Any]") -> "AppHandl
     Raises:
         ImproperlyConfiguredException: If the SPA handler is not available on the route metadata.
     """
+    from litestar_vite.handler._app import AppHandler
+
     opt = get_route_opt(request)
     handler = opt.get("_vite_spa_handler") if opt is not None else None
-    from litestar_vite.handler._app import AppHandler
 
     if isinstance(handler, AppHandler):
         return handler

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1474,6 +1474,30 @@ def _materialize_shared_value(value: "Any") -> "Any":
     return value
 
 
+def materialize_shared_props_to_session(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
+    """Flush scope-stored shared props into the session as serializable values.
+
+    This is called in the handler frame when a redirect or other non-Inertia response needs
+    shared values to survive the next request. Sync special props render here; async special
+    props remain request-local because they cannot be materialized synchronously.
+
+    Args:
+        connection: The current ASGI connection.
+    """
+    scope_shared = _get_scope_shared_props(connection)
+    if not scope_shared:
+        return
+    try:
+        session_shared = connection.session.setdefault("_shared", {})
+    except (AttributeError, ImproperlyConfiguredException):
+        return
+    for key, value in scope_shared.items():
+        materialized = _materialize_shared_value(value)
+        if materialized is _UNMATERIALIZABLE_SHARED:
+            continue
+        session_shared[key] = materialized
+
+
 def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "Any") -> "bool":
     """Share a value in the session.
 

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1477,9 +1477,10 @@ def _materialize_shared_value(value: "Any") -> "Any":
 def materialize_shared_props_to_session(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
     """Flush scope-stored shared props into the session as serializable values.
 
-    This is called in the handler frame when a redirect or other non-Inertia response needs
-    shared values to survive the next request. Sync special props render here; async special
-    props remain request-local because they cannot be materialized synchronously.
+    In-frame redirect construction and wrapped non-Inertia responses call this while handler
+    dependencies are alive. Exception-produced redirects use the same path after dependency
+    cleanup, where synchronous special props render on a best-effort basis. Async special props
+    are always skipped because they cannot be materialized synchronously.
 
     Args:
         connection: The current ASGI connection.
@@ -1504,10 +1505,12 @@ def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "
     Shared values are included in the props of every Inertia response for
     the current request. This is useful for data that should be available
     to all components (e.g., authenticated user, permissions, settings).
-    Top-level special props are materialized before storage; nested special
-    props inside a shared dict or list are not supported. Async top-level
-    special props cannot be persisted to the session, but remain available
-    to the current response from request scope.
+    Top-level special props remain raw in request scope and are materialized lazily in the
+    handler frame only when the response includes them. A redirect materializes synchronous
+    special props into the session so the next request can consume them; exception-produced
+    redirects perform the same work best-effort after dependency cleanup. Async top-level
+    special props cannot be persisted synchronously, return ``False``, and remain available only
+    to the current response. Nested special props inside a shared dict or list are not supported.
 
     Args:
         connection: The ASGI connection.

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1452,6 +1452,16 @@ def get_shared_props(
 _UNMATERIALIZABLE_SHARED = object()
 
 
+def _is_async_special_prop(value: "Any") -> bool:
+    """Return whether a top-level special prop wraps an async callback."""
+    if is_optional_prop(value):
+        return inspect.iscoroutinefunction(value._callback)  # pyright: ignore[reportPrivateUsage]
+    if is_deferred_prop(value) or is_once_prop(value):
+        callback = value._value  # pyright: ignore[reportPrivateUsage]
+        return callable(callback) and inspect.iscoroutinefunction(callback)
+    return False
+
+
 def _materialize_shared_value(value: "Any") -> "Any":
     """Convert top-level special props into session-serializable values for share()."""
     if is_merge_prop(value):
@@ -1483,23 +1493,25 @@ def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "
     Returns:
         True if the value was successfully shared, False otherwise.
     """
-    materialized = _materialize_shared_value(value)
-    if materialized is _UNMATERIALIZABLE_SHARED:
+    if is_special_prop(value) or is_merge_prop(value):
         _set_scope_shared_prop(connection, key, value)
-        connection.logger.warning(
-            "Cannot persist shared prop %r: async special props cannot be materialized for session storage.", key
-        )
-        return False
+        if _is_async_special_prop(value):
+            connection.logger.warning(
+                "Cannot persist shared prop %r across redirects: async special props "
+                "cannot be materialized for session storage.",
+                key,
+            )
+            return False
+        return True
 
     try:
-        connection.session.setdefault("_shared", {}).update({key: materialized})
+        connection.session.setdefault("_shared", {}).update({key: value})
     except (AttributeError, ImproperlyConfiguredException):
         msg = "Unable to share value: session not accessible (user may be unauthenticated)."
         connection.logger.debug(msg)
         return False
-    else:
-        _set_scope_shared_prop(connection, key, value)
-        return True
+    _set_scope_shared_prop(connection, key, value)
+    return True
 
 
 def error(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", message: "str") -> "bool":

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -125,6 +125,7 @@ class InertiaPlugin(InitPlugin):
         )
         from litestar_vite.inertia.helpers import DeferredProp, StaticProp
         from litestar_vite.inertia.middleware import InertiaMiddleware
+        from litestar_vite.inertia.precognition import create_precognition_exception_handler
         from litestar_vite.inertia.request import InertiaRequest
         from litestar_vite.inertia.response import InertiaBack, InertiaResponse
 
@@ -151,8 +152,6 @@ class InertiaPlugin(InitPlugin):
         # For successful validation to return 204 (without executing the handler),
         # use the @precognition decorator on your route handlers.
         if self.config.precognition:
-            from litestar_vite.inertia.precognition import create_precognition_exception_handler
-
             exception_handlers[ValidationException] = create_precognition_exception_handler(
                 fallback_handler=exception_to_http_response
             )
@@ -194,11 +193,11 @@ class InertiaPlugin(InitPlugin):
 
 
 def _request_from_context(kwargs: "dict[str, Any]") -> "Request[Any, Any, Any] | None":
+    from litestar_vite.inertia.middleware import get_current_inertia_request
+
     request = kwargs.get("request")
     if request is not None:
         return cast("Request[Any, Any, Any]", request)
-
-    from litestar_vite.inertia.middleware import get_current_inertia_request
 
     return get_current_inertia_request()
 

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -234,15 +234,15 @@ def _as_inertia_prop_mapping(data: "Any") -> "Mapping[str, Any] | None":
 
 
 async def _resolve_inertia_response_data(data: "Any", request: "Request[Any, Any, Any]") -> "Any":
+    from litestar_vite.inertia.helpers import is_pagination_container, materialize_shared_props_to_session
     from litestar_vite.inertia.response import InertiaResponse
 
     if isinstance(data, InertiaResponse):
         await data.resolve_async_props(request)
         return cast("InertiaResponse[Any]", data)
     if isinstance(data, Response):
+        materialize_shared_props_to_session(request)
         return cast("Response[Any]", data)
-
-    from litestar_vite.inertia.helpers import is_pagination_container
 
     content: "Any"
     if data is None or isinstance(data, Mapping) or is_pagination_container(data):

--- a/src/py/litestar_vite/inertia/precognition.py
+++ b/src/py/litestar_vite/inertia/precognition.py
@@ -261,6 +261,8 @@ def _find_request(args: tuple[Any, ...], kwargs: "dict[str, Any]") -> "Request[A
     """
     from litestar import Request
 
+    from litestar_vite.inertia.middleware import get_current_inertia_request
+
     # Check kwargs first (named 'request' parameter)
     if "request" in kwargs:
         req = kwargs["request"]
@@ -271,7 +273,5 @@ def _find_request(args: tuple[Any, ...], kwargs: "dict[str, Any]") -> "Request[A
     for arg in args:
         if isinstance(arg, Request):  # pyright: ignore[reportUnknownVariableType]
             return arg  # pyright: ignore[reportUnknownVariableType]
-
-    from litestar_vite.inertia.middleware import get_current_inertia_request
 
     return get_current_inertia_request()

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -33,6 +33,7 @@ from litestar_vite.inertia.helpers import (
     is_or_contains_special_prop,
     is_pagination_container,
     lazy_render,
+    materialize_shared_props_to_session,
     pagination_to_dict,
     resolve_async_props,
     should_render,
@@ -706,6 +707,7 @@ class InertiaExternalRedirect(Response[Any]):
             redirect_to: The URL to redirect to (can be external).
             **kwargs: Additional keyword arguments passed to the Response constructor.
         """
+        materialize_shared_props_to_session(request)
         super().__init__(
             content=b"",
             status_code=HTTP_409_CONFLICT,
@@ -733,6 +735,7 @@ class InertiaRedirect(Redirect):
             redirect_to: The URL to redirect to. Must be same-origin or relative.
             **kwargs: Additional keyword arguments passed to the Redirect constructor.
         """
+        materialize_shared_props_to_session(request)
         safe_url = _get_redirect_url(request, redirect_to)
         if _should_use_fragment_redirect(request, safe_url):
             self._uses_inertia_fragment_redirect = True

--- a/src/py/litestar_vite/loader.py
+++ b/src/py/litestar_vite/loader.py
@@ -347,6 +347,15 @@ class ViteAssetLoader:
         """
         self._manifest_content = value
 
+    @property
+    def manifest(self) -> "dict[str, Any]":
+        """The parsed Vite manifest.
+
+        Returns:
+            The parsed manifest dict, or an empty dict in hot-dev mode or before initialization.
+        """
+        return self._manifest
+
     @cached_property
     def version_id(self) -> str:
         """Get the version ID of the manifest.

--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -973,7 +973,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
         await self._asset_loader.initialize()
 
         if self._spa_handler is not None and not self._spa_handler.is_initialized:
-            await self._spa_handler.initialize_async(vite_url=self._proxy_target)
+            await self._spa_handler.initialize_async(vite_url=self._proxy_target, manifest=self._asset_loader.manifest)
 
         is_ssr_mode = self._config.wants_html_proxy
         if not self._config.is_dev_mode and not self._config.has_built_assets() and not is_ssr_mode:

--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -884,7 +884,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
             self._ensure_proxy_target()
 
         if self._config.set_environment:
-            set_environment(config=self._config)
+            set_environment(config=self._config, app=app)
             set_app_environment(app)
 
         self._export_types_sync(app)
@@ -965,7 +965,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
         self._set_route_prefix_state(app.state)
 
         if self._config.set_environment:
-            set_environment(config=self._config)
+            set_environment(config=self._config, app=app)
             set_app_environment(app)
 
         # Initialize shared proxy client for ViteProxyMiddleware/SSRProxyController

--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -840,7 +840,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
 
         from litestar_vite.codegen import export_integration_assets, typegen_outputs_requested
 
-        if not typegen_outputs_requested(self._config, self._config.types):
+        if not typegen_outputs_requested(self._config.types):
             return
 
         try:

--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -742,14 +742,14 @@ class VitePlugin(InitPlugin, CLIPlugin):
         if use_spa_handler:
             from litestar_vite.handler import AppHandler
 
-            self._spa_handler = AppHandler(self._config)
+            self._spa_handler = AppHandler(self._config, csrf_config=app_config.csrf_config)
             app_config.route_handlers.append(self._spa_handler.create_route_handler())
         elif self._config.mode == "hybrid":
             # Hybrid mode prebuilds AppHandler so InertiaResponse._render_spa can reuse it.
             # Template + Inertia uses _render_template (Jinja-direct) and does not need this.
             from litestar_vite.handler import AppHandler
 
-            self._spa_handler = AppHandler(self._config)
+            self._spa_handler = AppHandler(self._config, csrf_config=app_config.csrf_config)
 
         app_config.lifespan.append(self.lifespan)  # pyright: ignore[reportUnknownMemberType]
 

--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -4,6 +4,7 @@ Houses :class:`VitePlugin` and its route-inspection helper. Kept as a private
 module so ``litestar_vite.plugin`` stays a thin re-export surface.
 """
 
+import importlib
 import os
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
@@ -30,7 +31,7 @@ from litestar_vite.plugin._proxy import (
 from litestar_vite.plugin._proxy_headers import ProxyHeadersMiddleware
 from litestar_vite.plugin._static import StaticPlacement, StaticServerConfig, StaticServerMount
 from litestar_vite.plugin._utils import (
-    _build_litestar_route_prefixes,
+    build_litestar_route_prefixes,
     create_proxy_client,
     is_non_serving_assets_cli,
     is_non_serving_context,
@@ -508,9 +509,9 @@ class VitePlugin(InitPlugin, CLIPlugin):
         template_config = app_config.template_config  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
         if template_config is None:
             return False
-        from litestar.plugins.jinja import JinjaTemplateEngine
+        jinja_template_engine = importlib.import_module("litestar.plugins.jinja").JinjaTemplateEngine
 
-        return isinstance(template_config.engine_instance, JinjaTemplateEngine)  # pyright: ignore[reportUnknownMemberType]
+        return isinstance(template_config.engine_instance, jinja_template_engine)  # pyright: ignore[reportUnknownMemberType]
 
     def _configure_static_files(self, app_config: "AppConfig") -> None:
         """Configure static file serving for Vite assets.
@@ -541,6 +542,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
         user_opt = self._static_files_config.get("opt", {})
         if user_opt:
             opt = {**opt, **user_opt}
+        opt["_vite_static_handler"] = True
 
         base_config: dict[str, Any] = {
             "directories": (static_dirs if self._config.is_dev_mode else [bundle_dir]),
@@ -686,11 +688,13 @@ class VitePlugin(InitPlugin, CLIPlugin):
         Returns:
             The modified application configuration.
         """
-        if self._is_inert():
-            return app_config
-
         from litestar import Response
         from litestar.connection import Request as LitestarRequest
+
+        from litestar_vite.handler import AppHandler
+
+        if self._is_inert():
+            return app_config
 
         app_config.signature_namespace["Response"] = Response
         app_config.signature_namespace["Request"] = LitestarRequest
@@ -698,8 +702,6 @@ class VitePlugin(InitPlugin, CLIPlugin):
         # Register proxy headers middleware FIRST if configured
         # This must run before other middleware to ensure correct scheme/client in scope
         if self._config.trusted_proxies is not None:
-            from litestar_vite.plugin._proxy_headers import ProxyHeadersMiddleware
-
             app_config.middleware.insert(
                 0,  # Insert at beginning for early processing
                 DefineMiddleware(ProxyHeadersMiddleware, trusted_hosts=self._config.trusted_proxies),
@@ -741,25 +743,21 @@ class VitePlugin(InitPlugin, CLIPlugin):
             and self._config.runtime.external_dev_server is not None
         )
         if use_spa_handler:
-            from litestar_vite.handler import AppHandler
-
             self._spa_handler = AppHandler(self._config, csrf_config=app_config.csrf_config)
             app_config.route_handlers.append(self._spa_handler.create_route_handler())
         elif self._config.mode == "hybrid":
             # Hybrid mode prebuilds AppHandler so InertiaResponse._render_spa can reuse it.
             # Template + Inertia uses _render_template (Jinja-direct) and does not need this.
-            from litestar_vite.handler import AppHandler
-
             self._spa_handler = AppHandler(self._config, csrf_config=app_config.csrf_config)
 
         app_config.lifespan.append(self.lifespan)  # pyright: ignore[reportUnknownMemberType]
 
         return app_config
 
-    def _get_route_prefixes(self, app: "Litestar") -> tuple[str, ...]:
+    def get_route_prefixes(self, app: "Litestar") -> tuple[str, ...]:
         """Return the immutable route-prefix cache owned by this plugin."""
         if self._route_prefix_cache is None:
-            self._route_prefix_cache = _build_litestar_route_prefixes(app, self._config.runtime.extra_route_prefixes)
+            self._route_prefix_cache = build_litestar_route_prefixes(app, self._config.runtime.extra_route_prefixes)
         return self._route_prefix_cache
 
     def _check_health(self) -> None:
@@ -835,10 +833,10 @@ class VitePlugin(InitPlugin, CLIPlugin):
         Args:
             app: The Litestar application instance.
         """
+        from litestar_vite.codegen import export_integration_assets, typegen_outputs_requested
+
         if not isinstance(self._config.types, TypeGenConfig):
             return
-
-        from litestar_vite.codegen import export_integration_assets, typegen_outputs_requested
 
         if not typegen_outputs_requested(self._config.types):
             return

--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -5,7 +5,7 @@ module so ``litestar_vite.plugin`` stays a thin re-export surface.
 """
 
 import os
-from contextlib import asynccontextmanager, contextmanager, suppress
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
@@ -30,6 +30,7 @@ from litestar_vite.plugin._proxy import (
 from litestar_vite.plugin._proxy_headers import ProxyHeadersMiddleware
 from litestar_vite.plugin._static import StaticPlacement, StaticServerConfig, StaticServerMount
 from litestar_vite.plugin._utils import (
+    _build_litestar_route_prefixes,
     create_proxy_client,
     is_non_serving_assets_cli,
     is_non_serving_context,
@@ -126,6 +127,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
         "_config",
         "_proxy_client",
         "_proxy_target",
+        "_route_prefix_cache",
         "_spa_handler",
         "_ssr_process",
         "_static_files_config",
@@ -158,6 +160,7 @@ class VitePlugin(InitPlugin, CLIPlugin):
         self._static_files_config_supplied = static_files_config is not None
         self._proxy_target: "str | None" = None
         self._proxy_client: "httpx.AsyncClient | None" = None
+        self._route_prefix_cache: tuple[str, ...] | None = None
         self._spa_handler: "AppHandler | None" = None
 
     def _get_vite_process(self) -> ViteProcess:
@@ -686,8 +689,6 @@ class VitePlugin(InitPlugin, CLIPlugin):
         if self._is_inert():
             return app_config
 
-        self._set_route_prefix_state(app_config.state)
-
         from litestar import Response
         from litestar.connection import Request as LitestarRequest
 
@@ -755,13 +756,11 @@ class VitePlugin(InitPlugin, CLIPlugin):
 
         return app_config
 
-    def _set_route_prefix_state(self, state: Any) -> None:
-        """Store route-prefix config on Litestar state for request-time helpers."""
-        extra_prefixes = self._config.runtime.extra_route_prefixes
-        if getattr(state, "litestar_vite_extra_route_prefixes", None) != extra_prefixes:
-            with suppress(AttributeError):
-                del state.litestar_vite_route_prefixes
-        state.litestar_vite_extra_route_prefixes = extra_prefixes
+    def _get_route_prefixes(self, app: "Litestar") -> tuple[str, ...]:
+        """Return the immutable route-prefix cache owned by this plugin."""
+        if self._route_prefix_cache is None:
+            self._route_prefix_cache = _build_litestar_route_prefixes(app, self._config.runtime.extra_route_prefixes)
+        return self._route_prefix_cache
 
     def _check_health(self) -> None:
         """Check if the Vite dev server is running and ready.
@@ -878,8 +877,6 @@ class VitePlugin(InitPlugin, CLIPlugin):
             yield
             return
 
-        self._set_route_prefix_state(app.state)
-
         if self._config.is_dev_mode:
             self._ensure_proxy_target()
 
@@ -961,8 +958,6 @@ class VitePlugin(InitPlugin, CLIPlugin):
             None
         """
         from litestar_vite.loader import ViteAssetLoader
-
-        self._set_route_prefix_state(app.state)
 
         if self._config.set_environment:
             set_environment(config=self._config, app=app)

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -683,17 +683,32 @@ def create_hmr_target_getter(
         2. Main hotfile contents — actual upstream target resolved by the
            frontend side, preserving scheme and normalized host.
 
+    The ``.hmr`` sibling ``Path`` is built once here (not per call). Both candidates are
+    re-stat'd at most once per ``_HOTFILE_REVALIDATE_TTL_SECONDS`` -- including when the
+    ``.hmr`` sibling is absent (the common case) -- so a missing sibling does not cost a
+    stat() on every proxied/HMR-connect request.
+
     Returns:
         A callable that returns the HMR target URL or None if unavailable.
     """
-    cached_mtime_ns: list[int | None] = [None]
-    cached_path: list[Path | None] = [None]
+    if hotfile_path is None:
 
-    def _get_hmr_target_url() -> str | None:
-        if hotfile_path is None:
+        def _no_hmr_target_url() -> str | None:
             return None
 
-        hmr_path = Path(f"{hotfile_path}.hmr")
+        return _no_hmr_target_url
+
+    hmr_path = Path(f"{hotfile_path}.hmr")
+    cached_mtime_ns: list[int | None] = [None]
+    cached_path: list[Path | None] = [None]
+    has_cached_result: list[bool] = [False]
+    last_checked_at: list[float] = [0.0]
+
+    def _get_hmr_target_url() -> str | None:
+        now = time.monotonic()
+        if has_cached_result[0] and (now - last_checked_at[0]) < _HOTFILE_REVALIDATE_TTL_SECONDS:
+            return cached_hmr_target[0].rstrip("/") if cached_hmr_target[0] else None
+
         for candidate, label in ((hmr_path, "HMR target"), (hotfile_path, "HMR target fallback")):
             try:
                 candidate_stat = candidate.stat()
@@ -701,11 +716,12 @@ def create_hmr_target_getter(
                 continue
 
             if (
-                cached_path[0] == candidate
-                and cached_hmr_target[0] is not None
+                has_cached_result[0]
+                and cached_path[0] == candidate
                 and cached_mtime_ns[0] == candidate_stat.st_mtime_ns
             ):
-                return cached_hmr_target[0].rstrip("/")
+                last_checked_at[0] = now
+                return cached_hmr_target[0].rstrip("/") if cached_hmr_target[0] else None
 
             try:
                 url = read_hotfile_url(candidate)
@@ -715,6 +731,8 @@ def create_hmr_target_getter(
             cached_path[0] = candidate
             cached_mtime_ns[0] = candidate_stat.st_mtime_ns
             cached_hmr_target[0] = url
+            has_cached_result[0] = True
+            last_checked_at[0] = now
             if is_proxy_debug():
                 console.print(f"[dim][ssr-proxy] {label}: {url}[/]")
             return url.rstrip("/")
@@ -722,6 +740,8 @@ def create_hmr_target_getter(
         cached_path[0] = None
         cached_mtime_ns[0] = None
         cached_hmr_target[0] = None
+        has_cached_result[0] = True
+        last_checked_at[0] = now
         return None
 
     return _get_hmr_target_url

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -1,6 +1,7 @@
 """HTTP/WebSocket proxy middleware and HMR handlers."""
 
 import logging
+import time
 from collections.abc import AsyncGenerator, Awaitable, Iterable
 from contextlib import suppress
 from pathlib import Path
@@ -113,6 +114,12 @@ _WS_REQUEST_SKIP_HEADERS = _REQUEST_SKIP_HEADERS | {
 }
 
 _LOGGER = logging.getLogger(__name__)
+
+# Bounds how often create_target_url_getter/create_hmr_target_getter re-stat() the hotfile.
+# Keeps the proxy hot path free of a syscall on every proxied request while still picking up
+# a dev-server restart (new hotfile mtime) within one TTL window. Not a correctness cache: a
+# change is always observed within _HOTFILE_REVALIDATE_TTL_SECONDS, never "forever stale".
+_HOTFILE_REVALIDATE_TTL_SECONDS = 0.3
 
 
 def _normalize_header_key(raw_key: Any) -> str:
@@ -613,10 +620,18 @@ def create_target_url_getter(
 ) -> "Callable[[], str | None]":
     """Create a function that returns the current target URL with mtime-revalidated caching.
 
+    Re-stats the hotfile at most once per ``_HOTFILE_REVALIDATE_TTL_SECONDS`` (a monotonic-clock
+    TTL); within that window the last resolved result -- including "no target" from a missing or
+    unreadable hotfile -- is returned without touching the filesystem. A dev-server restart (new
+    hotfile mtime) is still observed on the next check after the TTL elapses, so cached results
+    are never permanently stale.
+
     Returns:
         A callable that returns the target URL or None if unavailable.
     """
     cached_mtime_ns: list[int | None] = [None]
+    has_cached_result: list[bool] = [False]
+    last_checked_at: list[float] = [0.0]
 
     def _get_target_url() -> str | None:
         if target is not None:
@@ -624,27 +639,34 @@ def create_target_url_getter(
         if hotfile_path is None:
             return None
 
+        now = time.monotonic()
+        if has_cached_result[0] and (now - last_checked_at[0]) < _HOTFILE_REVALIDATE_TTL_SECONDS:
+            return cached_target[0].rstrip("/") if cached_target[0] else None
+
         try:
             hotfile_stat = hotfile_path.stat()
         except (FileNotFoundError, OSError):
             cached_target[0] = None
             cached_mtime_ns[0] = None
+            has_cached_result[0] = True
+            last_checked_at[0] = now
             return None
 
-        if cached_target[0] is not None and cached_mtime_ns[0] == hotfile_stat.st_mtime_ns:
+        if has_cached_result[0] and cached_mtime_ns[0] == hotfile_stat.st_mtime_ns:
+            last_checked_at[0] = now
             return cached_target[0].rstrip("/") if cached_target[0] else None
 
         try:
-            url = read_hotfile_url(hotfile_path)
-            cached_target[0] = url
-            cached_mtime_ns[0] = hotfile_stat.st_mtime_ns
+            cached_target[0] = read_hotfile_url(hotfile_path)
             if is_proxy_debug():
-                console.print(f"[dim][{debug_label}] Dynamic target: {url}[/]")
-            return url.rstrip("/")
+                console.print(f"[dim][{debug_label}] Dynamic target: {cached_target[0]}[/]")
         except (FileNotFoundError, OSError):
             cached_target[0] = None
-            cached_mtime_ns[0] = None
-            return None
+
+        cached_mtime_ns[0] = hotfile_stat.st_mtime_ns
+        has_cached_result[0] = True
+        last_checked_at[0] = now
+        return cached_target[0].rstrip("/") if cached_target[0] else None
 
     return _get_target_url
 

--- a/src/py/litestar_vite/plugin/_proxy.py
+++ b/src/py/litestar_vite/plugin/_proxy.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-from collections.abc import AsyncGenerator, Awaitable, Iterable
+from collections.abc import AsyncGenerator, Awaitable
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -121,6 +121,8 @@ _LOGGER = logging.getLogger(__name__)
 # change is always observed within _HOTFILE_REVALIDATE_TTL_SECONDS, never "forever stale".
 _HOTFILE_REVALIDATE_TTL_SECONDS = 0.3
 
+_NO_CONNECTION_TOKENS: "frozenset[str]" = frozenset()
+
 
 def _normalize_header_key(raw_key: Any) -> str:
     """Normalize a raw header key to a lower-cased string."""
@@ -136,13 +138,21 @@ def _normalize_header_value(raw_value: Any) -> str:
     return str(raw_value)
 
 
-def _collect_connection_tokens(headers: Any) -> set[str]:
-    """Collect header names listed in Connection headers."""
-    tokens: set[str] = set()
+def _collect_connection_tokens(headers: Any) -> "frozenset[str]":
+    """Collect header names listed in Connection headers.
+
+    Returns:
+        A frozenset of the additional lower-cased header names to treat as hop-by-hop, or the
+        shared ``_NO_CONNECTION_TOKENS`` sentinel when no ``Connection`` header is present (the
+        common case) so callers can skip copying the base skip-set into a mutable set.
+    """
+    tokens: "set[str] | None" = None
     for key, value in headers:
         if _normalize_header_key(key) == "connection":
+            if tokens is None:
+                tokens = set()
             tokens.update(token.strip().lower() for token in _normalize_header_value(value).split(",") if token.strip())
-    return tokens
+    return frozenset(tokens) if tokens else _NO_CONNECTION_TOKENS
 
 
 def _filter_hop_by_hop_headers(headers: Any) -> list[tuple[str, str]]:
@@ -150,19 +160,23 @@ def _filter_hop_by_hop_headers(headers: Any) -> list[tuple[str, str]]:
     return _extract_request_headers(headers)
 
 
-def _extract_request_headers(
-    headers: Any, extra_skip_headers: "Iterable[bytes | str] | None" = None
-) -> list[tuple[str, str]]:
-    """Extract request headers, excluding hop-by-hop and optional additional skip headers."""
+def _extract_request_headers(headers: Any, extra_skip_headers: "frozenset[str] | None" = None) -> list[tuple[str, str]]:
+    """Extract request headers, excluding hop-by-hop and optional additional skip headers.
+
+    ``extra_skip_headers``, when given, must already be a normalized (lower-cased) frozenset
+    constant (e.g. ``_WS_REQUEST_SKIP_HEADERS``) -- this hot-path function trusts the caller
+    and does no per-call re-normalization or frozenset re-allocation for the base skip set. A
+    mutable copy is made only when the request actually carries dynamic ``Connection`` tokens
+    (RFC 7230 §6.1), which is the uncommon case; otherwise the frozenset is used directly for
+    membership tests.
+    """
     if not headers:
         return []
 
-    skip = _REQUEST_SKIP_HEADERS
-    if extra_skip_headers is not None:
-        skip = skip | frozenset(_normalize_header_key(name) for name in extra_skip_headers)
+    skip = extra_skip_headers if extra_skip_headers is not None else _REQUEST_SKIP_HEADERS
 
-    hop_by_hop = set(skip)
-    hop_by_hop.update(_collect_connection_tokens(headers))
+    connection_tokens = _collect_connection_tokens(headers)
+    hop_by_hop: "frozenset[str] | set[str]" = skip | connection_tokens if connection_tokens else skip
 
     filtered: list[tuple[str, str]] = []
     for key, value in headers:

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -99,8 +99,7 @@ def _check_h2_available() -> bool:
     global _h2_available  # noqa: PLW0603
     if _h2_available is None:
         try:
-            import h2  # noqa: F401  # pyright: ignore[reportMissingImports,reportUnusedImport]
-
+            __import__("h2")
             _h2_available = True
         except ImportError:
             _h2_available = False
@@ -439,6 +438,8 @@ def write_runtime_config_file(
     Returns:
         The path to the written config file.
     """
+    import msgspec
+    from litestar.serialization import encode_json
 
     root = config.root_dir or Path.cwd()
     path = Path(root) / ".litestar.json"
@@ -505,9 +506,6 @@ def write_runtime_config_file(
         "litestarVersion": litestar_version,
         "staticProps": config.static_props or None,
     }
-
-    import msgspec
-    from litestar.serialization import encode_json
 
     content = msgspec.json.format(encode_json(payload), indent=2)
     changed = _write_if_changed(path, content)
@@ -639,7 +637,16 @@ def _route_is_vite_spa(route: Any) -> bool:
     return False
 
 
-def _build_litestar_route_prefixes(app: "Litestar", extra_route_prefixes: tuple[str, ...] = ()) -> tuple[str, ...]:
+def _route_is_vite_static(route: Any) -> bool:
+    """Return whether a route belongs to the Vite-managed static router."""
+    handlers = getattr(route, "route_handlers", None)
+    if not handlers:
+        single = getattr(route, "route_handler", None)
+        handlers = [single] if single is not None else []
+    return any(bool((opt := getattr(handler, "opt", None)) and opt.get("_vite_static_handler")) for handler in handlers)
+
+
+def build_litestar_route_prefixes(app: "Litestar", extra_route_prefixes: tuple[str, ...] = ()) -> tuple[str, ...]:
     """Build Litestar route prefixes from registered routes and explicit configuration.
 
     This function collects all registered route paths from the Litestar application.
@@ -671,7 +678,7 @@ def _build_litestar_route_prefixes(app: "Litestar", extra_route_prefixes: tuple[
         # the prefix list would make is_litestar_route() self-exclude the SPA — non-root
         # spa_path values like "/ui" become unreachable. Identify SPA routes via the
         # _vite_spa_handler marker AppHandler.create_route_handler sets on opt.
-        if _route_is_vite_spa(route):
+        if _route_is_vite_spa(route) or _route_is_vite_static(route):
             continue
         prefix = _normalize_route_prefix(route.path)
         if prefix is not None:
@@ -718,10 +725,10 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
 
     try:
         plugin = app.plugins.get(VitePlugin)
-    except KeyError:
-        result = _build_litestar_route_prefixes(app)
+    except (AttributeError, KeyError):
+        result = build_litestar_route_prefixes(app)
     else:
-        result = plugin._get_route_prefixes(app)
+        result = plugin.get_route_prefixes(app)
 
     if is_proxy_debug():
         console.print(f"[dim][route-detection] Cached prefixes: {result}[/]")
@@ -776,8 +783,8 @@ def vite_not_found_handler(request: "Request[Any, Any, Any]", exc: "NotFoundExce
     """
     from litestar import Response
 
-    if request.headers.get("x-inertia", "").lower() == "true":
-        from litestar_vite.inertia.exception_handler import exception_to_http_response
+    from litestar_vite.inertia.exception_handler import exception_to_http_response
 
+    if request.headers.get("x-inertia", "").lower() == "true":
         return exception_to_http_response(request, exc)
     return Response(status_code=404, content=b"")

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -29,7 +29,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, cast, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 
 import click
 from litestar.cli._utils import console  # pyright: ignore[reportPrivateImportUsage]
@@ -611,11 +611,6 @@ def normalize_prefix(prefix: str) -> str:
     return prefix
 
 
-class _RoutePrefixesState(Protocol):
-    litestar_vite_route_prefixes: tuple[str, ...]
-    litestar_vite_extra_route_prefixes: tuple[str, ...]
-
-
 def _normalize_route_prefix(prefix: str) -> str | None:
     """Normalize route prefixes for SPA/proxy route exclusion."""
     normalized = prefix.strip()
@@ -644,30 +639,23 @@ def _route_is_vite_spa(route: Any) -> bool:
     return False
 
 
-def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
-    """Build a cached list of Litestar route prefixes for the given app.
+def _build_litestar_route_prefixes(app: "Litestar", extra_route_prefixes: tuple[str, ...] = ()) -> tuple[str, ...]:
+    """Build Litestar route prefixes from registered routes and explicit configuration.
 
-    This function collects all registered route paths from the Litestar application
-    and caches them for efficient lookup. The cache is stored in app.state to ensure
-    it's automatically cleaned up when the app is garbage collected.
+    This function collects all registered route paths from the Litestar application.
 
     Includes:
     - All registered Litestar route paths
     - OpenAPI schema/docs paths registered by Litestar
-    - RuntimeConfig.extra_route_prefixes values attached by VitePlugin
+    - Explicit RuntimeConfig.extra_route_prefixes values
 
     Args:
         app: The Litestar application instance.
+        extra_route_prefixes: Explicit backend prefixes configured on VitePlugin.
 
     Returns:
         A tuple of route prefix strings (without trailing slashes).
     """
-    state = cast("_RoutePrefixesState", app.state)
-    try:
-        return state.litestar_vite_route_prefixes
-    except AttributeError:
-        pass
-
     from litestar.routes import WebSocketRoute
 
     prefixes: list[str] = []
@@ -688,6 +676,14 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
         prefix = _normalize_route_prefix(route.path)
         if prefix is not None:
             prefixes.append(prefix)
+            static_segments = [segment for segment in prefix.split("/") if segment and not segment.startswith("{")]
+            parameter_index = next(
+                (index for index, segment in enumerate(prefix.split("/")) if segment.startswith("{")), None
+            )
+            if parameter_index is not None and static_segments:
+                static_prefix = _normalize_route_prefix("/".join(prefix.split("/")[:parameter_index]))
+                if static_prefix is not None:
+                    prefixes.append(static_prefix)
         elif route.path == "/":
             has_root_route = True
 
@@ -700,17 +696,32 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
                 prefixes.append(prefix)
 
     prefixes.extend(
-        prefix
-        for raw_prefix in getattr(state, "litestar_vite_extra_route_prefixes", ())
-        if (prefix := _normalize_route_prefix(raw_prefix)) is not None
+        prefix for raw_prefix in extra_route_prefixes if (prefix := _normalize_route_prefix(raw_prefix)) is not None
     )
 
     unique_prefixes = sorted(set(prefixes), key=len, reverse=True)
     if has_root_route:
         unique_prefixes.append("/")
-    result = tuple(unique_prefixes)
+    return tuple(unique_prefixes)
 
-    state.litestar_vite_route_prefixes = result
+
+def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
+    """Return route prefixes, using VitePlugin-owned caching when available.
+
+    Args:
+        app: The Litestar application instance.
+
+    Returns:
+        A tuple of route prefix strings (without trailing slashes).
+    """
+    from litestar_vite.plugin._core import VitePlugin
+
+    try:
+        plugin = app.plugins.get(VitePlugin)
+    except KeyError:
+        result = _build_litestar_route_prefixes(app)
+    else:
+        result = plugin._get_route_prefixes(app)
 
     if is_proxy_debug():
         console.print(f"[dim][route-detection] Cached prefixes: {result}[/]")

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -654,7 +654,6 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
     Includes:
     - All registered Litestar route paths
     - OpenAPI schema/docs paths registered by Litestar
-    - Common API prefixes as fallback (/api, /schema)
     - RuntimeConfig.extra_route_prefixes values attached by VitePlugin
 
     Args:
@@ -700,7 +699,6 @@ def get_litestar_route_prefixes(app: "Litestar") -> tuple[str, ...]:
             if prefix is not None:
                 prefixes.append(prefix)
 
-    prefixes.extend(["/api", "/schema"])
     prefixes.extend(
         prefix
         for raw_prefix in getattr(state, "litestar_vite_extra_route_prefixes", ())

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 
 import click
 from litestar.cli._utils import console  # pyright: ignore[reportPrivateImportUsage]
+from litestar.config.csrf import CSRFConfig
 
 from litestar_vite.codegen import write_if_changed as _write_if_changed
 from litestar_vite.config import InertiaConfig, TypeGenConfig
@@ -559,7 +560,7 @@ def set_environment(config: "ViteConfig", asset_url_override: str | None = None,
     if config.is_dev_mode:
         os.environ.setdefault("VITE_DEV_MODE", str(config.is_dev_mode))
 
-    csrf_config = app.csrf_config if app is not None else None
+    csrf_config = app.csrf_config if app is not None and isinstance(app.csrf_config, CSRFConfig) else None
     csrf_cookie_name = csrf_config.cookie_name if csrf_config is not None else None
     csrf_header_name = csrf_config.header_name if csrf_config is not None else None
     config_path = write_runtime_config_file(

--- a/src/py/litestar_vite/plugin/_utils.py
+++ b/src/py/litestar_vite/plugin/_utils.py
@@ -402,17 +402,33 @@ def _derive_bridge_litestar_port() -> int | None:
 
 
 @overload
-def write_runtime_config_file(config: "ViteConfig", *, asset_url_override: str | None = None) -> str: ...
+def write_runtime_config_file(
+    config: "ViteConfig",
+    *,
+    asset_url_override: str | None = None,
+    csrf_cookie_name: str | None = None,
+    csrf_header_name: str | None = None,
+) -> str: ...
 
 
 @overload
 def write_runtime_config_file(
-    config: "ViteConfig", *, asset_url_override: str | None = None, return_status: bool
+    config: "ViteConfig",
+    *,
+    asset_url_override: str | None = None,
+    csrf_cookie_name: str | None = None,
+    csrf_header_name: str | None = None,
+    return_status: bool,
 ) -> tuple[str, bool]: ...
 
 
 def write_runtime_config_file(
-    config: "ViteConfig", *, asset_url_override: str | None = None, return_status: bool = False
+    config: "ViteConfig",
+    *,
+    asset_url_override: str | None = None,
+    csrf_cookie_name: str | None = None,
+    csrf_header_name: str | None = None,
+    return_status: bool = False,
 ) -> str | tuple[str, bool]:
     """Write a JSON handoff file for the Vite plugin and return its path.
 
@@ -451,6 +467,8 @@ def write_runtime_config_file(
         "manifest": config.manifest_name,
         "mode": config.mode,
         "proxyMode": config.proxy_mode,
+        "csrfCookieName": csrf_cookie_name,
+        "csrfHeaderName": csrf_header_name,
         "port": config.port,
         "host": config.host,
         "ssrOutDir": ssr_out_dir_value,
@@ -497,7 +515,7 @@ def write_runtime_config_file(
     return str(path)
 
 
-def set_environment(config: "ViteConfig", asset_url_override: str | None = None) -> None:
+def set_environment(config: "ViteConfig", asset_url_override: str | None = None, app: "Litestar | None" = None) -> None:
     """Configure environment variables for Vite integration.
 
     Sets environment variables that can be used by both the Python backend
@@ -506,6 +524,7 @@ def set_environment(config: "ViteConfig", asset_url_override: str | None = None)
     Args:
         config: The Vite configuration.
         asset_url_override: Optional asset URL to force (e.g., CDN base during build).
+        app: Optional Litestar app supplying the configured CSRF names.
     """
     litestar_version = os.environ.get("LITESTAR_VERSION") or resolve_litestar_version()
     asset_url = asset_url_override or config.asset_url
@@ -540,7 +559,12 @@ def set_environment(config: "ViteConfig", asset_url_override: str | None = None)
     if config.is_dev_mode:
         os.environ.setdefault("VITE_DEV_MODE", str(config.is_dev_mode))
 
-    config_path = write_runtime_config_file(config)
+    csrf_config = app.csrf_config if app is not None else None
+    csrf_cookie_name = csrf_config.cookie_name if csrf_config is not None else None
+    csrf_header_name = csrf_config.header_name if csrf_config is not None else None
+    config_path = write_runtime_config_file(
+        config, csrf_cookie_name=csrf_cookie_name, csrf_header_name=csrf_header_name
+    )
     os.environ["LITESTAR_VITE_CONFIG_PATH"] = config_path
 
 

--- a/src/py/litestar_vite/scaffolding/generator.py
+++ b/src/py/litestar_vite/scaffolding/generator.py
@@ -197,7 +197,7 @@ def render_template(template_path: Path, context: dict[str, Any]) -> str:
     return template.render(**context)
 
 
-def _resolve_framework_template_dir(template_root: Path, framework_value: str) -> Path:
+def resolve_framework_template_dir(template_root: Path, framework_value: str) -> Path:
     """Resolve the on-disk template directory for a registered framework."""
     return template_root / _TEMPLATE_DIR_ALIASES.get(framework_value, framework_value)
 
@@ -298,7 +298,7 @@ def generate_project(output_dir: Path, context: TemplateContext, *, overwrite: b
     from litestar.cli._utils import console  # pyright: ignore[reportPrivateImportUsage]
 
     template_dir = get_template_dir()
-    framework_dir = _resolve_framework_template_dir(template_dir, context.framework.type.value)
+    framework_dir = resolve_framework_template_dir(template_dir, context.framework.type.value)
     base_dir = template_dir / "base"
     context_dict = context.to_dict()
     rendered_files: list[_RenderedTemplate] = []

--- a/src/py/tests/e2e/conftest.py
+++ b/src/py/tests/e2e/conftest.py
@@ -63,8 +63,6 @@ def _cleanup_processes_after_session() -> Generator[None, None, None]:
     yield
 
     # Stop all cached servers
-    from .conftest import _dev_servers, _prod_servers
-
     for server in list(_dev_servers.values()):
         try:
             server.stop()

--- a/src/py/tests/integration/test_optional_jinja.py
+++ b/src/py/tests/integration/test_optional_jinja.py
@@ -1,6 +1,7 @@
 """Tests for optional Jinja dependency support."""
 
 import gc
+import importlib
 import sys
 import time
 from pathlib import Path
@@ -10,6 +11,7 @@ import pytest
 from litestar.config.app import AppConfig
 from litestar.template.config import TemplateConfig
 
+from litestar_vite.commands import init_vite
 from litestar_vite.config import PathConfig, RuntimeConfig, ViteConfig
 from litestar_vite.exceptions import MissingDependencyError
 
@@ -35,8 +37,6 @@ def test_optional_jinja_init_vite_without_jinja_raises_clear_error(tmp_path: Pat
     """Test init_vite raises clear error when Jinja is missing."""
     # This should raise MissingDependencyError with helpful message
     with pytest.raises(MissingDependencyError, match="Package 'jinja2' is not installed but required"):
-        from litestar_vite.commands import init_vite
-
         init_vite(
             root_path=tmp_path,
             resource_path=tmp_path / "resources",
@@ -103,8 +103,6 @@ def test_optional_jinja_plugin_import_without_jinja_contrib() -> None:
 def test_optional_jinja_cli_without_jinja_shows_helpful_error(tmp_path: Path) -> None:
     """Test CLI commands show helpful error messages when Jinja features are used without dependency."""
     with pytest.raises(MissingDependencyError) as exc_info:
-        from litestar_vite.commands import init_vite
-
         init_vite(
             root_path=tmp_path,
             resource_path=tmp_path / "resources",
@@ -282,9 +280,7 @@ def test_conditional_imports_runtime_imports_fail_gracefully() -> None:
     with patch.dict(sys.modules, {"jinja2": None}):
         with pytest.raises((ImportError, ModuleNotFoundError)):
             # This should fail when trying to actually use jinja2
-            from jinja2 import Environment
-
-            Environment()
+            importlib.import_module("jinja2")
 
 
 # =====================================================
@@ -499,13 +495,13 @@ def test_production_serverless_environment_scenario() -> None:
     start_time = time.time()
 
     # Fast cold start simulation
-    from litestar_vite import ViteConfig, VitePlugin
+    package = importlib.import_module("litestar_vite")
 
     cold_start_time = time.time() - start_time
 
     # Should start quickly for serverless environments
     assert cold_start_time < 0.5, f"Cold start too slow for serverless: {cold_start_time}s"
 
-    config = ViteConfig()
-    plugin = VitePlugin(config=config)
+    config = package.ViteConfig()
+    plugin = package.VitePlugin(config=config)
     assert plugin is not None

--- a/src/py/tests/unit/inertia/test_connection_lifecycle.py
+++ b/src/py/tests/unit/inertia/test_connection_lifecycle.py
@@ -35,7 +35,7 @@ from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
 
 from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
-from litestar_vite.inertia.helpers import optional, share
+from litestar_vite.inertia.helpers import defer, optional, share
 from litestar_vite.plugin import VitePlugin
 
 
@@ -124,8 +124,6 @@ async def test_defer_async_callback_runs_inside_di_scope(
     async def handler(request: Request[Any, Any, Any], conn: NamedDependency[_FakeConnection]) -> "dict[str, Any]":
         async def fetch_stats() -> str:
             return await conn.fetch()
-
-        from litestar_vite.inertia.helpers import defer
 
         return {"stats": defer("stats", fetch_stats)}
 

--- a/src/py/tests/unit/inertia/test_exception_handler.py
+++ b/src/py/tests/unit/inertia/test_exception_handler.py
@@ -2,14 +2,47 @@
 
 from typing import Any
 
-from litestar import get
+from litestar import Request, get
+from litestar.exceptions import NotAuthorizedException
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client
 
 from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
+from litestar_vite.inertia.helpers import once, share
 from litestar_vite.plugin import VitePlugin
+
+
+async def test_shared_prop_survives_exception_redirect(
+    inertia_plugin: InertiaPlugin, vite_plugin: VitePlugin, template_config: TemplateConfig[Any]
+) -> None:
+    """Exception-produced redirects best-effort materialize shared sync props."""
+    calls: list[int] = []
+    inertia_plugin.config.redirect_unauthorized_to = "/login"
+
+    @get("/protected", component="Protected")
+    async def protected(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        share(request, "auth", once("auth", lambda: (calls.append(1), {"user": "Ada"})[1]))
+        raise NotAuthorizedException
+
+    @get("/login", component="Login")
+    async def login() -> dict[str, Any]:
+        return {}
+
+    with create_test_client(
+        route_handlers=[protected, login],
+        plugins=[inertia_plugin, vite_plugin],
+        template_config=template_config,
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+        raise_server_exceptions=False,
+    ) as client:
+        response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert response.json()["props"]["auth"] == {"user": "Ada"}
+    assert calls == [1]
 
 
 async def test_production_500_body_omits_exception_detail(

--- a/src/py/tests/unit/inertia/test_exception_handler.py
+++ b/src/py/tests/unit/inertia/test_exception_handler.py
@@ -21,9 +21,13 @@ async def test_shared_prop_survives_exception_redirect(
     calls: list[int] = []
     inertia_plugin.config.redirect_unauthorized_to = "/login"
 
+    def load_auth() -> dict[str, str]:
+        calls.append(1)
+        return {"user": "Ada"}
+
     @get("/protected", component="Protected")
     async def protected(request: Request[Any, Any, Any]) -> dict[str, Any]:
-        share(request, "auth", once("auth", lambda: (calls.append(1), {"user": "Ada"})[1]))
+        share(request, "auth", once("auth", load_auth))
         raise NotAuthorizedException
 
     @get("/login", component="Login")

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -662,9 +662,13 @@ async def test_share_does_not_execute_discarded_deferred_callable(
 
     calls: list[int] = []
 
+    def load_slow_prop() -> dict[str, int]:
+        calls.append(1)
+        return {"x": 1}
+
     @get("/", component="Home")
     async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
-        share(request, "slow", defer("slow", lambda: (calls.append(1), {"x": 1})[1]))
+        share(request, "slow", defer("slow", load_slow_prop))
         return {"eager": "ok"}
 
     with create_test_client(

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -622,22 +622,20 @@ async def test_share_returns_true_with_session(
         assert data["props"]["user"] == {"name": "Alice"}
 
 
-async def test_share_materializes_sync_special_prop_before_session_write(
+async def test_share_defers_sync_special_prop_materialization(
     inertia_plugin: InertiaPlugin,
     vite_plugin: VitePlugin,
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
-    """Test share() writes rendered values for sync special props."""
-    from litestar_vite.inertia.helpers import always, merge, once, share
+    """Sync special props remain scope-only until the response consumes them."""
+    from litestar_vite.inertia.helpers import once, share
 
     captured: dict[str, Any] = {}
 
     @get("/", component="Home")
     async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
         share(request, "count", once("count", lambda: 42))
-        share(request, "flag", always("flag", "y"))
-        share(request, "posts", merge("posts", [1, 2]))
-        captured["shared"] = dict(request.session["_shared"])
+        captured["shared"] = dict(request.session.get("_shared", {}))
         return {}
 
     with create_test_client(
@@ -650,10 +648,37 @@ async def test_share_materializes_sync_special_prop_before_session_write(
         response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
         assert response.status_code == 200
 
-    assert captured["shared"]["count"] == 42
-    assert isinstance(captured["shared"]["count"], int)
-    assert captured["shared"]["flag"] == "y"
-    assert captured["shared"]["posts"] == [1, 2]
+    assert "count" not in captured["shared"]
+    assert response.json()["props"]["count"] == 42
+
+
+async def test_share_does_not_execute_discarded_deferred_callable(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """A withheld shared deferred prop is not rendered at share() time."""
+    from litestar_vite.inertia.helpers import defer, share
+
+    calls: list[int] = []
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        share(request, "slow", defer("slow", lambda: (calls.append(1), {"x": 1})[1]))
+        return {"eager": "ok"}
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+        assert response.status_code == 200
+        assert "slow" not in response.json()["props"]
+
+    assert calls == []
 
 
 async def test_share_skips_async_special_prop(

--- a/src/py/tests/unit/inertia/test_repository_exception_boundary.py
+++ b/src/py/tests/unit/inertia/test_repository_exception_boundary.py
@@ -16,6 +16,7 @@ from litestar.stores.memory import MemoryStore
 from litestar.testing import create_test_client
 from litestar.utils.deprecation import LitestarDeprecationWarning
 
+from litestar_vite import _typing as lv_typing
 from litestar_vite.config import InertiaConfig, ViteConfig
 
 
@@ -30,6 +31,7 @@ def _repository_error(name: str, base: type[Exception] = Exception) -> type[Exce
 
 
 def _install_advanced_alchemy_exceptions(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Install Advanced Alchemy exception stand-ins."""
     exceptions = ModuleType("advanced_alchemy.exceptions")
 
     repository_error = _repository_error("RepositoryError", _RepositoryException)
@@ -39,8 +41,6 @@ def _install_advanced_alchemy_exceptions(monkeypatch: pytest.MonkeyPatch) -> Mod
     exceptions.IntegrityError = integrity_error
     exceptions.DuplicateKeyError = _repository_error("DuplicateKeyError", integrity_error)
     exceptions.ForeignKeyError = _repository_error("ForeignKeyError", integrity_error)
-
-    import litestar_vite._typing as lv_typing
 
     monkeypatch.setattr(lv_typing, "ADVANCED_ALCHEMY_INSTALLED", True)
     monkeypatch.setattr(lv_typing, "AdvancedAlchemyRepositoryError", exceptions.RepositoryError)
@@ -52,6 +52,7 @@ def _install_advanced_alchemy_exceptions(monkeypatch: pytest.MonkeyPatch) -> Mod
 
 
 def _install_sqlspec_exceptions(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Install SQLSpec exception stand-ins."""
     exceptions = ModuleType("sqlspec.exceptions")
 
     repository_error = _repository_error("RepositoryError", _RepositoryException)
@@ -63,8 +64,6 @@ def _install_sqlspec_exceptions(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     exceptions.ForeignKeyViolationError = _repository_error("ForeignKeyViolationError", integrity_error)
     exceptions.CheckViolationError = _repository_error("CheckViolationError", integrity_error)
     exceptions.NotNullViolationError = _repository_error("NotNullViolationError", integrity_error)
-
-    import litestar_vite._typing as lv_typing
 
     monkeypatch.setattr(lv_typing, "SQLSPEC_INSTALLED", True)
     monkeypatch.setattr(lv_typing, "SQLSpecRepositoryError", exceptions.RepositoryError)

--- a/src/py/tests/unit/inertia/test_request.py
+++ b/src/py/tests/unit/inertia/test_request.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from litestar import MediaType, Request, get
 from litestar.middleware.session.server_side import ServerSideSessionConfig
+from litestar.serialization import decode_json
 from litestar.status_codes import HTTP_200_OK
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
@@ -514,8 +515,6 @@ async def test_page_with_empty_string_value(
         stores={"sessions": MemoryStore()},
     ) as client:
         # With Inertia header, should return JSON
-        from litestar.serialization import decode_json
-
         response = client.get("/empty", headers={InertiaHeaders.ENABLED.value: "true"})
         data = decode_json(response.text)
         # Empty page should fallback to component

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -42,12 +42,77 @@ from litestar_vite.inertia.helpers import (
 from litestar_vite.inertia.response import (
     InertiaBack,
     InertiaExternalRedirect,
+    InertiaRedirect,
     InertiaResponse,
     _InertiaSSRResult,
     _parse_inertia_ssr_payload,
     _render_inertia_ssr,
 )
 from litestar_vite.plugin import VitePlugin
+
+
+async def test_share_sync_special_prop_delivered_across_redirect(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """A shared sync prop is materialized once when an in-frame redirect needs it."""
+    calls: list[int] = []
+
+    @get("/")
+    async def redirect_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        share(request, "cfg", once("cfg", lambda: (calls.append(1), {"a": 1})[1]))
+        return InertiaRedirect(request, "/next")
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, Any]:
+        return {}
+
+    with create_test_client(
+        route_handlers=[redirect_handler, next_handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
+
+    assert response.status_code == 200
+    assert response.json()["props"]["cfg"] == {"a": 1}
+    assert calls == [1]
+
+
+async def test_share_async_special_prop_not_persisted_across_redirect(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """An async shared special prop remains request-local across redirects."""
+
+    async def fetch_slow() -> dict[str, int]:
+        return {"a": 1}
+
+    @get("/")
+    async def redirect_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        share(request, "slow", defer("slow", fetch_slow))
+        return InertiaRedirect(request, "/next")
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, Any]:
+        return {}
+
+    with create_test_client(
+        route_handlers=[redirect_handler, next_handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        redirect_response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
+        assert redirect_response.status_code == 307
+        response = client.get("/next", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
+
+    assert "slow" not in response.json()["props"]
 
 
 async def test_component_enabled(

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -59,9 +59,13 @@ async def test_share_sync_special_prop_delivered_across_redirect(
     """A shared sync prop is materialized once when an in-frame redirect needs it."""
     calls: list[int] = []
 
+    def load_config() -> dict[str, int]:
+        calls.append(1)
+        return {"a": 1}
+
     @get("/")
     async def redirect_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
-        share(request, "cfg", once("cfg", lambda: (calls.append(1), {"a": 1})[1]))
+        share(request, "cfg", once("cfg", load_config))
         return InertiaRedirect(request, "/next")
 
     @get("/next", component="Next")
@@ -2812,8 +2816,6 @@ async def test_inertia_plugin_ssr_client_lifecycle() -> None:
     # (depends on when lifespan runs)
 
     # Use test client to run the lifespan
-    from litestar.testing import create_test_client
-
     with create_test_client(
         route_handlers=[handler],
         plugins=[inertia_plugin, vite_plugin],

--- a/src/py/tests/unit/inertia/test_ssr_di_lifecycle.py
+++ b/src/py/tests/unit/inertia/test_ssr_di_lifecycle.py
@@ -184,6 +184,33 @@ async def test_dict_handler_shared_props_close_over_di_dep(tmp_path: Path) -> No
     assert released_observations == [False]
 
 
+async def test_shared_sync_prop_renders_in_di_scope_without_ssr(tmp_path: Path) -> None:
+    """Lazy shared sync props render before yielded dependencies are released."""
+    inertia_plugin, vite_plugin = _build_hybrid_plugins(tmp_path)
+    released_observations: list[bool] = []
+
+    @get("/", component="Home", dependencies={"conn": Provide(_provide_conn)})
+    async def handler(request: Request[Any, Any, Any], conn: NamedDependency[_FakeConnection]) -> dict[str, Any]:
+        def fetch_user() -> str:
+            released_observations.append(conn.released)
+            return conn.fetch()
+
+        share(request, "user", once("user", fetch_user))
+        return {"message": "ok"}
+
+    with create_test_client(
+        route_handlers=[handler],
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["props"]["user"] == "ok"
+    assert released_observations == [False]
+
+
 async def test_explicit_inertia_response_path_unchanged(tmp_path: Path) -> None:
     """Explicit InertiaResponse returns should keep their existing DI-safe path."""
     inertia_plugin, vite_plugin = _build_hybrid_plugins(tmp_path)

--- a/src/py/tests/unit/test_asset_loader.py
+++ b/src/py/tests/unit/test_asset_loader.py
@@ -22,6 +22,17 @@ def test_parse_manifest_when_file_exists(tmp_path: Path) -> None:
     assert loader._manifest == {"main.js": {"file": "assets/main.123456.js"}}
 
 
+def test_asset_loader_manifest_property_exposes_parsed_dict(tmp_path: Path) -> None:
+    bundle_dir = tmp_path / "public"
+    bundle_dir.mkdir()
+    (bundle_dir / "manifest.json").write_text('{"main.js": {"file": "assets/main.123456.js"}}')
+
+    config = ViteConfig(paths=PathConfig(bundle_dir=bundle_dir), runtime=RuntimeConfig(dev_mode=False))
+    loader = ViteAssetLoader.initialize_loader(config=config)
+
+    assert loader.manifest == {"main.js": {"file": "assets/main.123456.js"}}
+
+
 def test_parse_manifest_when_file_exists_in_vite_dir(tmp_path: Path) -> None:
     bundle_dir = tmp_path / "public"
     (bundle_dir / ".vite").mkdir(parents=True)

--- a/src/py/tests/unit/test_cli.py
+++ b/src/py/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import os
 import subprocess
 from collections.abc import Callable
@@ -668,6 +669,30 @@ def test_cli_get_package_executor_cmd_uses_package_flag_for_typegen() -> None:
         "litestar-vite-typegen",
     ]
     assert _get_package_executor_cmd(None, "tsr") == ["npx", "tsr"]
+
+
+def test_cli_get_package_executor_cmd_deno_skips_suffix_when_package_default_bin_matches() -> None:
+    assert _get_package_executor_cmd("deno", "openapi-ts", package_name="@hey-api/openapi-ts@0.98.2") == [
+        "deno",
+        "run",
+        "-A",
+        "npm:@hey-api/openapi-ts@0.98.2",
+    ]
+    assert _get_package_executor_cmd("deno", "litestar-vite-typegen", package_name="litestar-vite-plugin") == [
+        "deno",
+        "run",
+        "-A",
+        "npm:litestar-vite-plugin/litestar-vite-typegen",
+    ]
+
+
+def test_executor_argv_parity_fixture() -> None:
+    fixture_path = Path(__file__).resolve().parents[4] / "src/js/tests/__fixtures__/executor-argv-parity.json"
+    cases = json.loads(fixture_path.read_text())["cases"]
+    for case in cases:
+        executor = None if case["executor"] == "node" else case["executor"]
+        result = _get_package_executor_cmd(executor, case["binary"], package_name=case["package_name"])
+        assert result == case["python"], case["label"]
 
 
 def _make_local_bin(root_dir: Path, name: str) -> Path:

--- a/src/py/tests/unit/test_cli.py
+++ b/src/py/tests/unit/test_cli.py
@@ -16,6 +16,7 @@ from litestar_vite.cli import (
     _apply_cli_log_level,
     _build_deploy_config,
     _coerce_option_value,
+    _find_scaffold_collisions,
     _format_command,
     _generate_schema_and_routes,
     _get_package_executor_cmd,
@@ -182,6 +183,44 @@ def test_cli_select_template_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("litestar_vite.cli.get_template", lambda *_: None)
     with pytest.raises(SystemExit):
         _select_framework_template("missing", no_prompt=True)
+
+
+def test_cli_is_inertia_framework_matches_commands_py_logic() -> None:
+    from litestar_vite.cli import _is_inertia_framework
+    from litestar_vite.scaffolding.templates import FRAMEWORK_TEMPLATES, FrameworkType
+
+    inertia_types = {
+        FrameworkType.REACT_INERTIA,
+        FrameworkType.REACT_INERTIA_JINJA,
+        FrameworkType.VUE_INERTIA,
+        FrameworkType.VUE_INERTIA_SSR,
+        FrameworkType.VUE_INERTIA_JINJA,
+        FrameworkType.VUE_INERTIA_JINJA_SSR,
+        FrameworkType.SVELTE_INERTIA,
+        FrameworkType.SVELTE_INERTIA_JINJA,
+    }
+    for framework_type, template in FRAMEWORK_TEMPLATES.items():
+        assert _is_inertia_framework(template) == (framework_type in inertia_types), framework_type
+
+
+def test_cli_find_scaffold_collisions_includes_nuxt_root_files(tmp_path: Path) -> None:
+    from litestar_vite.scaffolding.templates import FRAMEWORK_TEMPLATES, FrameworkType
+
+    (tmp_path / "nuxt.config.ts").write_text("", encoding="utf-8")
+    collisions = _find_scaffold_collisions(
+        tmp_path, "src", "public", "public", framework=FRAMEWORK_TEMPLATES[FrameworkType.NUXT], use_tailwind=False
+    )
+    assert tmp_path / "nuxt.config.ts" in collisions
+
+
+def test_cli_find_scaffold_collisions_no_longer_flags_postcss_without_tailwind(tmp_path: Path) -> None:
+    from litestar_vite.scaffolding.templates import FRAMEWORK_TEMPLATES, FrameworkType
+
+    (tmp_path / "postcss.config.mjs").write_text("", encoding="utf-8")
+    collisions = _find_scaffold_collisions(
+        tmp_path, "src", "public", "public", framework=FRAMEWORK_TEMPLATES[FrameworkType.REACT], use_tailwind=False
+    )
+    assert tmp_path / "postcss.config.mjs" not in collisions
 
 
 def test_cli_prompt_for_options_interactive(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/src/py/tests/unit/test_codegen.py
+++ b/src/py/tests/unit/test_codegen.py
@@ -26,6 +26,15 @@ from litestar_vite.codegen._ts import (
 from litestar_vite.config import PathConfig, TypeGenConfig, ViteConfig
 
 
+def test_typegen_outputs_requested_signature_has_no_dead_config_param() -> None:
+    import inspect
+
+    from litestar_vite.codegen._export import typegen_outputs_requested
+
+    params = list(inspect.signature(typegen_outputs_requested).parameters)
+    assert params == ["types_config"], params
+
+
 def testts_type_for_param_basic_types() -> None:
     """Test TypeScript type mapping for basic types."""
     assert ts_type_for_param("string") == "string"

--- a/src/py/tests/unit/test_codegen_refs.py
+++ b/src/py/tests/unit/test_codegen_refs.py
@@ -1,0 +1,13 @@
+from litestar_vite.codegen._refs import extract_schema_ref_name, resolve_component_schema_name
+
+
+def test_extract_schema_ref_name_components_schemas_prefix() -> None:
+    assert extract_schema_ref_name("#/components/schemas/User") == "User"
+    assert extract_schema_ref_name("#/components/parameters/Foo") is None
+
+
+def test_resolve_component_schema_name_mangled_prefix_stripping() -> None:
+    schemas = {"Granularity": {"enum": ["day", "week"]}}
+    assert resolve_component_schema_name("app_domain_insight_schemas__base_Granularity", schemas) == "Granularity"
+    assert resolve_component_schema_name("Granularity", schemas) == "Granularity"
+    assert resolve_component_schema_name("Unknown", schemas) is None

--- a/src/py/tests/unit/test_commands.py
+++ b/src/py/tests/unit/test_commands.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import pytest
 from litestar.serialization import decode_json
 
+from litestar_vite.commands import init_vite
+from litestar_vite.exceptions import MissingDependencyError
 from litestar_vite.scaffolding.templates import CURRENT_NPM_VERSION_RANGES as V
 
 pytestmark = pytest.mark.anyio
@@ -63,11 +65,7 @@ def test_init_vite_with_framework(tmp_path: Path) -> None:
 @patch("litestar_vite.commands.JINJA_INSTALLED", False)
 def test_init_vite_error_when_jinja_missing(tmp_path: Path) -> None:
     """Test init_vite raises appropriate error when Jinja is missing."""
-    from litestar_vite.exceptions import MissingDependencyError
-
     with pytest.raises(MissingDependencyError) as exc_info:
-        from litestar_vite.commands import init_vite
-
         init_vite(
             root_path=tmp_path,
             resource_path=Path("resources"),

--- a/src/py/tests/unit/test_config.py
+++ b/src/py/tests/unit/test_config.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 import pytest
 
 from litestar_vite.config import (
+    JINJA_INSTALLED,
     DeployConfig,
     ExternalDevServer,
     PathConfig,
@@ -13,6 +14,7 @@ from litestar_vite.config import (
     ViteConfig,
 )
 from litestar_vite.config._inertia import InertiaConfig, InertiaSSRConfig
+from litestar_vite.config._runtime import _cached_resolve_proxy_mode
 from litestar_vite.executor import BunExecutor, NodeenvExecutor, NodeExecutor
 
 # C2 narrowed ViteConfig.mode to a Literal union; parametrize over `str` for
@@ -176,8 +178,6 @@ def test_resolve_proxy_mode_cached_by_env(monkeypatch: pytest.MonkeyPatch) -> No
     """Verify proxy-mode env parsing is cached by normalized value."""
     monkeypatch.setenv("VITE_PROXY_MODE", "vite")
 
-    from litestar_vite.config._runtime import _cached_resolve_proxy_mode
-
     _cached_resolve_proxy_mode.cache_clear()
 
     RuntimeConfig()
@@ -311,8 +311,6 @@ def test_mode_auto_detection_template_with_jinja(tmp_path: Path) -> None:
     config = ViteConfig(paths=PathConfig(resource_dir=resource_dir))
 
     # Should default to template if Jinja2 is available, otherwise spa
-    from litestar_vite.config import JINJA_INSTALLED
-
     if JINJA_INSTALLED:
         assert config.mode == "template"
     else:

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -907,6 +907,15 @@ async def test_spa_handler_route_exclusion_api_path(spa_config: ViteConfig) -> N
         assert response.status_code == 200
         assert "Test SPA" in response.text
 
+    spa_only_handler = AppHandler(spa_config)
+    await spa_only_handler.initialize_async()
+    spa_only_app = Litestar(route_handlers=[spa_only_handler.create_route_handler()], openapi_config=None)
+    async with AsyncTestClient(app=spa_only_app) as client:
+        # With no backend route claiming /api, it remains available to the SPA.
+        response = await client.get("/api/playground")
+        assert response.status_code == 200
+        assert "Test SPA" in response.text
+
 
 def test_server_starting_html_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(app_module, "_SERVER_STARTING_PATH", tmp_path / "missing.html")

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 from litestar import Litestar, get
+from litestar.connection import Request
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.params import FromPath, FromQuery
 from litestar.testing import AsyncTestClient
@@ -14,6 +15,7 @@ from litestar.testing import AsyncTestClient
 from litestar_vite.config import ViteConfig
 from litestar_vite.handler import AppHandler
 from litestar_vite.handler import _app as app_module
+from litestar_vite.plugin import is_litestar_route
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -204,8 +206,6 @@ async def test_spa_handler_production_mode(spa_config: ViteConfig) -> None:
         # Create a mock request by making an actual request
         await client.get("/")
         # Get the request from the app's request scope
-        from litestar.connection import Request
-
         mock_request = Mock(spec=Request)
         mock_request.app = app
 
@@ -1432,8 +1432,6 @@ async def test_spa_handler_serves_non_root_spa_path(temp_resource_dir: Path, mon
         return {"book_id": book_id}
 
     app = Litestar(route_handlers=[get_book, route])
-
-    from litestar_vite.plugin import is_litestar_route
 
     # The SPA's own paths must not be classified as Litestar (non-SPA) routes.
     assert is_litestar_route("/ui", app) is False

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -741,6 +741,88 @@ async def test_spa_handler_csrf_injection_sync(temp_resource_dir: Path, monkeypa
     assert "Test SPA" in html
 
 
+async def test_spa_handler_csrf_names_injection(temp_resource_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configured CSRF cookie/header names are injected alongside the token."""
+    from litestar.config.csrf import CSRFConfig
+
+    from litestar_vite.config import PathConfig, RuntimeConfig, SPAConfig
+
+    monkeypatch.delenv("VITE_DEV_MODE", raising=False)
+    monkeypatch.delenv("VITE_HOT_RELOAD", raising=False)
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(resource_dir=temp_resource_dir),
+        runtime=RuntimeConfig(dev_mode=False),
+        spa=SPAConfig(inject_csrf=True, csrf_var_name="__LITESTAR_CSRF__"),
+    )
+    handler = AppHandler(
+        config, csrf_config=CSRFConfig(secret="s", cookie_name="custom_cookie", header_name="x-custom-header")
+    )
+    await handler.initialize_async()
+    mock_scope_state = Mock()
+    mock_scope_state.csrf_token = "tok"
+
+    with patch("litestar.utils.scope.state.ScopeState.from_scope", return_value=mock_scope_state):
+        html = await handler.get_html(Mock())
+
+    assert 'window.__LITESTAR_CSRF_HEADER_NAME__ = "x-custom-header";' in html
+    assert 'window.__LITESTAR_CSRF_COOKIE_NAME__ = "custom_cookie";' in html
+
+
+async def test_spa_handler_csrf_names_injection_uses_litestar_defaults(
+    temp_resource_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Litestar's default configured names are injected explicitly."""
+    from litestar.config.csrf import CSRFConfig
+
+    from litestar_vite.config import PathConfig, RuntimeConfig, SPAConfig
+
+    monkeypatch.delenv("VITE_DEV_MODE", raising=False)
+    monkeypatch.delenv("VITE_HOT_RELOAD", raising=False)
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(resource_dir=temp_resource_dir),
+        runtime=RuntimeConfig(dev_mode=False),
+        spa=SPAConfig(inject_csrf=True, csrf_var_name="__LITESTAR_CSRF__"),
+    )
+    handler = AppHandler(config, csrf_config=CSRFConfig(secret="s"))
+    await handler.initialize_async()
+    mock_scope_state = Mock()
+    mock_scope_state.csrf_token = "tok"
+
+    with patch("litestar.utils.scope.state.ScopeState.from_scope", return_value=mock_scope_state):
+        html = await handler.get_html(Mock())
+
+    assert 'window.__LITESTAR_CSRF_HEADER_NAME__ = "x-csrftoken";' in html
+    assert 'window.__LITESTAR_CSRF_COOKIE_NAME__ = "csrftoken";' in html
+
+
+async def test_spa_handler_csrf_names_absent_without_csrf_config(
+    temp_resource_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No configured CSRF names are injected when CSRF is disabled."""
+    from litestar_vite.config import PathConfig, RuntimeConfig, SPAConfig
+
+    monkeypatch.delenv("VITE_DEV_MODE", raising=False)
+    monkeypatch.delenv("VITE_HOT_RELOAD", raising=False)
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(resource_dir=temp_resource_dir),
+        runtime=RuntimeConfig(dev_mode=False),
+        spa=SPAConfig(inject_csrf=True, csrf_var_name="__LITESTAR_CSRF__"),
+    )
+    handler = AppHandler(config)
+    await handler.initialize_async()
+    mock_scope_state = Mock()
+    mock_scope_state.csrf_token = "tok"
+
+    with patch("litestar.utils.scope.state.ScopeState.from_scope", return_value=mock_scope_state):
+        html = await handler.get_html(Mock())
+
+    assert "__LITESTAR_CSRF_HEADER_NAME__" not in html
+    assert "__LITESTAR_CSRF_COOKIE_NAME__" not in html
+
+
 # ============================================================================
 # SPA Handler Route Exclusion Tests (Vite Proxy Route Exclusion Fix)
 # ============================================================================

--- a/src/py/tests/unit/test_handler.py
+++ b/src/py/tests/unit/test_handler.py
@@ -1017,6 +1017,45 @@ def test_app_handler_loads_manifest_from_vite_dir(tmp_path: Path) -> None:
     assert handler._manifest == {"src/main.ts": {"file": "assets/main.js"}}
 
 
+async def test_app_handler_initialize_async_uses_shared_manifest_without_reparsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A supplied parsed manifest is used without reading manifest.json again."""
+    from litestar_vite.config import PathConfig, RuntimeConfig
+
+    resource_dir = tmp_path / "resources"
+    resource_dir.mkdir()
+    (resource_dir / "index.html").write_text("<html><body><div id='app'></div></body></html>")
+
+    bundle_dir = tmp_path / "public"
+    manifest_dir = bundle_dir / ".vite"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "manifest.json").write_text('{"main.js": {"file": "assets/main.js"}}')
+
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(root=tmp_path, resource_dir="resources", bundle_dir="public", static_dir="public"),
+        runtime=RuntimeConfig(dev_mode=False),
+    )
+    handler = AppHandler(config)
+
+    load_calls = 0
+    original = AppHandler._load_manifest_async
+
+    async def counting_load_manifest_async(self: AppHandler) -> None:
+        nonlocal load_calls
+        load_calls += 1
+        await original(self)
+
+    monkeypatch.setattr(AppHandler, "_load_manifest_async", counting_load_manifest_async)
+
+    shared_manifest = {"main.js": {"file": "assets/DIFFERENT.js"}}
+    await handler.initialize_async(manifest=shared_manifest)
+
+    assert load_calls == 0, "handler must not re-parse manifest.json when a manifest is supplied"
+    assert handler._manifest == shared_manifest
+
+
 def test_transform_asset_urls_in_html_uses_manifest(spa_config: ViteConfig) -> None:
     handler = AppHandler(spa_config)
     handler._manifest = {"entry": {"file": "assets/main.js"}}

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -2152,8 +2152,51 @@ async def test_vite_plugin_lifespan_initializes_spa_handler_async() -> None:
     async with plugin.lifespan(app):
         pass
 
-    plugin._spa_handler.initialize_async.assert_awaited_once_with(vite_url=plugin._proxy_target)
+    plugin._spa_handler.initialize_async.assert_awaited_once_with(
+        vite_url=plugin._proxy_target, manifest=plugin._asset_loader.manifest
+    )
     plugin._spa_handler.initialize_sync.assert_not_called()
+
+
+async def test_vite_plugin_lifespan_parses_manifest_once_across_loader_and_handler(tmp_path: Path) -> None:
+    """The loader and SPA handler decode manifest.json only once during worker startup."""
+    from litestar.serialization import decode_json as real_decode_json
+
+    from litestar_vite.handler import AppHandler
+
+    resource_dir = tmp_path / "resources"
+    resource_dir.mkdir()
+    (resource_dir / "index.html").write_text("<html><body><div id='app'></div></body></html>")
+
+    bundle_dir = tmp_path / "public"
+    manifest_dir = bundle_dir / ".vite"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "manifest.json").write_text('{"main.js": {"file": "assets/main.js"}}')
+
+    config = ViteConfig(
+        mode="spa",
+        paths=PathConfig(root=tmp_path, resource_dir="resources", bundle_dir="public", static_dir="public"),
+        runtime=RuntimeConfig(dev_mode=False),
+    )
+    plugin = VitePlugin(config=config)
+    plugin._spa_handler = AppHandler(config)
+    app = Litestar(route_handlers=[])
+
+    decode_calls = 0
+
+    def counting_decode_json(*args: object, **kwargs: object) -> object:
+        nonlocal decode_calls
+        decode_calls += 1
+        return real_decode_json(*args, **kwargs)
+
+    with (
+        patch("litestar_vite.loader.decode_json", counting_decode_json),
+        patch("litestar_vite.handler._app.decode_json", counting_decode_json),
+    ):
+        async with plugin.lifespan(app):
+            pass
+
+    assert decode_calls == 1, f"expected manifest.json to be decoded exactly once, got {decode_calls}"
 
 
 async def test_vite_plugin_proxy_client_created_in_dev_mode_with_ssr_proxy() -> None:

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -483,6 +483,32 @@ def test_vite_plugin_app_init_static_directories_configuration(tmp_path: Path) -
     assert len(app_config.route_handlers) > 0
 
 
+def test_vite_plugin_app_init_threads_csrf_config_to_spa_handler(tmp_path: Path) -> None:
+    from litestar.config.csrf import CSRFConfig
+
+    plugin = VitePlugin(config=ViteConfig(mode="spa", paths=PathConfig(root=tmp_path)))
+    app_config = AppConfig(
+        csrf_config=CSRFConfig(secret="s", cookie_name="custom_cookie", header_name="x-custom-header")
+    )
+
+    plugin.on_app_init(app_config)
+
+    assert plugin._spa_handler is not None
+    assert plugin._spa_handler._csrf_cookie_name == "custom_cookie"
+    assert plugin._spa_handler._csrf_header_name == "x-custom-header"
+
+
+def test_vite_plugin_app_init_csrf_names_none_when_csrf_config_absent(tmp_path: Path) -> None:
+    plugin = VitePlugin(config=ViteConfig(mode="spa", paths=PathConfig(root=tmp_path)))
+    app_config = AppConfig()
+
+    plugin.on_app_init(app_config)
+
+    assert plugin._spa_handler is not None
+    assert plugin._spa_handler._csrf_cookie_name is None
+    assert plugin._spa_handler._csrf_header_name is None
+
+
 def test_vite_plugin_production_stale_hmr_websocket_closes_cleanly(tmp_path: Path) -> None:
     """Stale dev clients reconnecting to HMR in production must not hit Litestar's static HTTP route.
 
@@ -654,7 +680,7 @@ def test_vite_plugin_lifespan_with_environment_setup(mock_set_env: Mock) -> None
         pass
 
     # Should call set_environment when enabled
-    mock_set_env.assert_called_once_with(config=config)
+    mock_set_env.assert_called_once_with(config=config, app=app)
 
 
 def test_server_lifespan_does_not_prewrite_hotfile_in_vite_mode(tmp_path: Path) -> None:

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -1776,8 +1776,8 @@ def test_get_litestar_route_prefixes_with_multiple_routes() -> None:
     assert "/users" in prefixes
     assert "/posts/{post_id:int}" in prefixes
     assert "/api/v1/items" in prefixes
-    # Should include common API prefixes as fallback
-    assert "/api" in prefixes
+    # Only registered routes and the configured OpenAPI path are reserved.
+    assert "/api" not in prefixes
     assert "/schema" in prefixes
     assert "/docs" not in prefixes
 
@@ -1801,8 +1801,7 @@ def test_get_litestar_route_prefixes_includes_openapi_config_path() -> None:
 
     # Should include custom schema path
     assert "/custom-schema" in prefixes
-    # Should still include fallback schema path
-    assert "/schema" in prefixes
+    assert "/schema" not in prefixes
 
 
 def test_get_litestar_route_prefixes_caches_by_app() -> None:
@@ -1841,9 +1840,8 @@ def test_get_litestar_route_prefixes_with_no_openapi() -> None:
 
     prefixes = get_litestar_route_prefixes(app)
 
-    # Should still include fallback prefixes
-    assert "/api" in prefixes
-    assert "/schema" in prefixes
+    assert "/api" not in prefixes
+    assert "/schema" not in prefixes
     assert "/docs" not in prefixes
 
 
@@ -2091,8 +2089,7 @@ def test_get_litestar_route_prefixes_with_empty_app() -> None:
 
     prefixes = get_litestar_route_prefixes(app)
 
-    # Should still include common fallback prefixes
-    assert "/api" in prefixes
+    assert "/api" not in prefixes
     assert "/schema" in prefixes
     assert "/docs" not in prefixes
 

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -2184,10 +2184,10 @@ async def test_vite_plugin_lifespan_parses_manifest_once_across_loader_and_handl
 
     decode_calls = 0
 
-    def counting_decode_json(*args: object, **kwargs: object) -> object:
+    def counting_decode_json(value: str | bytes, strict: bool = True) -> Any:
         nonlocal decode_calls
         decode_calls += 1
-        return real_decode_json(*args, **kwargs)
+        return real_decode_json(value, strict=strict)
 
     with (
         patch("litestar_vite.loader.decode_json", counting_decode_json),

--- a/src/py/tests/unit/test_plugin.py
+++ b/src/py/tests/unit/test_plugin.py
@@ -1805,27 +1805,29 @@ def test_get_litestar_route_prefixes_includes_openapi_config_path() -> None:
 
 
 def test_get_litestar_route_prefixes_caches_by_app() -> None:
-    """Test that route prefixes are cached per app instance."""
+    """Route prefixes are cached on each Vite plugin, never on app.state."""
     from litestar_vite.plugin import get_litestar_route_prefixes
 
     @get("/users")
     async def get_users() -> dict[str, str]:
         return {"message": "users"}
 
-    app1 = Litestar(route_handlers=[get_users])
-    app2 = Litestar(route_handlers=[get_users])
+    plugin1 = VitePlugin()
+    plugin2 = VitePlugin()
+    app1 = Litestar(route_handlers=[get_users], plugins=[plugin1])
+    app2 = Litestar(route_handlers=[get_users], plugins=[plugin2])
 
-    # First call should populate cache in app.state
     prefixes1 = get_litestar_route_prefixes(app1)
+    assert plugin1._route_prefix_cache is prefixes1
+    assert not hasattr(app1.state, "litestar_vite_route_prefixes")
+    assert not hasattr(app1.state, "litestar_vite_extra_route_prefixes")
 
-    # Second call with same app should return cached result
     prefixes1_again = get_litestar_route_prefixes(app1)
-    assert prefixes1 is prefixes1_again  # Same object (tuple is immutable)
+    assert prefixes1 is prefixes1_again
 
-    # Different app should have separate cache entry
     prefixes2 = get_litestar_route_prefixes(app2)
-    assert prefixes1 == prefixes2  # Same content
-    assert prefixes1 is not prefixes2  # Different objects (separate app instances)
+    assert prefixes1 == prefixes2
+    assert prefixes1 is not prefixes2
 
 
 def test_get_litestar_route_prefixes_with_no_openapi() -> None:
@@ -1956,7 +1958,7 @@ def test_is_litestar_route_prefix_match() -> None:
 
     # Prefix match should return True
     assert is_litestar_route("/api/users/123", app) is True
-    assert is_litestar_route("/api/v1/items", app) is True  # Matches /api fallback
+    assert is_litestar_route("/api/v1/items", app) is False
 
 
 def test_is_litestar_route_non_match() -> None:
@@ -2004,9 +2006,9 @@ def test_is_litestar_route_with_path_parameters() -> None:
 
     app = Litestar(route_handlers=[get_user])
 
-    # Should match based on /api prefix (from fallback)
+    # The concrete static parent is derived from the registered parameterized route.
     assert is_litestar_route("/api/users/123", app) is True
-    assert is_litestar_route("/api/posts/456", app) is True
+    assert is_litestar_route("/api/posts/456", app) is False
 
 
 def test_is_litestar_route_case_sensitive() -> None:
@@ -2046,7 +2048,8 @@ def test_is_litestar_route_root_absent_when_no_root_handler() -> None:
     async def get_users() -> dict[str, str]:
         return {"message": "users"}
 
-    app = Litestar(route_handlers=[get_users])
+    plugin = VitePlugin()
+    app = Litestar(route_handlers=[get_users], plugins=[plugin])
 
     assert is_litestar_route("/", app) is False
     assert is_litestar_route("/api/users", app) is True
@@ -2066,7 +2069,8 @@ def test_is_litestar_route_cache_performance() -> None:
     async def get_users() -> dict[str, str]:
         return {"message": "users"}
 
-    app = Litestar(route_handlers=[get_users])
+    plugin = VitePlugin()
+    app = Litestar(route_handlers=[get_users], plugins=[plugin])
 
     # Prime the cache
     prefixes_before = get_litestar_route_prefixes(app)

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -196,13 +196,12 @@ def test_extract_request_headers_avoids_set_copy_without_connection_header(monke
     from litestar_vite.plugin._proxy import _extract_request_headers
 
     set_calls = 0
-    real_set = set
 
-    class _CountingSet(real_set):
+    class _CountingSet(set[object]):
         def __new__(cls, *args: object, **kwargs: object) -> Self:
             nonlocal set_calls
             set_calls += 1
-            return real_set.__new__(cls, *args, **kwargs)
+            return super().__new__(cls)
 
     monkeypatch.setattr("builtins.set", _CountingSet)
 
@@ -270,10 +269,10 @@ def test_target_url_getter_throttles_stat_within_ttl_window(tmp_path: Path, monk
     stat_calls = 0
     real_stat = Path.stat
 
-    def counting_stat(self: Path, *args: object, **kwargs: object) -> object:
+    def counting_stat(self: Path, *, follow_symlinks: bool = True) -> os.stat_result:
         nonlocal stat_calls
         stat_calls += 1
-        return real_stat(self, *args, **kwargs)
+        return real_stat(self, follow_symlinks=follow_symlinks)
 
     monkeypatch.setattr(Path, "stat", counting_stat)
     getter = create_target_url_getter(None, hotfile, cached)
@@ -334,10 +333,10 @@ def test_hmr_target_getter_ttls_negative_result(tmp_path: Path, monkeypatch: pyt
     stat_calls = 0
     real_stat = Path.stat
 
-    def counting_stat(self: Path, *args: object, **kwargs: object) -> object:
+    def counting_stat(self: Path, *, follow_symlinks: bool = True) -> os.stat_result:
         nonlocal stat_calls
         stat_calls += 1
-        return real_stat(self, *args, **kwargs)
+        return real_stat(self, follow_symlinks=follow_symlinks)
 
     monkeypatch.setattr(Path, "stat", counting_stat)
 

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -277,6 +277,46 @@ def test_target_url_getter_caches_negative_result_without_reread(
     assert read_calls == 1
 
 
+def test_hmr_target_getter_hoists_hmr_path_once(tmp_path: Path) -> None:
+    """The '<hotfile>.hmr' Path must be constructed once per getter, not once per call."""
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+    (tmp_path / "hot.hmr").write_text("http://127.0.0.1:24678")
+
+    with patch("litestar_vite.plugin._proxy.Path", wraps=Path) as path_spy:
+        getter = create_hmr_target_getter(hotfile, [None])
+        for _ in range(5):
+            assert getter() == "http://127.0.0.1:24678"
+
+    assert path_spy.call_count == 1, (
+        f"expected Path(...) to be constructed once for the .hmr sibling, got {path_spy.call_count}"
+    )
+
+
+def test_hmr_target_getter_ttls_negative_result(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no '.hmr' sibling exists, repeated calls within the TTL window must not re-stat either candidate."""
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+    fake_time = [1000.0]
+    monkeypatch.setattr("litestar_vite.plugin._proxy.time.monotonic", lambda: fake_time[0])
+
+    stat_calls = 0
+    real_stat = Path.stat
+
+    def counting_stat(self: Path, *args: object, **kwargs: object) -> object:
+        nonlocal stat_calls
+        stat_calls += 1
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", counting_stat)
+
+    getter = create_hmr_target_getter(hotfile, [None])
+    for _ in range(5):
+        assert getter() == "http://localhost:5173"
+
+    assert stat_calls == 2, f"expected exactly 2 stat() calls across 5 getter() calls, got {stat_calls}"
+
+
 def test_hmr_target_getter_caches(tmp_path: Path) -> None:
     hotfile = tmp_path / "hot"
     hotfile.write_text("http://localhost:5173")

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -182,6 +182,37 @@ def test_extract_forward_headers_drops_connection_derived_headers() -> None:
     assert extract_forward_headers(scope) == [("X-Test", "value")]
 
 
+def test_collect_connection_tokens_returns_shared_empty_sentinel_when_absent() -> None:
+    """No Connection header returns the shared sentinel instead of allocating a set."""
+    from litestar_vite.plugin._proxy import _NO_CONNECTION_TOKENS, _collect_connection_tokens
+
+    result = _collect_connection_tokens([(b"host", b"example.com"), (b"x-test", b"value")])
+
+    assert result is _NO_CONNECTION_TOKENS
+
+
+def test_extract_request_headers_avoids_set_copy_without_connection_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No Connection header uses the immutable skip set directly."""
+    from litestar_vite.plugin._proxy import _extract_request_headers
+
+    set_calls = 0
+    real_set = set
+
+    class _CountingSet(real_set):
+        def __new__(cls, *args: object, **kwargs: object) -> Self:
+            nonlocal set_calls
+            set_calls += 1
+            return real_set.__new__(cls, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.set", _CountingSet)
+
+    headers = [(b"X-Test", b"value"), (b"Host", b"example.com")]
+    result = _extract_request_headers(headers)
+
+    assert result == [("X-Test", "value"), ("Host", "example.com")]
+    assert set_calls == 0, f"expected zero set() allocations with no Connection header, got {set_calls}"
+
+
 def test_normalize_proxy_prefixes(tmp_path: Path) -> None:
     prefixes = normalize_proxy_prefixes(
         ("/@vite",),

--- a/src/py/tests/unit/test_proxy_helpers.py
+++ b/src/py/tests/unit/test_proxy_helpers.py
@@ -194,10 +194,12 @@ def test_normalize_proxy_prefixes(tmp_path: Path) -> None:
     assert "/static/" in prefixes
 
 
-def test_target_url_getter_caches(tmp_path: Path) -> None:
+def test_target_url_getter_caches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     hotfile = tmp_path / "hot"
     hotfile.write_text("http://localhost:5173")
     cached: list[str | None] = [None]
+    fake_time = [1000.0]
+    monkeypatch.setattr("litestar_vite.plugin._proxy.time.monotonic", lambda: fake_time[0])
     getter = create_target_url_getter(None, hotfile, cached)
 
     assert getter() == "http://localhost:5173"
@@ -207,19 +209,72 @@ def test_target_url_getter_caches(tmp_path: Path) -> None:
     current_mtime = hotfile.stat().st_mtime_ns
     os.utime(hotfile, ns=(current_mtime + 1_000_000, current_mtime + 1_000_000))
 
+    fake_time[0] += 1.0
     assert getter() == "http://changed:1234"
 
 
-def test_target_url_getter_recovers_after_initial_missing_hotfile(tmp_path: Path) -> None:
+def test_target_url_getter_recovers_after_initial_missing_hotfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     hotfile = tmp_path / "hot"
     cached: list[str | None] = [None]
+    fake_time = [1000.0]
+    monkeypatch.setattr("litestar_vite.plugin._proxy.time.monotonic", lambda: fake_time[0])
     getter = create_target_url_getter(None, hotfile, cached)
 
     assert getter() is None
 
     hotfile.write_text("http://localhost:5173")
 
+    fake_time[0] += 1.0
     assert getter() == "http://localhost:5173"
+
+
+def test_target_url_getter_throttles_stat_within_ttl_window(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+    cached: list[str | None] = [None]
+    fake_time = [1000.0]
+    monkeypatch.setattr("litestar_vite.plugin._proxy.time.monotonic", lambda: fake_time[0])
+    stat_calls = 0
+    real_stat = Path.stat
+
+    def counting_stat(self: Path, *args: object, **kwargs: object) -> object:
+        nonlocal stat_calls
+        stat_calls += 1
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", counting_stat)
+    getter = create_target_url_getter(None, hotfile, cached)
+
+    for _ in range(5):
+        assert getter() == "http://localhost:5173"
+
+    assert stat_calls == 1
+
+
+def test_target_url_getter_caches_negative_result_without_reread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    hotfile = tmp_path / "hot"
+    hotfile.write_text("http://localhost:5173")
+    cached: list[str | None] = [None]
+    fake_time = [1000.0]
+    monkeypatch.setattr("litestar_vite.plugin._proxy.time.monotonic", lambda: fake_time[0])
+    read_calls = 0
+
+    def failing_read(_path: Path) -> str:
+        nonlocal read_calls
+        read_calls += 1
+        raise OSError("simulated malformed hotfile read")
+
+    monkeypatch.setattr("litestar_vite.plugin._proxy.read_hotfile_url", failing_read)
+    getter = create_target_url_getter(None, hotfile, cached)
+
+    assert getter() is None
+    fake_time[0] += 1.0
+    assert getter() is None
+    assert read_calls == 1
 
 
 def test_hmr_target_getter_caches(tmp_path: Path) -> None:

--- a/src/py/tests/unit/test_proxy_middleware.py
+++ b/src/py/tests/unit/test_proxy_middleware.py
@@ -362,6 +362,7 @@ def test_proxy_target_cache_invariant(tmp_path: Path, monkeypatch: pytest.Monkey
     hotfile.write_text("http://bridge")
 
     call_count = 0
+    fake_time = [1000.0]
     real_read = proxy_module.read_hotfile_url
 
     def counting_read(hotfile_path: Path) -> str:
@@ -370,6 +371,7 @@ def test_proxy_target_cache_invariant(tmp_path: Path, monkeypatch: pytest.Monkey
         return real_read(hotfile_path)
 
     monkeypatch.setattr(proxy_module, "read_hotfile_url", counting_read)
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: fake_time[0])
 
     async def noop(scope: Scope, receive: Receive, send: Send) -> None:
         return None
@@ -385,21 +387,27 @@ def test_proxy_target_cache_invariant(tmp_path: Path, monkeypatch: pytest.Monkey
     hotfile.write_text("http://changed:1234")
     current_mtime = hotfile.stat().st_mtime_ns
     os.utime(hotfile, ns=(current_mtime + 1_000_000, current_mtime + 1_000_000))
+    fake_time[0] += 1.0
 
     assert middleware._get_target_base_url() == "http://changed:1234"
     assert call_count == 2
     read_bridge_config.cache_clear()
 
 
-def test_proxy_target_recovers_after_initial_missing_hotfile(tmp_path: Path) -> None:
+def test_proxy_target_recovers_after_initial_missing_hotfile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import litestar_vite.plugin._proxy as proxy_module
+
     async def noop(scope: Scope, receive: Receive, send: Send) -> None:
         return None
 
     hotfile = tmp_path / "hot"
+    fake_time = [1000.0]
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: fake_time[0])
     middleware = ViteProxyMiddleware(noop, hotfile_path=hotfile)
 
     assert middleware._get_target_base_url() is None
 
     hotfile.write_text("http://localhost:5173")
+    fake_time[0] += 1.0
 
     assert middleware._get_target_base_url() == "http://localhost:5173"

--- a/src/py/tests/unit/test_runtime_config.py
+++ b/src/py/tests/unit/test_runtime_config.py
@@ -107,6 +107,28 @@ def test_bridge_app_url_null_when_unknown(tmp_path: Path, monkeypatch: pytest.Mo
     assert data["appUrl"] is None
 
 
+def test_bridge_csrf_names_included_when_provided(tmp_path: Path) -> None:
+    cfg = ViteConfig()
+    cfg.paths.root = tmp_path
+
+    path_str = write_runtime_config_file(cfg, csrf_cookie_name="custom_cookie", csrf_header_name="x-custom-header")
+    data = decode_json(Path(path_str).read_text())
+
+    assert data["csrfCookieName"] == "custom_cookie"
+    assert data["csrfHeaderName"] == "x-custom-header"
+
+
+def test_bridge_csrf_names_null_by_default(tmp_path: Path) -> None:
+    cfg = ViteConfig()
+    cfg.paths.root = tmp_path
+
+    path_str = write_runtime_config_file(cfg)
+    data = decode_json(Path(path_str).read_text())
+
+    assert data["csrfCookieName"] is None
+    assert data["csrfHeaderName"] is None
+
+
 def test_bridge_litestar_port_from_app_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Bridge MUST emit litestarPort parsed from APP_URL so framework integrations can route HMR through it."""
     monkeypatch.setenv("APP_URL", "https://api.example.com:9876")

--- a/src/py/tests/unit/test_scaffold_manifest_render_matrix.py
+++ b/src/py/tests/unit/test_scaffold_manifest_render_matrix.py
@@ -96,6 +96,7 @@ def test_scaffold_manifest_typegen_dependencies_use_compatible_pins(framework: F
 
 
 def test_typegen_fallback_pins_match_scaffold_registry() -> None:
+    """Keep the Python scaffold registry and shipped JS fallback pins in parity."""
     constants_source = (REPOSITORY_ROOT / "src/js/src/shared/constants.ts").read_text()
 
     assert (

--- a/src/py/tests/unit/test_utils.py
+++ b/src/py/tests/unit/test_utils.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock
 import click
 import pytest
 from litestar import Litestar, get
+from litestar.config.csrf import CSRFConfig
 from litestar.connection import Request
 from litestar.serialization import decode_json
 
@@ -116,6 +117,28 @@ def test_set_environment_uses_effective_litestar_run_bind(tmp_path: Path, monkey
     assert os.environ["APP_URL"] == "http://localhost:9123"
     assert bridge["appUrl"] == "http://localhost:9123"
     assert bridge["litestarPort"] == 9123
+
+
+def test_set_environment_threads_csrf_config_into_bridge(tmp_path: Path) -> None:
+    """set_environment must derive csrfCookieName/csrfHeaderName from app.csrf_config."""
+    config = ViteConfig(mode="spa", paths=PathConfig(root=tmp_path), runtime=RuntimeConfig(dev_mode=True))
+    app = Litestar(csrf_config=CSRFConfig(secret="s", cookie_name="custom_cookie", header_name="x-custom-header"))
+
+    utils.set_environment(config, app=app)
+
+    bridge = decode_json((tmp_path / ".litestar.json").read_bytes())
+    assert bridge["csrfCookieName"] == "custom_cookie"
+    assert bridge["csrfHeaderName"] == "x-custom-header"
+
+
+def test_set_environment_csrf_names_null_without_app(tmp_path: Path) -> None:
+    config = ViteConfig(mode="spa", paths=PathConfig(root=tmp_path), runtime=RuntimeConfig(dev_mode=True))
+
+    utils.set_environment(config)
+
+    bridge = decode_json((tmp_path / ".litestar.json").read_bytes())
+    assert bridge["csrfCookieName"] is None
+    assert bridge["csrfHeaderName"] is None
 
 
 def test_is_non_serving_assets_cli(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1078,7 +1078,7 @@ wheels = [
 
 [[package]]
 name = "litestar-vite"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- carry configured CSRF cookie and header names through `.litestar.json` into the browser helpers
- derive backend route prefixes from registered routes and explicit configuration while excluding Vite-owned SPA/static fallbacks
- reduce proxy/HMR hot-path filesystem and allocation work and share one parsed startup manifest
- materialize Inertia shared special props lazily, including safe redirect and exception-redirect persistence
- replace HTMX expression `eval` behavior with a bounded CSP-safe allowlist interpreter
- consolidate executor argv, schema-reference, scaffold, framework, and typegen sources of truth