### PR TITLE
feat(inertia): make session middleware optional

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ Litestar Vite Changelog
   callables run only when the current response renders them or when a redirect needs to persist
   them. The ``True``/``False`` return contract is unchanged, and async special props still return
   ``False`` because they cannot be persisted synchronously across redirects.
+- Changed Inertia transient state to stay request-local when the current response can consume it
+  and to use the configured session automatically when state must survive a redirect. Existing
+  session-backed application setup remains compatible.
+- Deprecated ``materialize_shared_props_to_session()`` for removal in v0.30.0; Inertia redirect
+  responses now perform the compatible session handoff automatically.
 - Replaced HTMX JSON-template expression evaluation with a CSP-safe allowlist interpreter. Assignment,
   ``new``, functions/arrows, computed indexing, array literals, and globals other than ``JSON`` and
   ``Math`` are no longer supported. Reserved data-field names include ``constructor``, ``__proto__``,

--- a/docs/frameworks/inertia/configuration.rst
+++ b/docs/frameworks/inertia/configuration.rst
@@ -228,7 +228,7 @@ Flash data is now sent as a **top-level** ``page.flash`` property instead of ``p
 
    @post("/submit")
    async def submit_form(request: Request) -> InertiaBack:
-       flash(request, "success", "Form submitted!")
+       flash(request, "Form submitted!", "success")
        return InertiaBack(request)
 
 **Client side** (accessing flash data):

--- a/docs/frameworks/inertia/flash-data.rst
+++ b/docs/frameworks/inertia/flash-data.rst
@@ -34,6 +34,10 @@ Use the ``flash()`` helper to queue messages for the next Inertia response:
 Flash categories are grouped under their category name (``success``, ``error``,
 ``warning``, ``info``). Each category contains a list of messages.
 
+.. note::
+   Litestar's ``FlashPlugin`` is optional. If it is already configured, its
+   session-backed messages work with Inertia too.
+
 Frontend Usage
 --------------
 

--- a/docs/frameworks/inertia/installation.rst
+++ b/docs/frameworks/inertia/installation.rst
@@ -79,7 +79,12 @@ Minimal Configuration
    from typing import Any
 
    from litestar import Litestar, get
+   from litestar.middleware.session.client_side import CookieBackendConfig
    from litestar_vite import ViteConfig, VitePlugin
+
+   session_backend = CookieBackendConfig(
+       secret=b"development-only-secret-32-chars",
+   )
 
    @get("/", component="Home")
    async def home() -> dict[str, Any]:
@@ -93,9 +98,11 @@ Minimal Configuration
                inertia=True,  # Enables Inertia with defaults
            )),
        ],
+       middleware=[session_backend.middleware],
    )
 
 The ``inertia=True`` shortcut enables Inertia with sensible defaults.
+Load the session secret from application configuration in production.
 For custom configuration, see :doc:`configuration`.
 
 See Also

--- a/src/py/litestar_vite/config/_inertia.py
+++ b/src/py/litestar_vite/config/_inertia.py
@@ -125,9 +125,10 @@ class InertiaConfig:
     extra_session_page_props: "set[str] | dict[str, type]" = field(default_factory=empty_set_factory)
     """Session props to include in page responses.
 
-    This option requires a Litestar session middleware integration. Use
-    ``CookieBackendConfig`` for encrypted, server-store-free redirect persistence,
-    or ``ServerSideSessionConfig`` with a Litestar store.
+    Keys are copied when the current request exposes a Litestar session. They are
+    omitted from sessionless responses. Use ``CookieBackendConfig`` for encrypted,
+    server-store-free persistence, or ``ServerSideSessionConfig`` with a Litestar
+    store.
 
     Can be either:
     - A set of session key names (types will be 'unknown')

--- a/src/py/litestar_vite/config/_inertia.py
+++ b/src/py/litestar_vite/config/_inertia.py
@@ -125,6 +125,10 @@ class InertiaConfig:
     extra_session_page_props: "set[str] | dict[str, type]" = field(default_factory=empty_set_factory)
     """Session props to include in page responses.
 
+    This option requires a Litestar session middleware integration. Use
+    ``CookieBackendConfig`` for encrypted, server-store-free redirect persistence,
+    or ``ServerSideSessionConfig`` with a Litestar store.
+
     Can be either:
     - A set of session key names (types will be 'unknown')
     - A dict mapping session keys to Python types (auto-registered with OpenAPI)

--- a/src/py/litestar_vite/inertia/exception_handler.py
+++ b/src/py/litestar_vite/inertia/exception_handler.py
@@ -31,6 +31,7 @@ from litestar.status_codes import (
 from litestar_vite.inertia.helpers import error, flash
 from litestar_vite.inertia.request import InertiaRequest
 from litestar_vite.inertia.response import InertiaBack, InertiaRedirect, InertiaResponse
+from litestar_vite.inertia.state import has_redirect_state_transport
 
 if TYPE_CHECKING:
     from litestar.connection.base import AuthT, StateT, UserT
@@ -135,20 +136,14 @@ def _append_error_query(redirect_to: str, detail: Any) -> str:
 
 
 def _create_unauthorized_response(
-    request: "Request[Any, Any, Any]",
-    *,
-    detail: Any,
-    flash_succeeded: bool,
-    inertia_plugin: "InertiaPlugin",
-    status_code: int,
-    exc: Exception,
+    request: "Request[Any, Any, Any]", *, detail: Any, inertia_plugin: "InertiaPlugin", status_code: int, exc: Exception
 ) -> "Response[Any] | None":
     is_unauthorized = status_code == HTTP_401_UNAUTHORIZED or isinstance(exc, NotAuthorizedException)
     redirect_to_login = inertia_plugin.config.redirect_unauthorized_to
     if not is_unauthorized or redirect_to_login is None:
         return None
     if request.url.path != redirect_to_login:
-        if not flash_succeeded and detail:
+        if not has_redirect_state_transport(request) and detail:
             redirect_to_login = _append_error_query(redirect_to_login, detail)
         return InertiaRedirect(request, redirect_to=redirect_to_login)
     return InertiaBack(request)
@@ -187,9 +182,8 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
     if extras:
         content.update({"extra": extras})
 
-    flash_succeeded = False
     if detail:
-        flash_succeeded = flash(request, detail, category="error")
+        flash(request, detail, category="error")
 
     _store_field_errors(request, extras, detail)
 
@@ -208,12 +202,7 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
         )
 
     unauthorized_response = _create_unauthorized_response(
-        request,
-        detail=detail,
-        flash_succeeded=flash_succeeded,
-        inertia_plugin=inertia_plugin,
-        status_code=status_code,
-        exc=exc,
+        request, detail=detail, inertia_plugin=inertia_plugin, status_code=status_code, exc=exc
     )
     if unauthorized_response is not None:
         return unauthorized_response

--- a/src/py/litestar_vite/inertia/exception_handler.py
+++ b/src/py/litestar_vite/inertia/exception_handler.py
@@ -136,17 +136,33 @@ def _append_error_query(redirect_to: str, detail: Any) -> str:
 
 
 def _create_unauthorized_response(
-    request: "Request[Any, Any, Any]", *, detail: Any, inertia_plugin: "InertiaPlugin", status_code: int, exc: Exception
+    request: "Request[Any, Any, Any]", *, inertia_plugin: "InertiaPlugin", status_code: int, exc: Exception
 ) -> "Response[Any] | None":
     is_unauthorized = status_code == HTTP_401_UNAUTHORIZED or isinstance(exc, NotAuthorizedException)
     redirect_to_login = inertia_plugin.config.redirect_unauthorized_to
     if not is_unauthorized or redirect_to_login is None:
         return None
     if request.url.path != redirect_to_login:
-        if not has_redirect_state_transport(request) and detail:
-            redirect_to_login = _append_error_query(redirect_to_login, detail)
         return InertiaRedirect(request, redirect_to=redirect_to_login)
     return InertiaBack(request)
+
+
+def _create_sessionless_unauthorized_response(
+    request: "Request[Any, Any, Any]", *, detail: Any, inertia_plugin: "InertiaPlugin", status_code: int, exc: Exception
+) -> "Response[Any] | None":
+    """Return the query-string fallback before staging redirect-bound state."""
+    is_unauthorized = status_code == HTTP_401_UNAUTHORIZED or isinstance(exc, NotAuthorizedException)
+    redirect_to_login = inertia_plugin.config.redirect_unauthorized_to
+    if (
+        not is_unauthorized
+        or redirect_to_login is None
+        or request.url.path == redirect_to_login
+        or has_redirect_state_transport(request)
+    ):
+        return None
+    if detail:
+        redirect_to_login = _append_error_query(redirect_to_login, detail)
+    return InertiaRedirect(request, redirect_to=redirect_to_login)
 
 
 def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", exc: "Exception") -> "Response[Any]":
@@ -182,6 +198,13 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
     if extras:
         content.update({"extra": extras})
 
+    if inertia_plugin is not None:
+        unauthorized_response = _create_sessionless_unauthorized_response(
+            request, detail=detail, inertia_plugin=inertia_plugin, status_code=status_code, exc=exc
+        )
+        if unauthorized_response is not None:
+            return unauthorized_response
+
     if detail:
         flash(request, detail, category="error")
 
@@ -202,7 +225,7 @@ def create_inertia_exception_response(request: "Request[UserT, AuthT, StateT]", 
         )
 
     unauthorized_response = _create_unauthorized_response(
-        request, detail=detail, inertia_plugin=inertia_plugin, status_code=status_code, exc=exc
+        request, inertia_plugin=inertia_plugin, status_code=status_code, exc=exc
     )
     if unauthorized_response is not None:
         return unauthorized_response

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1351,7 +1351,7 @@ def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapp
     return {**session_shared, **_get_scope_shared_props(request)}
 
 
-def _consume_legacy_session_state(
+def _consume_session_handoff_state(
     request: "ASGIConnection[Any, Any, Any, Any]",
 ) -> "tuple[dict[str, Any] | None, Mapping[str, Any], dict[str, Any], list[dict[str, Any]]]":
     try:
@@ -1396,7 +1396,7 @@ def get_shared_props(
     once_props_entries: "list[_OncePropEntry]" = []
     error_bag = request.headers.get("X-Inertia-Error-Bag", None)
 
-    session, session_shared_props, errors, session_messages = _consume_legacy_session_state(request)
+    session, session_shared_props, errors, session_messages = _consume_session_handoff_state(request)
     local_shared_props = consume_shared(request)
     local_flash = consume_flash(request)
     local_errors = consume_errors(request)

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -8,6 +8,18 @@ from litestar.exceptions import ImproperlyConfiguredException
 from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 
+from litestar_vite.inertia.state import (
+    _TRANSIENT_STATE_SCOPE_KEY,  # pyright: ignore[reportPrivateUsage]
+    consume_errors,
+    consume_flash,
+    consume_shared,
+    peek_transient_state,
+    persist_transient_state_for_redirect,
+    stage_clear_history,
+    stage_error,
+    stage_flash,
+    stage_shared,
+)
 from litestar_vite.inertia.types import ScrollPropsConfig
 
 if TYPE_CHECKING:
@@ -1310,23 +1322,16 @@ async def resolve_async_props(
     await _resolve_one(value, partial_data, partial_except, except_once_props, _key)
 
 
-_RAW_SHARED_SCOPE_KEY = "_litestar_vite_inertia_shared"
+_RAW_SHARED_SCOPE_KEY = _TRANSIENT_STATE_SCOPE_KEY
 
 
 def _get_scope_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
-    scope = cast("dict[str, Any]", request.scope)
-    scope_shared = scope.get(_RAW_SHARED_SCOPE_KEY)
-    return cast("Mapping[str, Any]", scope_shared) if isinstance(scope_shared, Mapping) else {}
+    state = peek_transient_state(request)
+    return state.shared if state is not None else {}
 
 
 def _set_scope_shared_prop(connection: "ASGIConnection[Any, Any, Any, Any]", key: str, value: "Any") -> None:
-    scope = getattr(connection, "scope", None)
-    if not isinstance(scope, dict):
-        return
-    scope_dict = cast("dict[str, Any]", scope)
-    shared = scope_dict.setdefault(_RAW_SHARED_SCOPE_KEY, {})
-    if isinstance(shared, dict):
-        shared[key] = value
+    stage_shared(connection, key, value)
 
 
 def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
@@ -1344,6 +1349,23 @@ def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapp
         cast("Mapping[str, Any]", shared_props) if isinstance(shared_props, Mapping) else {}
     )
     return {**session_shared, **_get_scope_shared_props(request)}
+
+
+def _consume_legacy_session_state(
+    request: "ASGIConnection[Any, Any, Any, Any]",
+) -> "tuple[dict[str, Any] | None, Mapping[str, Any], dict[str, Any], list[dict[str, Any]]]":
+    try:
+        session = request.session
+        raw_shared: Any = session.pop("_shared", {})
+        raw_errors: Any = session.pop("_errors", {})
+        raw_messages: Any = session.pop("_messages", [])
+    except (AttributeError, ImproperlyConfiguredException):
+        return None, {}, {}, []
+
+    shared: Mapping[str, Any] = cast("Mapping[str, Any]", raw_shared) if isinstance(raw_shared, Mapping) else {}
+    errors = dict(cast("Mapping[str, Any]", raw_errors)) if isinstance(raw_errors, Mapping) else {}
+    messages = cast("list[dict[str, Any]]", raw_messages) if isinstance(raw_messages, list) else []
+    return session, shared, errors, messages
 
 
 def get_shared_props(
@@ -1371,30 +1393,15 @@ def get_shared_props(
     """
     props: "dict[str, Any]" = {}
     flash: "dict[str, list[str]]" = defaultdict(list)
-    errors: "dict[str, Any]" = {}
     once_props_entries: "list[_OncePropEntry]" = []
     error_bag = request.headers.get("X-Inertia-Error-Bag", None)
 
-    session_available = True
-    session_shared_props: Mapping[str, Any] = {}
-    scope_shared_props = cast("dict[str, Any]", request.scope).pop(_RAW_SHARED_SCOPE_KEY, {})
-    try:
-        errors = request.session.pop("_errors", {})
-        raw_session_shared_props = request.session.pop("_shared", {})
-    except (AttributeError, ImproperlyConfiguredException):
-        session_available = False
-        msg = "Unable to generate all shared props.  A valid session was not found for this request."
-        request.logger.warning(msg)
-    else:
-        session_shared_props = (
-            cast("Mapping[str, Any]", raw_session_shared_props) if isinstance(raw_session_shared_props, Mapping) else {}
-        )
-
-    shared_props = (
-        {**session_shared_props, **cast("Mapping[str, Any]", scope_shared_props)}
-        if isinstance(scope_shared_props, Mapping)
-        else dict(session_shared_props)
-    )
+    session, session_shared_props, errors, session_messages = _consume_legacy_session_state(request)
+    local_shared_props = consume_shared(request)
+    local_flash = consume_flash(request)
+    local_errors = consume_errors(request)
+    errors.update(local_errors)
+    shared_props = {**session_shared_props, **local_shared_props}
 
     try:
         inertia_plugin = cast("InertiaPlugin", request.app.plugins.get("InertiaPlugin"))
@@ -1420,26 +1427,26 @@ def get_shared_props(
             else:
                 props[key] = value
 
-        if session_available:
-            for message in cast("list[dict[str,Any]]", request.session.pop("_messages", [])):
-                flash[message["category"]].append(message["message"])
+        for message in session_messages:
+            flash[message["category"]].append(message["message"])
+        for category, messages in local_flash.items():
+            flash[category].extend(messages)
 
         for key, value in inertia_plugin.config.extra_static_page_props.items():
             if should_render(value, partial_data, partial_except, key=key):
                 props[key] = value
 
-        if session_available:
+        if session is not None:
             for session_prop in inertia_plugin.config.extra_session_page_props:
                 if (
                     session_prop not in props
-                    and session_prop in request.session
+                    and session_prop in session
                     and should_render(None, partial_data, partial_except, key=session_prop)
                 ):
-                    props[session_prop] = request.session.get(session_prop)
+                    props[session_prop] = session.get(session_prop)
 
-    except (AttributeError, ImproperlyConfiguredException):
-        msg = "Unable to generate all shared props.  A valid session was not found for this request."
-        request.logger.warning(msg)
+    except (AttributeError, ImproperlyConfiguredException, KeyError):
+        pass
 
     props["flash"] = flash
     props["errors"] = {error_bag: errors} if error_bag is not None else errors
@@ -1452,17 +1459,7 @@ def get_shared_props(
 _UNMATERIALIZABLE_SHARED = object()
 
 
-def _is_async_special_prop(value: "Any") -> bool:
-    """Return whether a top-level special prop wraps an async callback."""
-    if is_optional_prop(value):
-        return inspect.iscoroutinefunction(value._callback)  # pyright: ignore[reportPrivateUsage]
-    if is_deferred_prop(value) or is_once_prop(value):
-        callback = value._value  # pyright: ignore[reportPrivateUsage]
-        return callable(callback) and inspect.iscoroutinefunction(callback)
-    return False
-
-
-def _materialize_shared_value(value: "Any") -> "Any":
+def _materialize_shared_value(value: "Any") -> "Any":  # pyright: ignore[reportUnusedFunction]
     """Convert top-level special props into session-serializable values for share()."""
     if is_merge_prop(value):
         return unwrap_merge_props(value)
@@ -1475,7 +1472,7 @@ def _materialize_shared_value(value: "Any") -> "Any":
 
 
 def materialize_shared_props_to_session(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
-    """Flush scope-stored shared props into the session as serializable values.
+    """Persist transient state through the request's session when available.
 
     In-frame redirect construction and wrapped non-Inertia responses call this while handler
     dependencies are alive. Exception-produced redirects use the same path after dependency
@@ -1485,32 +1482,19 @@ def materialize_shared_props_to_session(connection: "ASGIConnection[Any, Any, An
     Args:
         connection: The current ASGI connection.
     """
-    scope_shared = _get_scope_shared_props(connection)
-    if not scope_shared:
-        return
-    try:
-        session_shared = connection.session.setdefault("_shared", {})
-    except (AttributeError, ImproperlyConfiguredException):
-        return
-    for key, value in scope_shared.items():
-        materialized = _materialize_shared_value(value)
-        if materialized is _UNMATERIALIZABLE_SHARED:
-            continue
-        session_shared[key] = materialized
+    persist_transient_state_for_redirect(connection)
 
 
 def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "Any") -> "bool":
-    """Share a value in the session.
+    """Stage a shared value for the current Inertia response.
 
     Shared values are included in the props of every Inertia response for
     the current request. This is useful for data that should be available
     to all components (e.g., authenticated user, permissions, settings).
     Top-level special props remain raw in request scope and are materialized lazily in the
-    handler frame only when the response includes them. A redirect materializes synchronous
-    special props into the session so the next request can consume them; exception-produced
-    redirects perform the same work best-effort after dependency cleanup. Async top-level
-    special props cannot be persisted synchronously, return ``False``, and remain available only
-    to the current response. Nested special props inside a shared dict or list are not supported.
+    handler frame only when the response includes them. Redirect responses persist supported
+    synchronous values when the request exposes a session transport. Async special props remain
+    available to the current response but cannot cross a redirect.
 
     Args:
         connection: The ASGI connection.
@@ -1518,31 +1502,14 @@ def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "
         value: The value to store.
 
     Returns:
-        True if the value was successfully shared, False otherwise.
+        True when the value was staged for the current request.
     """
-    if is_special_prop(value) or is_merge_prop(value):
-        _set_scope_shared_prop(connection, key, value)
-        if _is_async_special_prop(value):
-            connection.logger.warning(
-                "Cannot persist shared prop %r across redirects: async special props "
-                "cannot be materialized for session storage.",
-                key,
-            )
-            return False
-        return True
-
-    try:
-        connection.session.setdefault("_shared", {}).update({key: value})
-    except (AttributeError, ImproperlyConfiguredException):
-        msg = "Unable to share value: session not accessible (user may be unauthenticated)."
-        connection.logger.debug(msg)
-        return False
     _set_scope_shared_prop(connection, key, value)
     return True
 
 
 def error(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", message: "str") -> "bool":
-    """Set an error message in the session.
+    """Stage an error message for the current Inertia response.
 
     Error messages are included in the ``errors`` prop of Inertia responses,
     typically used for form validation errors. The key usually corresponds
@@ -1554,24 +1521,17 @@ def error(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", message:
         message: The error message.
 
     Returns:
-        True if the error was successfully stored, False otherwise.
+        True when the error was staged for the current request.
     """
-    try:
-        connection.session.setdefault("_errors", {}).update({key: message})
-    except (AttributeError, ImproperlyConfiguredException):
-        msg = "Unable to set error: session not accessible (user may be unauthenticated)."
-        connection.logger.debug(msg)
-        return False
-    else:
-        return True
+    stage_error(connection, key, message)
+    return True
 
 
 def flash(connection: "ASGIConnection[Any, Any, Any, Any]", message: "str", category: "str" = "info") -> "bool":
-    """Add a flash message to the session.
+    """Stage a flash message for the current Inertia response.
 
-    Flash messages are stored in the session and passed to the frontend
-    via the `flash` prop in every Inertia response. They're automatically
-    cleared after being displayed (pop semantics).
+    Flash messages are consumed into the top-level ``flash`` page field. Redirect responses
+    persist them when the request exposes a session transport.
 
     This function works without requiring Litestar's FlashPlugin or
     any Jinja2 template configuration, making it ideal for SPA-only
@@ -1584,7 +1544,7 @@ def flash(connection: "ASGIConnection[Any, Any, Any, Any]", message: "str", cate
                   Defaults to "info".
 
     Returns:
-        True if the flash message was successfully stored, False otherwise.
+        True when the flash message was staged for the current request.
 
     Example::
 
@@ -1595,34 +1555,22 @@ def flash(connection: "ASGIConnection[Any, Any, Any, Any]", message: "str", cate
             flash(request, "Item created successfully!", "success")
             return InertiaResponse(...)
     """
-    try:
-        messages = connection.session.setdefault("_messages", [])
-        messages.append({"category": category, "message": message})
-    except (AttributeError, ImproperlyConfiguredException):
-        msg = "Unable to flash message: session not accessible (user may be unauthenticated)."
-        connection.logger.debug(msg)
-        return False
-    else:
-        return True
+    stage_flash(connection, message, category)
+    return True
 
 
 def clear_history(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
     """Mark that the next response should clear client history encryption keys.
 
-    This function sets a session flag that will be consumed by the next
-    InertiaResponse, causing it to include `clearHistory: true` in the page
-    object. The Inertia client will then regenerate its encryption key,
-    invalidating all previously encrypted history entries.
+    This function stages a request-local flag consumed by the current
+    InertiaResponse. Redirect responses persist the flag when the request
+    exposes a session transport.
 
     This should typically be called during logout to ensure sensitive data
     cannot be recovered from browser history after a user logs out.
 
     Args:
         connection: The ASGI connection (Request).
-
-    Note:
-        Requires session middleware to be configured.
-        See: https://inertiajs.com/history-encryption
 
     Example::
 
@@ -1634,11 +1582,7 @@ def clear_history(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
             clear_history(request)
             return InertiaRedirect(request, redirect_to="/login")
     """
-    try:
-        connection.session["_inertia_clear_history"] = True
-    except (AttributeError, ImproperlyConfiguredException):
-        msg = "Unable to set clear_history flag. A valid session was not found for this request."
-        connection.logger.warning(msg)
+    stage_clear_history(connection)
 
 
 def is_pagination_container(value: "Any") -> bool:

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from collections import defaultdict
 from collections.abc import Callable, Coroutine, Iterable, Iterator, Mapping
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from litestar_vite.inertia.state import (
     consume_flash,
     consume_shared,
     peek_transient_state,
+    persist_transient_state_for_redirect,
     stage_clear_history,
     stage_error,
     stage_flash,
@@ -1456,6 +1458,25 @@ def _materialize_shared_value(value: "Any") -> "Any":  # pyright: ignore[reportU
         except RuntimeError:
             return _UNMATERIALIZABLE_SHARED
     return value
+
+
+def materialize_shared_props_to_session(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
+    """Persist staged Inertia state through the compatibility session handoff.
+
+    Deprecated:
+        This compatibility shim will be removed in v0.30.0. Redirect responses
+        persist transient state automatically.
+
+    Args:
+        connection: The current ASGI connection.
+    """
+    warnings.warn(
+        "materialize_shared_props_to_session() is deprecated and will be removed in v0.30.0; "
+        "redirect responses persist transient Inertia state automatically.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    persist_transient_state_for_redirect(connection)
 
 
 def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "Any") -> "bool":

--- a/src/py/litestar_vite/inertia/helpers.py
+++ b/src/py/litestar_vite/inertia/helpers.py
@@ -9,12 +9,10 @@ from litestar.utils.empty import value_or_default
 from litestar.utils.scope.state import ScopeState
 
 from litestar_vite.inertia.state import (
-    _TRANSIENT_STATE_SCOPE_KEY,  # pyright: ignore[reportPrivateUsage]
     consume_errors,
     consume_flash,
     consume_shared,
     peek_transient_state,
-    persist_transient_state_for_redirect,
     stage_clear_history,
     stage_error,
     stage_flash,
@@ -1322,18 +1320,6 @@ async def resolve_async_props(
     await _resolve_one(value, partial_data, partial_except, except_once_props, _key)
 
 
-_RAW_SHARED_SCOPE_KEY = _TRANSIENT_STATE_SCOPE_KEY
-
-
-def _get_scope_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
-    state = peek_transient_state(request)
-    return state.shared if state is not None else {}
-
-
-def _set_scope_shared_prop(connection: "ASGIConnection[Any, Any, Any, Any]", key: str, value: "Any") -> None:
-    stage_shared(connection, key, value)
-
-
 def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapping[str, Any]":
     """Return the unrendered shared props stored on the request session.
 
@@ -1348,7 +1334,8 @@ def get_raw_shared_props(request: "ASGIConnection[Any, Any, Any, Any]") -> "Mapp
     session_shared: Mapping[str, Any] = (
         cast("Mapping[str, Any]", shared_props) if isinstance(shared_props, Mapping) else {}
     )
-    return {**session_shared, **_get_scope_shared_props(request)}
+    state = peek_transient_state(request)
+    return {**session_shared, **(state.shared if state is not None else {})}
 
 
 def _consume_session_handoff_state(
@@ -1471,20 +1458,6 @@ def _materialize_shared_value(value: "Any") -> "Any":  # pyright: ignore[reportU
     return value
 
 
-def materialize_shared_props_to_session(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
-    """Persist transient state through the request's session when available.
-
-    In-frame redirect construction and wrapped non-Inertia responses call this while handler
-    dependencies are alive. Exception-produced redirects use the same path after dependency
-    cleanup, where synchronous special props render on a best-effort basis. Async special props
-    are always skipped because they cannot be materialized synchronously.
-
-    Args:
-        connection: The current ASGI connection.
-    """
-    persist_transient_state_for_redirect(connection)
-
-
 def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "Any") -> "bool":
     """Stage a shared value for the current Inertia response.
 
@@ -1504,7 +1477,7 @@ def share(connection: "ASGIConnection[Any, Any, Any, Any]", key: "str", value: "
     Returns:
         True when the value was staged for the current request.
     """
-    _set_scope_shared_prop(connection, key, value)
+    stage_shared(connection, key, value)
     return True
 
 

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import msgspec
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.http_handlers.base import HTTPRouteHandler
+from litestar.middleware import DefineMiddleware
+from litestar.middleware.session import SessionMiddleware
 from litestar.plugins import InitPlugin
 from litestar.response import Response
+from litestar.security.session_auth.middleware import MiddlewareWrapper
+from litestar.utils.predicates import is_class_and_subclass
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -18,6 +23,21 @@ if TYPE_CHECKING:
     from litestar.config.app import AppConfig
 
     from litestar_vite.config import InertiaConfig
+
+
+_EXTRA_SESSION_PAGE_PROPS_SESSION_MSG = (
+    "InertiaConfig.extra_session_page_props requires Litestar session middleware. "
+    "Add CookieBackendConfig(...).middleware or ServerSideSessionConfig(...).middleware, "
+    "or clear extra_session_page_props."
+)
+
+
+def _has_session_integration(app_config: "AppConfig") -> bool:
+    return any(
+        isinstance(middleware, DefineMiddleware)
+        and is_class_and_subclass(middleware.middleware, (MiddlewareWrapper, SessionMiddleware))
+        for middleware in app_config.middleware
+    )
 
 
 class InertiaPlugin(InitPlugin):
@@ -120,6 +140,9 @@ class InertiaPlugin(InitPlugin):
         from litestar_vite.inertia.precognition import create_precognition_exception_handler
         from litestar_vite.inertia.request import InertiaRequest
         from litestar_vite.inertia.response import InertiaBack, InertiaResponse
+
+        if self.config.extra_session_page_props and not _has_session_integration(app_config):
+            raise ImproperlyConfiguredException(_EXTRA_SESSION_PAGE_PROPS_SESSION_MSG)
 
         if app_config.response_class is InertiaResponse:  # pyright: ignore[reportUnknownMemberType]
             return app_config

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -218,13 +218,11 @@ def _as_inertia_prop_mapping(data: "Any") -> "Mapping[str, Any] | None":
 async def _resolve_inertia_response_data(data: "Any", request: "Request[Any, Any, Any]") -> "Any":
     from litestar_vite.inertia.helpers import is_pagination_container
     from litestar_vite.inertia.response import InertiaResponse
-    from litestar_vite.inertia.state import persist_transient_state_for_redirect
 
     if isinstance(data, InertiaResponse):
         await data.resolve_async_props(request)
         return cast("InertiaResponse[Any]", data)
     if isinstance(data, Response):
-        persist_transient_state_for_redirect(request)
         return cast("Response[Any]", data)
 
     content: "Any"

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -24,7 +24,7 @@ class InertiaPlugin(InitPlugin):
     """Inertia plugin.
 
     This plugin configures Litestar for Inertia.js support, including:
-    - Session middleware requirement validation
+    - Optional session-backed redirect state
     - Exception handler for Inertia responses
     - InertiaRequest and InertiaResponse as default classes
     - Type encoders for StaticProp and DeferredProp
@@ -52,7 +52,6 @@ class InertiaPlugin(InitPlugin):
 
         app = Litestar(
             plugins=[InertiaPlugin(InertiaConfig())],
-            middleware=[ServerSideSessionConfig().middleware],
         )
     """
 
@@ -107,17 +106,10 @@ class InertiaPlugin(InitPlugin):
         Args:
             app_config: The :class:`AppConfig <litestar.config.app.AppConfig>` instance.
 
-        Raises:
-            ImproperlyConfiguredException: If the Inertia plugin is not properly configured.
-
         Returns:
             The :class:`AppConfig <litestar.config.app.AppConfig>` instance.
         """
-        from litestar.exceptions import HTTPException, ImproperlyConfiguredException, ValidationException
-        from litestar.middleware import DefineMiddleware
-        from litestar.middleware.session import SessionMiddleware
-        from litestar.security.session_auth.middleware import MiddlewareWrapper
-        from litestar.utils.predicates import is_class_and_subclass
+        from litestar.exceptions import HTTPException, ValidationException
 
         from litestar_vite.inertia.exception_handler import (
             _register_exception_handlers,  # pyright: ignore[reportPrivateUsage]
@@ -131,15 +123,6 @@ class InertiaPlugin(InitPlugin):
 
         if app_config.response_class is InertiaResponse:  # pyright: ignore[reportUnknownMemberType]
             return app_config
-
-        for mw in app_config.middleware:
-            if isinstance(mw, DefineMiddleware) and is_class_and_subclass(
-                mw.middleware, (MiddlewareWrapper, SessionMiddleware)
-            ):
-                break
-        else:
-            msg = "The Inertia plugin require a session middleware."
-            raise ImproperlyConfiguredException(msg)
 
         # Register exception handlers
         exception_handlers: "dict[type[Exception] | int, Any]" = {

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -7,14 +7,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import msgspec
-from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.http_handlers.base import HTTPRouteHandler
-from litestar.middleware import DefineMiddleware
-from litestar.middleware.session import SessionMiddleware
 from litestar.plugins import InitPlugin
 from litestar.response import Response
-from litestar.security.session_auth.middleware import MiddlewareWrapper
-from litestar.utils.predicates import is_class_and_subclass
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -23,21 +18,6 @@ if TYPE_CHECKING:
     from litestar.config.app import AppConfig
 
     from litestar_vite.config import InertiaConfig
-
-
-_EXTRA_SESSION_PAGE_PROPS_SESSION_MSG = (
-    "InertiaConfig.extra_session_page_props requires Litestar session middleware. "
-    "Add CookieBackendConfig(...).middleware or ServerSideSessionConfig(...).middleware, "
-    "or clear extra_session_page_props."
-)
-
-
-def _has_session_integration(app_config: "AppConfig") -> bool:
-    return any(
-        isinstance(middleware, DefineMiddleware)
-        and is_class_and_subclass(middleware.middleware, (MiddlewareWrapper, SessionMiddleware))
-        for middleware in app_config.middleware
-    )
 
 
 class InertiaPlugin(InitPlugin):
@@ -140,9 +120,6 @@ class InertiaPlugin(InitPlugin):
         from litestar_vite.inertia.precognition import create_precognition_exception_handler
         from litestar_vite.inertia.request import InertiaRequest
         from litestar_vite.inertia.response import InertiaBack, InertiaResponse
-
-        if self.config.extra_session_page_props and not _has_session_integration(app_config):
-            raise ImproperlyConfiguredException(_EXTRA_SESSION_PAGE_PROPS_SESSION_MSG)
 
         if app_config.response_class is InertiaResponse:  # pyright: ignore[reportUnknownMemberType]
             return app_config

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -233,14 +233,15 @@ def _as_inertia_prop_mapping(data: "Any") -> "Mapping[str, Any] | None":
 
 
 async def _resolve_inertia_response_data(data: "Any", request: "Request[Any, Any, Any]") -> "Any":
-    from litestar_vite.inertia.helpers import is_pagination_container, materialize_shared_props_to_session
+    from litestar_vite.inertia.helpers import is_pagination_container
     from litestar_vite.inertia.response import InertiaResponse
+    from litestar_vite.inertia.state import persist_transient_state_for_redirect
 
     if isinstance(data, InertiaResponse):
         await data.resolve_async_props(request)
         return cast("InertiaResponse[Any]", data)
     if isinstance(data, Response):
-        materialize_shared_props_to_session(request)
+        persist_transient_state_for_redirect(request)
         return cast("Response[Any]", data)
 
     content: "Any"

--- a/src/py/litestar_vite/inertia/response.py
+++ b/src/py/litestar_vite/inertia/response.py
@@ -33,7 +33,6 @@ from litestar_vite.inertia.helpers import (
     is_or_contains_special_prop,
     is_pagination_container,
     lazy_render,
-    materialize_shared_props_to_session,
     pagination_to_dict,
     resolve_async_props,
     should_render,
@@ -41,6 +40,7 @@ from litestar_vite.inertia.helpers import (
 )
 from litestar_vite.inertia.plugin import InertiaPlugin
 from litestar_vite.inertia.request import InertiaDetails, InertiaRequest
+from litestar_vite.inertia.state import consume_clear_history, persist_transient_state_for_redirect
 from litestar_vite.inertia.types import InertiaHeaderType, PageProps, ScrollPropsConfig
 from litestar_vite.plugin import VitePlugin
 
@@ -707,7 +707,7 @@ class InertiaExternalRedirect(Response[Any]):
             redirect_to: The URL to redirect to (can be external).
             **kwargs: Additional keyword arguments passed to the Response constructor.
         """
-        materialize_shared_props_to_session(request)
+        persist_transient_state_for_redirect(request)
         super().__init__(
             content=b"",
             status_code=HTTP_409_CONFLICT,
@@ -735,7 +735,7 @@ class InertiaRedirect(Redirect):
             redirect_to: The URL to redirect to. Must be same-origin or relative.
             **kwargs: Additional keyword arguments passed to the Redirect constructor.
         """
-        materialize_shared_props_to_session(request)
+        persist_transient_state_for_redirect(request)
         safe_url = _get_redirect_url(request, redirect_to)
         if _should_use_fragment_redirect(request, safe_url):
             self._uses_inertia_fragment_redirect = True
@@ -1113,14 +1113,14 @@ def _resolve_encrypt_history(encrypt_history: "bool | None", inertia_plugin: "In
 
 
 def _resolve_clear_history(clear_history: bool, request: "Request[Any, Any, Any]") -> bool:
-    if clear_history:
-        return True
+    local_clear_history = consume_clear_history(request)
+    session_clear_history = False
     with contextlib.suppress(AttributeError, ImproperlyConfiguredException):
-        return cast(
+        session_clear_history = cast(
             "bool",
             request.session.pop("_inertia_clear_history", False),  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
         )
-    return False
+    return clear_history or local_clear_history or session_clear_history
 
 
 def _merge_deferred_props(target: "dict[str, list[str]]", source: "Mapping[str, list[str]]") -> None:

--- a/src/py/litestar_vite/inertia/state.py
+++ b/src/py/litestar_vite/inertia/state.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
@@ -53,19 +52,11 @@ def _scope(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, Any]"
     return cast("dict[str, Any]", scope)
 
 
-def _coerce_transient_state(value: Any) -> "InertiaTransientState | None":
-    if isinstance(value, InertiaTransientState):
-        return value
-    if isinstance(value, Mapping):
-        return InertiaTransientState(shared=dict(cast("Mapping[str, Any]", value)))
-    return None
-
-
 def get_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> InertiaTransientState:
     """Return the connection's transient state, creating it when absent."""
     scope = _scope(connection)
-    state = _coerce_transient_state(scope.get(_TRANSIENT_STATE_SCOPE_KEY))
-    if state is None:
+    state = scope.get(_TRANSIENT_STATE_SCOPE_KEY)
+    if not isinstance(state, InertiaTransientState):
         state = InertiaTransientState()
     scope[_TRANSIENT_STATE_SCOPE_KEY] = state
     return state
@@ -73,18 +64,14 @@ def get_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> Ine
 
 def peek_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> "InertiaTransientState | None":
     """Return transient state without creating or consuming it."""
-    scope = _scope(connection)
-    value = scope.get(_TRANSIENT_STATE_SCOPE_KEY)
-    state = _coerce_transient_state(value)
-    if state is not None and state is not value:
-        scope[_TRANSIENT_STATE_SCOPE_KEY] = state
-    return state
+    state = _scope(connection).get(_TRANSIENT_STATE_SCOPE_KEY)
+    return state if isinstance(state, InertiaTransientState) else None
 
 
 def consume_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> InertiaTransientState:
     """Remove and return all transient state from the connection."""
-    value = _scope(connection).pop(_TRANSIENT_STATE_SCOPE_KEY, None)
-    return _coerce_transient_state(value) or InertiaTransientState()
+    state = _scope(connection).pop(_TRANSIENT_STATE_SCOPE_KEY, None)
+    return state if isinstance(state, InertiaTransientState) else InertiaTransientState()
 
 
 def _discard_empty_state(connection: "ASGIConnection[Any, Any, Any, Any]", state: InertiaTransientState) -> None:

--- a/src/py/litestar_vite/inertia/state.py
+++ b/src/py/litestar_vite/inertia/state.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
@@ -7,6 +8,8 @@ from litestar.exceptions import ImproperlyConfiguredException
 if TYPE_CHECKING:
     from litestar.connection import ASGIConnection
 
+
+logger = logging.getLogger("litestar_vite")
 
 _TRANSIENT_STATE_SCOPE_KEY = "_litestar_vite_inertia_shared"
 
@@ -157,10 +160,25 @@ def consume_clear_history(connection: "ASGIConnection[Any, Any, Any, Any]") -> b
 
 
 def _session(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, Any] | None":
-    try:
-        return connection.session
-    except (AttributeError, ImproperlyConfiguredException):
-        return None
+    session = _scope(connection).get("session")
+    return cast("dict[str, Any]", session) if isinstance(session, dict) else None
+
+
+def _warn_redirect_state_loss(result: RedirectStatePersistence) -> None:
+    if not result.had_pending or result.persisted:
+        return
+    if result.dropped_keys:
+        logger.warning(
+            "Inertia redirect dropped shared prop(s) that cannot be materialized synchronously: %s. "
+            "Async shared props cannot cross redirects; return a direct Inertia response or share serializable values.",
+            ", ".join(result.dropped_keys),
+        )
+        return
+    logger.warning(
+        "Inertia redirect discarded pending transient state because this request has no writable Litestar session. "
+        "Add CookieBackendConfig(...).middleware for server-store-free redirect persistence, or return a direct "
+        "Inertia response."
+    )
 
 
 def has_redirect_state_transport(connection: "ASGIConnection[Any, Any, Any, Any]") -> bool:
@@ -177,7 +195,10 @@ def persist_transient_state_for_redirect(connection: "ASGIConnection[Any, Any, A
 
     session = _session(connection)
     if session is None:
-        return RedirectStatePersistence(had_pending=True, persisted=False)
+        consume_transient_state(connection)
+        result = RedirectStatePersistence(had_pending=True, persisted=False)
+        _warn_redirect_state_loss(result)
+        return result
 
     from litestar_vite.inertia.helpers import (
         _UNMATERIALIZABLE_SHARED,  # pyright: ignore[reportPrivateUsage]
@@ -217,4 +238,6 @@ def persist_transient_state_for_redirect(connection: "ASGIConnection[Any, Any, A
 
     consume_transient_state(connection)
     dropped = tuple(dropped_keys)
-    return RedirectStatePersistence(had_pending=True, persisted=not dropped, dropped_keys=dropped)
+    result = RedirectStatePersistence(had_pending=True, persisted=not dropped, dropped_keys=dropped)
+    _warn_redirect_state_loss(result)
+    return result

--- a/src/py/litestar_vite/inertia/state.py
+++ b/src/py/litestar_vite/inertia/state.py
@@ -1,0 +1,220 @@
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from litestar.exceptions import ImproperlyConfiguredException
+
+if TYPE_CHECKING:
+    from litestar.connection import ASGIConnection
+
+
+_TRANSIENT_STATE_SCOPE_KEY = "_litestar_vite_inertia_shared"
+
+
+def _empty_shared() -> "dict[str, Any]":
+    return {}
+
+
+def _empty_flash() -> "dict[str, list[str]]":
+    return {}
+
+
+def _empty_errors() -> "dict[str, str]":
+    return {}
+
+
+@dataclass
+class InertiaTransientState:
+    """Current-request state staged by Inertia helpers."""
+
+    shared: dict[str, Any] = field(default_factory=_empty_shared)
+    flash: dict[str, list[str]] = field(default_factory=_empty_flash)
+    errors: dict[str, str] = field(default_factory=_empty_errors)
+    clear_history: bool = False
+
+
+@dataclass(frozen=True)
+class RedirectStatePersistence:
+    """Result of attempting to persist transient state across a redirect."""
+
+    had_pending: bool
+    persisted: bool
+    dropped_keys: tuple[str, ...] = ()
+
+
+def _scope(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, Any]":
+    scope = getattr(connection, "scope", None)
+    if not isinstance(scope, dict):
+        msg = "Inertia transient state requires a mutable ASGI scope."
+        raise ImproperlyConfiguredException(msg)
+    return cast("dict[str, Any]", scope)
+
+
+def _coerce_transient_state(value: Any) -> "InertiaTransientState | None":
+    if isinstance(value, InertiaTransientState):
+        return value
+    if isinstance(value, Mapping):
+        return InertiaTransientState(shared=dict(cast("Mapping[str, Any]", value)))
+    return None
+
+
+def get_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> InertiaTransientState:
+    """Return the connection's transient state, creating it when absent."""
+    scope = _scope(connection)
+    state = _coerce_transient_state(scope.get(_TRANSIENT_STATE_SCOPE_KEY))
+    if state is None:
+        state = InertiaTransientState()
+    scope[_TRANSIENT_STATE_SCOPE_KEY] = state
+    return state
+
+
+def peek_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> "InertiaTransientState | None":
+    """Return transient state without creating or consuming it."""
+    scope = _scope(connection)
+    value = scope.get(_TRANSIENT_STATE_SCOPE_KEY)
+    state = _coerce_transient_state(value)
+    if state is not None and state is not value:
+        scope[_TRANSIENT_STATE_SCOPE_KEY] = state
+    return state
+
+
+def consume_transient_state(connection: "ASGIConnection[Any, Any, Any, Any]") -> InertiaTransientState:
+    """Remove and return all transient state from the connection."""
+    value = _scope(connection).pop(_TRANSIENT_STATE_SCOPE_KEY, None)
+    return _coerce_transient_state(value) or InertiaTransientState()
+
+
+def _discard_empty_state(connection: "ASGIConnection[Any, Any, Any, Any]", state: InertiaTransientState) -> None:
+    if state.shared or state.flash or state.errors or state.clear_history:
+        return
+    scope = _scope(connection)
+    if scope.get(_TRANSIENT_STATE_SCOPE_KEY) is state:
+        scope.pop(_TRANSIENT_STATE_SCOPE_KEY, None)
+
+
+def stage_shared(connection: "ASGIConnection[Any, Any, Any, Any]", key: str, value: Any) -> None:
+    """Stage one raw shared prop for the current response."""
+    get_transient_state(connection).shared[key] = value
+
+
+def stage_flash(connection: "ASGIConnection[Any, Any, Any, Any]", message: str, category: str = "info") -> None:
+    """Append one flash message for the current response."""
+    get_transient_state(connection).flash.setdefault(category, []).append(message)
+
+
+def stage_error(connection: "ASGIConnection[Any, Any, Any, Any]", key: str, message: str) -> None:
+    """Stage one validation error for the current response."""
+    get_transient_state(connection).errors[key] = message
+
+
+def stage_clear_history(connection: "ASGIConnection[Any, Any, Any, Any]") -> None:
+    """Mark the current response as clearing encrypted browser history."""
+    get_transient_state(connection).clear_history = True
+
+
+def consume_shared(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, Any]":
+    """Consume current-request shared props."""
+    state = peek_transient_state(connection)
+    if state is None:
+        return {}
+    shared = state.shared
+    state.shared = {}
+    _discard_empty_state(connection, state)
+    return shared
+
+
+def consume_flash(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, list[str]]":
+    """Consume current-request flash messages."""
+    state = peek_transient_state(connection)
+    if state is None:
+        return {}
+    flash = state.flash
+    state.flash = {}
+    _discard_empty_state(connection, state)
+    return flash
+
+
+def consume_errors(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, str]":
+    """Consume current-request validation errors."""
+    state = peek_transient_state(connection)
+    if state is None:
+        return {}
+    errors = state.errors
+    state.errors = {}
+    _discard_empty_state(connection, state)
+    return errors
+
+
+def consume_clear_history(connection: "ASGIConnection[Any, Any, Any, Any]") -> bool:
+    """Consume the current-request clear-history flag."""
+    state = peek_transient_state(connection)
+    if state is None:
+        return False
+    clear_history = state.clear_history
+    state.clear_history = False
+    _discard_empty_state(connection, state)
+    return clear_history
+
+
+def _session(connection: "ASGIConnection[Any, Any, Any, Any]") -> "dict[str, Any] | None":
+    try:
+        return connection.session
+    except (AttributeError, ImproperlyConfiguredException):
+        return None
+
+
+def has_redirect_state_transport(connection: "ASGIConnection[Any, Any, Any, Any]") -> bool:
+    """Return whether this request exposes a writable session transport."""
+    return _session(connection) is not None
+
+
+def persist_transient_state_for_redirect(connection: "ASGIConnection[Any, Any, Any, Any]") -> RedirectStatePersistence:
+    """Persist supported transient state into the legacy session wire keys."""
+    state = peek_transient_state(connection)
+    had_pending = bool(state and (state.shared or state.flash or state.errors or state.clear_history))
+    if not had_pending or state is None:
+        return RedirectStatePersistence(had_pending=False, persisted=False)
+
+    session = _session(connection)
+    if session is None:
+        return RedirectStatePersistence(had_pending=True, persisted=False)
+
+    from litestar_vite.inertia.helpers import (
+        _UNMATERIALIZABLE_SHARED,  # pyright: ignore[reportPrivateUsage]
+        _materialize_shared_value,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    dropped_keys: list[str] = []
+    if state.shared:
+        raw_session_shared: Any = session.setdefault("_shared", {})
+        session_shared = cast("dict[str, Any]", raw_session_shared) if isinstance(raw_session_shared, dict) else {}
+        if session_shared is not raw_session_shared:
+            session["_shared"] = session_shared
+        for key, value in state.shared.items():
+            materialized = _materialize_shared_value(value)
+            if materialized is _UNMATERIALIZABLE_SHARED:
+                dropped_keys.append(key)
+                continue
+            session_shared[key] = materialized
+
+    if state.flash:
+        raw_messages: Any = session.setdefault("_messages", [])
+        session_messages = cast("list[dict[str, str]]", raw_messages) if isinstance(raw_messages, list) else []
+        if session_messages is not raw_messages:
+            session["_messages"] = session_messages
+        for category, messages in state.flash.items():
+            session_messages.extend({"category": category, "message": message} for message in messages)
+
+    if state.errors:
+        raw_errors: Any = session.setdefault("_errors", {})
+        session_errors = cast("dict[str, str]", raw_errors) if isinstance(raw_errors, dict) else {}
+        if session_errors is not raw_errors:
+            session["_errors"] = session_errors
+        session_errors.update(state.errors)
+
+    if state.clear_history:
+        session["_inertia_clear_history"] = True
+
+    consume_transient_state(connection)
+    dropped = tuple(dropped_keys)
+    return RedirectStatePersistence(had_pending=True, persisted=not dropped, dropped_keys=dropped)

--- a/src/py/litestar_vite/inertia/state.py
+++ b/src/py/litestar_vite/inertia/state.py
@@ -162,9 +162,8 @@ def _warn_redirect_state_loss(result: RedirectStatePersistence) -> None:
         )
         return
     logger.warning(
-        "Inertia redirect discarded pending transient state because this request has no writable Litestar session. "
-        "Add CookieBackendConfig(...).middleware for server-store-free redirect persistence, or return a direct "
-        "Inertia response."
+        "Inertia redirect could not persist staged state because this request has no writable Litestar session. "
+        "Ensure the configured Litestar session middleware covers this route."
     )
 
 

--- a/src/py/litestar_vite/inertia/state.py
+++ b/src/py/litestar_vite/inertia/state.py
@@ -187,7 +187,7 @@ def has_redirect_state_transport(connection: "ASGIConnection[Any, Any, Any, Any]
 
 
 def persist_transient_state_for_redirect(connection: "ASGIConnection[Any, Any, Any, Any]") -> RedirectStatePersistence:
-    """Persist supported transient state into the legacy session wire keys."""
+    """Persist supported transient state into the session handoff keys."""
     state = peek_transient_state(connection)
     had_pending = bool(state and (state.shared or state.flash or state.errors or state.clear_history))
     if not had_pending or state is None:

--- a/src/py/tests/unit/inertia/test_auto_registration.py
+++ b/src/py/tests/unit/inertia/test_auto_registration.py
@@ -100,6 +100,28 @@ def test_inertia_envelope_returned_when_auto_registered(
         assert data["props"]["thing"] == "value"
 
 
+def test_inertia_envelope_returned_without_session_middleware(
+    inertia_vite_config: ViteConfig, template_config_inertia: TemplateConfig[Any]
+) -> None:
+    """Core Inertia wiring should not require cross-request persistence."""
+
+    @get("/", component="Home")
+    async def handler() -> dict[str, str]:
+        return {"thing": "value"}
+
+    with create_test_client(
+        plugins=[VitePlugin(config=inertia_vite_config)],
+        route_handlers=[handler],
+        template_config=template_config_inertia,
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    data = response.json()
+    assert data["component"] == "Home"
+    assert data["props"]["thing"] == "value"
+    assert data["flash"] == {}
+
+
 def test_inertia_envelope_uses_custom_component_opt_keys(
     test_app_path: Path, template_config_inertia: TemplateConfig[Any]
 ) -> None:
@@ -267,6 +289,22 @@ def test_inertia_plugin_on_app_init_is_idempotent(inertia_vite_config: ViteConfi
 
     config = AppConfig(middleware=[ServerSideSessionConfig().middleware], stores={"sessions": MemoryStore()})
     config = plugin.on_app_init(config)
+    middleware_count_after_first = len(config.middleware)
+    lifespan_count_after_first = len(config.lifespan)
+    on_startup_count_after_first = len(config.on_startup)
+
+    config = plugin.on_app_init(config)
+
+    assert len(config.middleware) == middleware_count_after_first
+    assert len(config.lifespan) == lifespan_count_after_first
+    assert len(config.on_startup) == on_startup_count_after_first
+
+
+def test_inertia_plugin_on_app_init_is_session_optional_and_idempotent(inertia_vite_config: ViteConfig) -> None:
+    """Direct plugin setup should succeed without any session middleware."""
+    plugin = InertiaPlugin(config=inertia_vite_config.inertia)  # type: ignore[arg-type]
+
+    config = plugin.on_app_init(AppConfig())
     middleware_count_after_first = len(config.middleware)
     lifespan_count_after_first = len(config.lifespan)
     on_startup_count_after_first = len(config.on_startup)

--- a/src/py/tests/unit/inertia/test_auto_registration.py
+++ b/src/py/tests/unit/inertia/test_auto_registration.py
@@ -22,8 +22,11 @@ from typing import Any
 import pytest
 from litestar import Request, get
 from litestar.config.app import AppConfig
+from litestar.exceptions import ImproperlyConfiguredException
+from litestar.middleware.session.client_side import CookieBackendConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.plugins import InitPlugin
+from litestar.security.session_auth import SessionAuth
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
@@ -32,6 +35,7 @@ from litestar_vite.config import InertiaConfig, PathConfig, RuntimeConfig, ViteC
 from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
 from litestar_vite.inertia.middleware import InertiaMiddleware
 from litestar_vite.inertia.plugin import _wrap_app_handlers
+from litestar_vite.inertia.response import InertiaResponse
 from litestar_vite.plugin import VitePlugin
 
 
@@ -314,6 +318,48 @@ def test_inertia_plugin_on_app_init_is_session_optional_and_idempotent(inertia_v
     assert len(config.middleware) == middleware_count_after_first
     assert len(config.lifespan) == lifespan_count_after_first
     assert len(config.on_startup) == on_startup_count_after_first
+
+
+@pytest.mark.parametrize("preconfigured_response", [False, True], ids=["default-response", "inertia-response"])
+def test_extra_session_page_props_requires_session_integration(preconfigured_response: bool) -> None:
+    """Explicit session props should fail with an option-specific startup error."""
+    plugin = InertiaPlugin(config=InertiaConfig(extra_session_page_props={"locale"}))
+    app_config = AppConfig(response_class=InertiaResponse) if preconfigured_response else AppConfig()
+
+    with pytest.raises(ImproperlyConfiguredException) as exc_info:
+        plugin.on_app_init(app_config)
+
+    assert exc_info.value.detail == (
+        "InertiaConfig.extra_session_page_props requires Litestar session middleware. "
+        "Add CookieBackendConfig(...).middleware or ServerSideSessionConfig(...).middleware, "
+        "or clear extra_session_page_props."
+    )
+
+
+async def _retrieve_test_user(_: Any, __: Any) -> None:
+    return None
+
+
+@pytest.mark.parametrize(
+    "middleware",
+    [
+        pytest.param(ServerSideSessionConfig().middleware, id="server-side"),
+        pytest.param(CookieBackendConfig(secret=b"x" * 32).middleware, id="encrypted-cookie"),
+        pytest.param(
+            SessionAuth(
+                session_backend_config=CookieBackendConfig(secret=b"x" * 32), retrieve_user_handler=_retrieve_test_user
+            ).middleware,
+            id="session-auth",
+        ),
+    ],
+)
+def test_extra_session_page_props_accepts_supported_session_integrations(middleware: Any) -> None:
+    """All first-party Litestar session integration shapes should satisfy validation."""
+    plugin = InertiaPlugin(config=InertiaConfig(extra_session_page_props={"locale"}))
+
+    config = plugin.on_app_init(AppConfig(middleware=[middleware]))
+
+    assert config.response_class is InertiaResponse
 
 
 # Quiet pyright about an unused import -- Iterator is reserved for future params.

--- a/src/py/tests/unit/inertia/test_auto_registration.py
+++ b/src/py/tests/unit/inertia/test_auto_registration.py
@@ -22,11 +22,8 @@ from typing import Any
 import pytest
 from litestar import Request, get
 from litestar.config.app import AppConfig
-from litestar.exceptions import ImproperlyConfiguredException
-from litestar.middleware.session.client_side import CookieBackendConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.plugins import InitPlugin
-from litestar.security.session_auth import SessionAuth
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
 from litestar.testing import create_test_client  # pyright: ignore[reportUnknownVariableType]
@@ -107,7 +104,9 @@ def test_inertia_envelope_returned_when_auto_registered(
 def test_inertia_envelope_returned_without_session_middleware(
     inertia_vite_config: ViteConfig, template_config_inertia: TemplateConfig[Any]
 ) -> None:
-    """Core Inertia wiring should not require cross-request persistence."""
+    """Core Inertia wiring should omit unavailable configured session props."""
+    assert isinstance(inertia_vite_config.inertia, InertiaConfig)
+    inertia_vite_config.inertia.extra_session_page_props = {"locale"}
 
     @get("/", component="Home")
     async def handler() -> dict[str, str]:
@@ -123,6 +122,7 @@ def test_inertia_envelope_returned_without_session_middleware(
     data = response.json()
     assert data["component"] == "Home"
     assert data["props"]["thing"] == "value"
+    assert "locale" not in data["props"]
     assert data["flash"] == {}
 
 
@@ -321,43 +321,12 @@ def test_inertia_plugin_on_app_init_is_session_optional_and_idempotent(inertia_v
 
 
 @pytest.mark.parametrize("preconfigured_response", [False, True], ids=["default-response", "inertia-response"])
-def test_extra_session_page_props_requires_session_integration(preconfigured_response: bool) -> None:
-    """Explicit session props should fail with an option-specific startup error."""
+def test_extra_session_page_props_allow_sessionless_startup(preconfigured_response: bool) -> None:
+    """Configured session props should not make a sessionless app fail startup."""
     plugin = InertiaPlugin(config=InertiaConfig(extra_session_page_props={"locale"}))
     app_config = AppConfig(response_class=InertiaResponse) if preconfigured_response else AppConfig()
 
-    with pytest.raises(ImproperlyConfiguredException) as exc_info:
-        plugin.on_app_init(app_config)
-
-    assert exc_info.value.detail == (
-        "InertiaConfig.extra_session_page_props requires Litestar session middleware. "
-        "Add CookieBackendConfig(...).middleware or ServerSideSessionConfig(...).middleware, "
-        "or clear extra_session_page_props."
-    )
-
-
-async def _retrieve_test_user(_: Any, __: Any) -> None:
-    return None
-
-
-@pytest.mark.parametrize(
-    "middleware",
-    [
-        pytest.param(ServerSideSessionConfig().middleware, id="server-side"),
-        pytest.param(CookieBackendConfig(secret=b"x" * 32).middleware, id="encrypted-cookie"),
-        pytest.param(
-            SessionAuth(
-                session_backend_config=CookieBackendConfig(secret=b"x" * 32), retrieve_user_handler=_retrieve_test_user
-            ).middleware,
-            id="session-auth",
-        ),
-    ],
-)
-def test_extra_session_page_props_accepts_supported_session_integrations(middleware: Any) -> None:
-    """All first-party Litestar session integration shapes should satisfy validation."""
-    plugin = InertiaPlugin(config=InertiaConfig(extra_session_page_props={"locale"}))
-
-    config = plugin.on_app_init(AppConfig(middleware=[middleware]))
+    config = plugin.on_app_init(app_config)
 
     assert config.response_class is InertiaResponse
 

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -64,6 +64,106 @@ def test_get_shared_props_includes_scope_props_when_session_is_unavailable() -> 
     assert _RAW_SHARED_SCOPE_KEY not in request.scope
 
 
+async def test_transient_helpers_render_direct_response_without_route_session(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Current-request state should not require a session-enabled route."""
+    from litestar_vite.inertia.helpers import error, flash, share
+
+    @get("/current", component="Current")
+    async def current_handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        return {
+            "share_result": share(request, "auth", {"user": "Ada"}),
+            "flash_result": flash(request, "Saved", "success"),
+            "error_result": error(request, "email", "Invalid email"),
+            "clear_result": clear_history(request),
+        }
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, str]:
+        return {"page": "next"}
+
+    with create_test_client(
+        route_handlers=[current_handler, next_handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig(exclude=["/current", "/next"]).middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        current_response = client.get("/current", headers={InertiaHeaders.ENABLED.value: "true"})
+        next_response = client.get("/next", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    current_page = current_response.json()
+    assert current_page["props"]["auth"] == {"user": "Ada"}
+    assert current_page["props"]["errors"] == {"email": "Invalid email"}
+    assert current_page["flash"] == {"success": ["Saved"]}
+    assert current_page["clearHistory"] is True
+    assert current_page["props"]["share_result"] is True
+    assert current_page["props"]["flash_result"] is True
+    assert current_page["props"]["error_result"] is True
+
+    next_page = next_response.json()
+    assert "auth" not in next_page["props"]
+    assert next_page["props"]["errors"] == {}
+    assert next_page["flash"] == {}
+    assert "clearHistory" not in next_page
+
+
+async def test_transient_state_overrides_legacy_session_without_eager_persistence(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Local state wins while legacy incoming flash keeps stable ordering."""
+    from litestar_vite.inertia.helpers import error, flash, share
+
+    captured_session: dict[str, Any] = {}
+
+    @get("/", component="Home")
+    async def handler(request: Request[Any, Any, Any]) -> dict[str, bool]:
+        request.session.update({
+            "_shared": {"auth": {"user": "Grace"}},
+            "_errors": {"email": "Legacy error"},
+            "_messages": [{"category": "success", "message": "Legacy"}],
+        })
+        results = {
+            "share_result": share(request, "auth", {"user": "Ada"}),
+            "flash_result": flash(request, "Saved", "success"),
+            "error_result": error(request, "email", "Invalid email"),
+        }
+        clear_history(request)
+        captured_session.update({
+            "_shared": dict(request.session["_shared"]),
+            "_errors": dict(request.session["_errors"]),
+            "_messages": list(request.session["_messages"]),
+            "clear_history": request.session.get("_inertia_clear_history"),
+        })
+        return results
+
+    with create_test_client(
+        route_handlers=[handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
+
+    page = response.json()
+    assert page["props"]["auth"] == {"user": "Ada"}
+    assert page["props"]["errors"] == {"email": "Invalid email"}
+    assert page["flash"] == {"success": ["Legacy", "Saved"]}
+    assert page["clearHistory"] is True
+    assert captured_session == {
+        "_shared": {"auth": {"user": "Grace"}},
+        "_errors": {"email": "Legacy error"},
+        "_messages": [{"category": "success", "message": "Legacy"}],
+        "clear_history": None,
+    }
+
+
 def test_scroll_props_helper_creates_config() -> None:
     """Test scroll_props() helper creates correct ScrollPropsConfig."""
     config = scroll_props(page_name="page", current_page=2, previous_page=1, next_page=3)
@@ -544,8 +644,8 @@ async def test_flash_returns_true_with_session(
         assert data["flash"] == {"success": ["Test message"]}
 
 
-def test_flash_returns_false_when_session_access_fails() -> None:
-    """Test flash() returns False when session access fails (GitHub #164).
+def test_flash_stages_locally_when_session_access_fails() -> None:
+    """Test flash() succeeds locally when session access fails.
 
     This simulates the scenario where session middleware is configured but
     the session itself is not accessible (e.g., for unauthenticated users
@@ -559,34 +659,34 @@ def test_flash_returns_false_when_session_access_fails() -> None:
 
     # Create a mock connection where session access raises an exception
     mock_connection = MagicMock()
+    mock_connection.scope = {}
     mock_connection.session.setdefault.side_effect = ImproperlyConfiguredException("No session")
     mock_connection.logger = MagicMock()
 
     result = flash(mock_connection, "Test message", "error")
 
-    # flash should have failed and returned False
-    assert result is False
-    # Should log at debug level (not warning)
-    mock_connection.logger.debug.assert_called_once()
+    assert result is True
+    mock_connection.session.setdefault.assert_not_called()
+    mock_connection.logger.debug.assert_not_called()
 
 
-def test_flash_returns_false_when_session_setdefault_raises_attribute_error() -> None:
-    """Test flash() returns False when session.setdefault raises AttributeError."""
+def test_flash_stages_locally_without_accessing_session_setdefault() -> None:
+    """Test flash() does not touch a broken session mapping."""
     from unittest.mock import MagicMock
 
     from litestar_vite.inertia.helpers import flash
 
     # Create a mock connection where session.setdefault raises AttributeError
     mock_connection = MagicMock()
+    mock_connection.scope = {}
     mock_connection.session.setdefault.side_effect = AttributeError("session attribute error")
     mock_connection.logger = MagicMock()
 
     result = flash(mock_connection, "Test message", "error")
 
-    # flash should have failed and returned False
-    assert result is False
-    # Should log at debug level
-    mock_connection.logger.debug.assert_called_once()
+    assert result is True
+    mock_connection.session.setdefault.assert_not_called()
+    mock_connection.logger.debug.assert_not_called()
 
 
 # =====================================================
@@ -685,12 +785,12 @@ async def test_share_does_not_execute_discarded_deferred_callable(
     assert calls == []
 
 
-async def test_share_skips_async_special_prop(
+async def test_share_stages_async_special_prop_for_current_response(
     inertia_plugin: InertiaPlugin,
     vite_plugin: VitePlugin,
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
-    """Test share() skips async special props that cannot be stored in session."""
+    """Async special props stage locally even though redirects cannot persist them."""
     from litestar_vite.inertia.helpers import defer, share
 
     captured: dict[str, Any] = {}
@@ -714,7 +814,7 @@ async def test_share_skips_async_special_prop(
         response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"})
         assert response.status_code == 200
 
-    assert captured["result"] is False
+    assert captured["result"] is True
     assert "slow" not in captured["shared"]
 
 
@@ -743,8 +843,8 @@ async def test_share_special_prop_survives_redirect(
         assert response.status_code == 307
 
 
-def test_share_returns_false_when_session_fails() -> None:
-    """Test share() returns False when session access fails."""
+def test_share_stages_locally_when_session_fails() -> None:
+    """Test share() succeeds locally when session access fails."""
     from unittest.mock import MagicMock
 
     from litestar.exceptions import ImproperlyConfiguredException
@@ -752,13 +852,15 @@ def test_share_returns_false_when_session_fails() -> None:
     from litestar_vite.inertia.helpers import share
 
     mock_connection = MagicMock()
+    mock_connection.scope = {}
     mock_connection.session.setdefault.side_effect = ImproperlyConfiguredException("No session")
     mock_connection.logger = MagicMock()
 
     result = share(mock_connection, "key", "value")
 
-    assert result is False
-    mock_connection.logger.debug.assert_called_once()
+    assert result is True
+    mock_connection.session.setdefault.assert_not_called()
+    mock_connection.logger.debug.assert_not_called()
 
 
 # =====================================================
@@ -794,8 +896,8 @@ async def test_error_returns_true_with_session(
         assert data["props"]["errors"]["email"] == "Invalid email format"
 
 
-def test_error_returns_false_when_session_fails() -> None:
-    """Test error() returns False when session access fails."""
+def test_error_stages_locally_when_session_fails() -> None:
+    """Test error() succeeds locally when session access fails."""
     from unittest.mock import MagicMock
 
     from litestar.exceptions import ImproperlyConfiguredException
@@ -803,13 +905,15 @@ def test_error_returns_false_when_session_fails() -> None:
     from litestar_vite.inertia.helpers import error
 
     mock_connection = MagicMock()
+    mock_connection.scope = {}
     mock_connection.session.setdefault.side_effect = ImproperlyConfiguredException("No session")
     mock_connection.logger = MagicMock()
 
     result = error(mock_connection, "field", "Error message")
 
-    assert result is False
-    mock_connection.logger.debug.assert_called_once()
+    assert result is True
+    mock_connection.session.setdefault.assert_not_called()
+    mock_connection.logger.debug.assert_not_called()
 
 
 # =====================================================

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from litestar import Request, get
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.middleware.session.server_side import ServerSideSessionConfig
@@ -14,6 +15,24 @@ from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
 from litestar_vite.inertia.helpers import clear_history, lazy, scroll_props, should_render
 from litestar_vite.inertia.response import InertiaResponse
 from litestar_vite.plugin import VitePlugin
+
+
+def test_materialize_shared_props_to_session_is_deprecated_compatibility_shim(recwarn: pytest.WarningsRecorder) -> None:
+    """The former materializer should persist staged state for one deprecation cycle."""
+    from litestar_vite.inertia.helpers import materialize_shared_props_to_session, share
+    from litestar_vite.inertia.state import peek_transient_state
+
+    request = MagicMock()
+    request.scope = {"session": {}}
+    share(request, "auth", {"user": "Ada"})
+
+    materialize_shared_props_to_session(request)
+
+    assert request.scope["session"]["_shared"] == {"auth": {"user": "Ada"}}
+    assert peek_transient_state(request) is None
+    warning = recwarn.pop(DeprecationWarning)
+    assert "will be removed in v0.30.0" in str(warning.message)
+
 
 # =====================================================
 # scroll_props() Helper Tests

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -74,11 +74,11 @@ async def test_transient_helpers_render_direct_response_without_route_session(
 
     @get("/current", component="Current")
     async def current_handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
+        clear_history(request)
         return {
             "share_result": share(request, "auth", {"user": "Ada"}),
             "flash_result": flash(request, "Saved", "success"),
             "error_result": error(request, "email", "Invalid email"),
-            "clear_result": clear_history(request),
         }
 
     @get("/next", component="Next")

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -115,12 +115,12 @@ async def test_transient_helpers_render_direct_response_without_route_session(
     warning.assert_not_called()
 
 
-async def test_transient_state_overrides_legacy_session_without_eager_persistence(
+async def test_transient_state_overrides_session_handoff_without_eager_persistence(
     inertia_plugin: InertiaPlugin,
     vite_plugin: VitePlugin,
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
-    """Local state wins while legacy incoming flash keeps stable ordering."""
+    """Local state wins while incoming session-handoff flash keeps stable ordering."""
     from litestar_vite.inertia.helpers import error, flash, share
 
     captured_session: dict[str, Any] = {}

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -1,7 +1,7 @@
 """Tests for Inertia helper functions (scroll_props, clear_history, should_render)."""
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from litestar import Request, get
 from litestar.exceptions import ImproperlyConfiguredException
@@ -85,13 +85,16 @@ async def test_transient_helpers_render_direct_response_without_route_session(
     async def next_handler() -> dict[str, str]:
         return {"page": "next"}
 
-    with create_test_client(
-        route_handlers=[current_handler, next_handler],
-        template_config=template_config,
-        plugins=[inertia_plugin, vite_plugin],
-        middleware=[ServerSideSessionConfig(exclude=["/current", "/next"]).middleware],
-        stores={"sessions": MemoryStore()},
-    ) as client:
+    with (
+        patch("litestar_vite.inertia.state.logger.warning") as warning,
+        create_test_client(
+            route_handlers=[current_handler, next_handler],
+            template_config=template_config,
+            plugins=[inertia_plugin, vite_plugin],
+            middleware=[ServerSideSessionConfig(exclude=["/current", "/next"]).middleware],
+            stores={"sessions": MemoryStore()},
+        ) as client,
+    ):
         current_response = client.get("/current", headers={InertiaHeaders.ENABLED.value: "true"})
         next_response = client.get("/next", headers={InertiaHeaders.ENABLED.value: "true"})
 
@@ -109,6 +112,7 @@ async def test_transient_helpers_render_direct_response_without_route_session(
     assert next_page["props"]["errors"] == {}
     assert next_page["flash"] == {}
     assert "clearHistory" not in next_page
+    warning.assert_not_called()
 
 
 async def test_transient_state_overrides_legacy_session_without_eager_persistence(

--- a/src/py/tests/unit/inertia/test_helpers.py
+++ b/src/py/tests/unit/inertia/test_helpers.py
@@ -45,13 +45,15 @@ def test_get_shared_props_includes_csrf_token_from_scope() -> None:
 
 def test_get_shared_props_includes_scope_props_when_session_is_unavailable() -> None:
     """Request-scope shared props should survive requests excluded from session middleware."""
-    from litestar_vite.inertia.helpers import _RAW_SHARED_SCOPE_KEY, get_shared_props
+    from litestar_vite.inertia.helpers import get_shared_props, share
+    from litestar_vite.inertia.state import peek_transient_state
 
     request = MagicMock()
     request.headers.get.return_value = None
     request.session.pop.side_effect = ImproperlyConfiguredException("No session")
-    request.scope = {_RAW_SHARED_SCOPE_KEY: {"auth": {"user": "Ada"}}}
+    request.scope = {}
     request.logger = MagicMock()
+    share(request, "auth", {"user": "Ada"})
 
     inertia_plugin = MagicMock()
     inertia_plugin.config.extra_static_page_props = {}
@@ -61,7 +63,7 @@ def test_get_shared_props_includes_scope_props_when_session_is_unavailable() -> 
     shared_props = get_shared_props(request)
 
     assert shared_props["auth"] == {"user": "Ada"}
-    assert _RAW_SHARED_SCOPE_KEY not in request.scope
+    assert peek_transient_state(request) is None
 
 
 async def test_transient_helpers_render_direct_response_without_route_session(

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -127,7 +127,7 @@ async def test_transient_state_delivered_across_session_backed_redirect(
     vite_plugin: VitePlugin,
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
-    """Supported local state should use the legacy session keys across PRG."""
+    """Supported local state should use the session handoff keys across PRG."""
 
     @post("/submit")
     async def submit_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from time import sleep
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from litestar import Request, delete, get, post
@@ -12,6 +12,7 @@ from litestar.middleware.session.client_side import CookieBackendConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.params import FromPath, FromQuery
 from litestar.plugins.jinja import JinjaTemplateEngine
+from litestar.response import Response
 from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_202_ACCEPTED, HTTP_204_NO_CONTENT
 from litestar.stores.memory import MemoryStore
 from litestar.template.config import TemplateConfig
@@ -42,6 +43,7 @@ from litestar_vite.inertia.helpers import (
     share,
     should_render,
 )
+from litestar_vite.inertia.plugin import _resolve_inertia_response_data
 from litestar_vite.inertia.response import (
     InertiaBack,
     InertiaExternalRedirect,
@@ -261,6 +263,18 @@ async def test_sessionless_redirect_without_pending_state_is_quiet(
 
     assert response.status_code == 307
     warning.assert_not_called()
+
+
+async def test_plain_response_does_not_attempt_redirect_persistence() -> None:
+    """Plain responses should not probe redirect transport for request-local state."""
+    request = MagicMock(spec=Request)
+    response = Response({"ok": True})
+
+    with patch("litestar_vite.inertia.state.persist_transient_state_for_redirect") as persist:
+        result = await _resolve_inertia_response_data(response, request)
+
+    assert result is response
+    persist.assert_not_called()
 
 
 async def test_component_enabled(
@@ -547,7 +561,7 @@ async def test_unauthenticated_redirect_with_query_param_fallback(
 ) -> None:
     """Test that sessionless unauthorized redirects retain the query fallback.
 
-    Local flash staging cannot cross a redirect without a request transport.
+    The fallback is selected before local flash state is staged.
     """
 
     @get("/protected", component="Protected")
@@ -575,8 +589,7 @@ async def test_unauthenticated_redirect_with_query_param_fallback(
     assert "/login" in location
     assert "error=" in location
     assert "Authentication%20required" in location or "Authentication+required" in location
-    warning.assert_called_once()
-    assert "no writable Litestar session" in warning.call_args.args[0]
+    warning.assert_not_called()
 
 
 async def test_unauthenticated_redirect_no_query_param_when_flash_succeeds(

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from litestar import Request, delete, get, post
 from litestar.exceptions import ImproperlyConfiguredException, NotAuthorizedException
+from litestar.middleware.session.client_side import CookieBackendConfig
 from litestar.middleware.session.server_side import ServerSideSessionConfig
 from litestar.params import FromPath, FromQuery
 from litestar.plugins.jinja import JinjaTemplateEngine
@@ -155,6 +156,111 @@ async def test_transient_state_delivered_across_session_backed_redirect(
     assert page["props"]["errors"] == {"email": "Invalid email"}
     assert page["flash"] == {"success": ["Saved"]}
     assert page["clearHistory"] is True
+
+
+async def test_transient_state_delivered_across_encrypted_cookie_redirect_without_warning(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Encrypted cookie sessions provide store-free PRG persistence."""
+
+    @post("/submit")
+    async def submit_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        share(request, "auth", {"user": "Ada"})
+        flash(request, "Saved", "success")
+        error(request, "email", "Invalid email")
+        clear_history(request)
+        return InertiaRedirect(request, "/next")
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, Any]:
+        return {}
+
+    with (
+        patch("litestar_vite.inertia.state.logger.warning") as warning,
+        create_test_client(
+            route_handlers=[submit_handler, next_handler],
+            template_config=template_config,
+            plugins=[inertia_plugin, vite_plugin],
+            middleware=[CookieBackendConfig(secret=b"x" * 32).middleware],
+        ) as client,
+    ):
+        response = client.post("/submit", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
+
+    page = response.json()
+    assert response.status_code == 200
+    assert page["props"]["auth"] == {"user": "Ada"}
+    assert page["props"]["errors"] == {"email": "Invalid email"}
+    assert page["flash"] == {"success": ["Saved"]}
+    assert page["clearHistory"] is True
+    warning.assert_not_called()
+
+
+async def test_route_excluded_from_session_discards_redirect_state_with_one_warning(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Route exclusions use actual request capability and diagnose lost state once."""
+
+    @post("/submit")
+    async def submit_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        flash(request, "Saved", "success")
+        error(request, "email", "Invalid email")
+        return InertiaRedirect(request, "/next")
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, Any]:
+        return {}
+
+    with (
+        patch("litestar_vite.inertia.state.logger.warning") as warning,
+        create_test_client(
+            route_handlers=[submit_handler, next_handler],
+            template_config=template_config,
+            plugins=[inertia_plugin, vite_plugin],
+            middleware=[ServerSideSessionConfig(exclude=["/submit"]).middleware],
+            stores={"sessions": MemoryStore()},
+        ) as client,
+    ):
+        response = client.post("/submit", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
+
+    page = response.json()
+    assert response.status_code == 200
+    assert page["props"]["errors"] == {}
+    assert page["flash"] == {}
+    warning.assert_called_once()
+    assert "no writable Litestar session" in warning.call_args.args[0]
+
+
+async def test_sessionless_redirect_without_pending_state_is_quiet(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Redirects only diagnose actual pending-state loss."""
+
+    @get("/")
+    async def redirect_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        return InertiaRedirect(request, "/next")
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, Any]:
+        return {}
+
+    with (
+        patch("litestar_vite.inertia.state.logger.warning") as warning,
+        create_test_client(
+            route_handlers=[redirect_handler, next_handler],
+            template_config=template_config,
+            plugins=[inertia_plugin, vite_plugin],
+        ) as client,
+    ):
+        response = client.get("/", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
+
+    assert response.status_code == 307
+    warning.assert_not_called()
 
 
 async def test_component_enabled(
@@ -454,11 +560,14 @@ async def test_unauthenticated_redirect_with_query_param_fallback(
 
     inertia_plugin.config.redirect_unauthorized_to = "/login"
 
-    with create_test_client(
-        route_handlers=[protected_handler, login_handler],
-        template_config=template_config,
-        plugins=[inertia_plugin, vite_plugin],
-    ) as client:
+    with (
+        patch("litestar_vite.inertia.state.logger.warning") as warning,
+        create_test_client(
+            route_handlers=[protected_handler, login_handler],
+            template_config=template_config,
+            plugins=[inertia_plugin, vite_plugin],
+        ) as client,
+    ):
         response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
 
     assert response.status_code == 307 or response.status_code == 302
@@ -466,6 +575,8 @@ async def test_unauthenticated_redirect_with_query_param_fallback(
     assert "/login" in location
     assert "error=" in location
     assert "Authentication%20required" in location or "Authentication+required" in location
+    warning.assert_called_once()
+    assert "no writable Litestar session" in warning.call_args.args[0]
 
 
 async def test_unauthenticated_redirect_no_query_param_when_flash_succeeds(

--- a/src/py/tests/unit/inertia/test_response.py
+++ b/src/py/tests/unit/inertia/test_response.py
@@ -22,7 +22,9 @@ from litestar_vite.inertia.helpers import (
     DeferredProp,
     MergeProp,
     StaticProp,
+    clear_history,
     defer,
+    error,
     except_,
     extract_deferred_props,
     extract_merge_props,
@@ -117,6 +119,42 @@ async def test_share_async_special_prop_not_persisted_across_redirect(
         response = client.get("/next", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
 
     assert "slow" not in response.json()["props"]
+
+
+async def test_transient_state_delivered_across_session_backed_redirect(
+    inertia_plugin: InertiaPlugin,
+    vite_plugin: VitePlugin,
+    template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
+) -> None:
+    """Supported local state should use the legacy session keys across PRG."""
+
+    @post("/submit")
+    async def submit_handler(request: Request[Any, Any, Any]) -> InertiaRedirect:
+        share(request, "auth", {"user": "Ada"})
+        flash(request, "Saved", "success")
+        error(request, "email", "Invalid email")
+        clear_history(request)
+        return InertiaRedirect(request, "/next")
+
+    @get("/next", component="Next")
+    async def next_handler() -> dict[str, Any]:
+        return {}
+
+    with create_test_client(
+        route_handlers=[submit_handler, next_handler],
+        template_config=template_config,
+        plugins=[inertia_plugin, vite_plugin],
+        middleware=[ServerSideSessionConfig().middleware],
+        stores={"sessions": MemoryStore()},
+    ) as client:
+        response = client.post("/submit", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=True)
+
+    page = response.json()
+    assert response.status_code == 200
+    assert page["props"]["auth"] == {"user": "Ada"}
+    assert page["props"]["errors"] == {"email": "Invalid email"}
+    assert page["flash"] == {"success": ["Saved"]}
+    assert page["clearHistory"] is True
 
 
 async def test_component_enabled(
@@ -401,12 +439,10 @@ async def test_unauthenticated_redirect_with_query_param_fallback(
     vite_plugin: VitePlugin,
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
-    """Test that unauthorized redirect includes error query param when flash fails (GitHub #164).
+    """Test that sessionless unauthorized redirects retain the query fallback.
 
-    When flash() fails due to session not being accessible, the exception handler
-    should fall back to passing the error message via query parameter.
+    Local flash staging cannot cross a redirect without a request transport.
     """
-    from unittest.mock import patch
 
     @get("/protected", component="Protected")
     async def protected_handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
@@ -422,19 +458,14 @@ async def test_unauthenticated_redirect_with_query_param_fallback(
         route_handlers=[protected_handler, login_handler],
         template_config=template_config,
         plugins=[inertia_plugin, vite_plugin],
-        middleware=[ServerSideSessionConfig().middleware],
-        stores={"sessions": MemoryStore()},
     ) as client:
-        # Mock flash() to return False (simulating session failure)
-        with patch("litestar_vite.inertia.exception_handler.flash", return_value=False):
-            response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
-            # Should redirect with query param fallback
-            assert response.status_code == 307 or response.status_code == 302
-            location = response.headers.get("location", "")
-            assert "/login" in location
-            assert "error=" in location
-            # URL-encoded message
-            assert "Authentication%20required" in location or "Authentication+required" in location
+        response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
+
+    assert response.status_code == 307 or response.status_code == 302
+    location = response.headers.get("location", "")
+    assert "/login" in location
+    assert "error=" in location
+    assert "Authentication%20required" in location or "Authentication+required" in location
 
 
 async def test_unauthenticated_redirect_no_query_param_when_flash_succeeds(
@@ -479,7 +510,6 @@ async def test_unauthenticated_redirect_query_param_with_special_chars(
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
     """Test that error messages with special characters are properly URL-encoded."""
-    from unittest.mock import patch
 
     @get("/protected", component="Protected")
     async def protected_handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
@@ -495,16 +525,12 @@ async def test_unauthenticated_redirect_query_param_with_special_chars(
         route_handlers=[protected_handler, login_handler],
         template_config=template_config,
         plugins=[inertia_plugin, vite_plugin],
-        middleware=[ServerSideSessionConfig().middleware],
-        stores={"sessions": MemoryStore()},
     ) as client:
-        # Mock flash() to return False (simulating session failure)
-        with patch("litestar_vite.inertia.exception_handler.flash", return_value=False):
-            response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
-            location = response.headers.get("location", "")
-            assert "error=" in location
-            # Special chars should be URL-encoded (@ becomes %40)
-            assert "@" not in location.split("error=")[1] if "error=" in location else True
+        response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
+
+    location = response.headers.get("location", "")
+    assert "error=" in location
+    assert "@" not in location.split("error=")[1] if "error=" in location else True
 
 
 async def test_unauthenticated_redirect_preserves_existing_query_params(
@@ -513,7 +539,6 @@ async def test_unauthenticated_redirect_preserves_existing_query_params(
     template_config: TemplateConfig,  # pyright: ignore[reportUnknownParameterType,reportMissingTypeArgument]
 ) -> None:
     """Test that error query param is appended to existing query params."""
-    from unittest.mock import patch
 
     @get("/protected", component="Protected")
     async def protected_handler(request: Request[Any, Any, Any]) -> dict[str, Any]:
@@ -530,19 +555,14 @@ async def test_unauthenticated_redirect_preserves_existing_query_params(
         route_handlers=[protected_handler, login_handler],
         template_config=template_config,
         plugins=[inertia_plugin, vite_plugin],
-        middleware=[ServerSideSessionConfig().middleware],
-        stores={"sessions": MemoryStore()},
     ) as client:
-        # Mock flash() to return False (simulating session failure)
-        with patch("litestar_vite.inertia.exception_handler.flash", return_value=False):
-            response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
-            location = response.headers.get("location", "")
-            # Should have both original and new query params
-            assert "redirect=" in location
-            assert "error=" in location
-            # Properly joined with &
-            assert "?" in location
-            assert "&" in location
+        response = client.get("/protected", headers={InertiaHeaders.ENABLED.value: "true"}, follow_redirects=False)
+
+    location = response.headers.get("location", "")
+    assert "redirect=" in location
+    assert "error=" in location
+    assert "?" in location
+    assert "&" in location
 
 
 async def test_404_redirect(

--- a/src/py/tests/unit/inertia/test_state.py
+++ b/src/py/tests/unit/inertia/test_state.py
@@ -1,0 +1,105 @@
+import logging
+from types import MappingProxyType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from litestar.types import Empty
+
+from litestar_vite.inertia.helpers import defer
+from litestar_vite.inertia.state import (
+    RedirectStatePersistence,
+    has_redirect_state_transport,
+    peek_transient_state,
+    persist_transient_state_for_redirect,
+    stage_clear_history,
+    stage_error,
+    stage_flash,
+    stage_shared,
+)
+
+
+def _connection(scope: dict[str, Any]) -> MagicMock:
+    connection = MagicMock()
+    connection.scope = scope
+    connection.session = scope.get("session")
+    return connection
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    [
+        pytest.param({}, False, id="absent"),
+        pytest.param({"session": None}, False, id="none"),
+        pytest.param({"session": Empty}, False, id="empty-sentinel"),
+        pytest.param({"session": MappingProxyType({})}, False, id="read-only-mapping"),
+        pytest.param({"session": {}}, True, id="writable-dict"),
+    ],
+)
+def test_has_redirect_state_transport_requires_writable_session_dict(scope: dict[str, Any], expected: bool) -> None:
+    connection = _connection(scope)
+
+    assert has_redirect_state_transport(connection) is expected
+
+
+def test_persist_transient_state_without_transport_consumes_and_warns_once(caplog: pytest.LogCaptureFixture) -> None:
+    connection = _connection({})
+    stage_flash(connection, "Saved", "success")
+
+    with caplog.at_level(logging.WARNING, logger="litestar_vite"):
+        first_result = persist_transient_state_for_redirect(connection)
+        second_result = persist_transient_state_for_redirect(connection)
+
+    assert first_result == RedirectStatePersistence(had_pending=True, persisted=False)
+    assert second_result == RedirectStatePersistence(had_pending=False, persisted=False)
+    assert peek_transient_state(connection) is None
+    assert len(caplog.records) == 1
+    assert "no writable Litestar session" in caplog.text
+    assert "CookieBackendConfig" in caplog.text
+    assert "direct Inertia response" in caplog.text
+
+
+def test_persist_transient_state_writes_legacy_session_keys_without_warning(caplog: pytest.LogCaptureFixture) -> None:
+    session: dict[str, Any] = {}
+    connection = _connection({"session": session})
+    stage_shared(connection, "auth", {"user": "Ada"})
+    stage_flash(connection, "Saved", "success")
+    stage_error(connection, "email", "Invalid email")
+    stage_clear_history(connection)
+
+    with caplog.at_level(logging.WARNING, logger="litestar_vite"):
+        result = persist_transient_state_for_redirect(connection)
+
+    assert result == RedirectStatePersistence(had_pending=True, persisted=True)
+    assert session == {
+        "_shared": {"auth": {"user": "Ada"}},
+        "_messages": [{"category": "success", "message": "Saved"}],
+        "_errors": {"email": "Invalid email"},
+        "_inertia_clear_history": True,
+    }
+    assert peek_transient_state(connection) is None
+    assert caplog.records == []
+
+
+def test_persist_transient_state_reports_unmaterializable_shared_keys_once(caplog: pytest.LogCaptureFixture) -> None:
+    async def load_slow() -> dict[str, int]:
+        return {"value": 1}
+
+    session: dict[str, Any] = {}
+    connection = _connection({"session": session})
+    stage_shared(connection, "ready", {"value": 2})
+    stage_shared(connection, "slow", defer("slow", load_slow))
+    stage_flash(connection, "Saved", "success")
+
+    with caplog.at_level(logging.WARNING, logger="litestar_vite"):
+        first_result = persist_transient_state_for_redirect(connection)
+        second_result = persist_transient_state_for_redirect(connection)
+
+    assert first_result == RedirectStatePersistence(had_pending=True, persisted=False, dropped_keys=("slow",))
+    assert second_result == RedirectStatePersistence(had_pending=False, persisted=False)
+    assert session == {"_shared": {"ready": {"value": 2}}, "_messages": [{"category": "success", "message": "Saved"}]}
+    assert peek_transient_state(connection) is None
+    assert len(caplog.records) == 1
+    assert "slow" in caplog.text
+    assert "Async shared props cannot cross redirects" in caplog.text
+    assert "direct Inertia response" in caplog.text

--- a/src/py/tests/unit/inertia/test_state.py
+++ b/src/py/tests/unit/inertia/test_state.py
@@ -59,7 +59,7 @@ def test_persist_transient_state_without_transport_consumes_and_warns_once(caplo
     assert "direct Inertia response" in caplog.text
 
 
-def test_persist_transient_state_writes_legacy_session_keys_without_warning(caplog: pytest.LogCaptureFixture) -> None:
+def test_persist_transient_state_writes_session_handoff_keys_without_warning(caplog: pytest.LogCaptureFixture) -> None:
     session: dict[str, Any] = {}
     connection = _connection({"session": session})
     stage_shared(connection, "auth", {"user": "Ada"})

--- a/src/py/tests/unit/inertia/test_state.py
+++ b/src/py/tests/unit/inertia/test_state.py
@@ -55,8 +55,8 @@ def test_persist_transient_state_without_transport_consumes_and_warns_once(caplo
     assert peek_transient_state(connection) is None
     assert len(caplog.records) == 1
     assert "no writable Litestar session" in caplog.text
-    assert "CookieBackendConfig" in caplog.text
-    assert "direct Inertia response" in caplog.text
+    assert "session middleware covers this route" in caplog.text
+    assert "CookieBackendConfig" not in caplog.text
 
 
 def test_persist_transient_state_writes_session_handoff_keys_without_warning(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary

- move Inertia shared props, flash messages, validation errors, and `clearHistory` into request-local transient state for direct responses
- make session middleware optional while preserving the existing session-backed redirect wire keys and handler-frame prop materialization
- detect redirect transport capability from the actual request scope and emit one actionable warning when pending state cannot cross a redirect
- validate `extra_session_page_props` only when that explicitly session-backed option is configured, including Litestar server-side, encrypted-cookie, and session-auth integrations
- add regression coverage for session-excluded routes, unauthorized fallbacks, encrypted-cookie PRG, dropped async props, and quiet direct/no-pending paths

## Why

Core Inertia page rendering does not require a session. The previous startup guard required session middleware globally even for applications that only needed current-request page state. At the same time, helper return values conflated local staging with cross-request persistence.

This change makes the request/response cycle the owner of transient page state and treats a Litestar session as an optional redirect transport. Applications that need store-free POST-Redirect-GET persistence can use Litestar's encrypted `CookieBackendConfig` rather than a separate flash-cookie implementation.

## Impact

Default `InertiaConfig()` applications can start and render direct shared props, flash, errors, and `clearHistory` without session middleware. Existing session-backed applications retain the `_shared`, `_messages`, `_errors`, and `_inertia_clear_history` compatibility contract.

Redirects with pending state and no writable session now warn instead of silently dropping data. Configuring `extra_session_page_props` without a supported session integration raises an option-specific startup error.