### PR TITLE
fix(inertia): preserve msgspec field aliases

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,9 @@ Litestar Vite Changelog
 0.30.0 - Unreleased
 -------------------
 
+- Fixed direct ``msgspec.Struct`` Inertia handler returns to use serialized top-level field names,
+  including struct ``rename=`` rules and explicit ``msgspec.field(name=...)`` aliases.
+  (`#345 <https://github.com/litestar-org/litestar-vite/issues/345>`_)
 - Added async and synchronous ``ViteAssetLoader`` APIs for resolving exact secondary Vite HTML
   entries in development and their explicit artifacts in production. The paired npm endpoint safely
   reads entries beneath the configured Vite root, and optional absolute development asset URLs support

--- a/src/py/litestar_vite/inertia/plugin.py
+++ b/src/py/litestar_vite/inertia/plugin.py
@@ -209,7 +209,7 @@ def _as_inertia_prop_mapping(data: "Any") -> "Mapping[str, Any] | None":
     if model_fields is not None and hasattr(obj, "model_dump"):
         return {name: getattr(obj, name) for name in model_fields}
     if isinstance(obj, msgspec.Struct):
-        return {field: getattr(obj, field) for field in obj.__struct_fields__}
+        return {field.encode_name: getattr(obj, field.name) for field in msgspec.structs.fields(obj)}
     if is_dataclass(obj) and not isinstance(obj, type):
         return {field.name: getattr(obj, field.name) for field in fields(obj)}
     return None

--- a/src/py/tests/unit/inertia/test_structured_props.py
+++ b/src/py/tests/unit/inertia/test_structured_props.py
@@ -1,4 +1,4 @@
-"""Regression tests for structured handler return types in Inertia mode (issue #272).
+"""Regression tests for structured handler return types in Inertia mode (issues #272 and #345).
 
 A handler returning a ``msgspec.Struct``, dataclass, or pydantic model represents
 a bag of page props, exactly like a returned ``dict``. On an initial (non-Inertia)
@@ -21,8 +21,9 @@ from litestar_vite.inertia import InertiaHeaders, InertiaPlugin
 from litestar_vite.plugin import VitePlugin
 
 
-class StructResp(msgspec.Struct):
-    name: str
+class StructResp(msgspec.Struct, rename="camel"):
+    browser_sessions: list[str]
+    display_name: str = msgspec.field(name="name")
 
 
 @dataclass
@@ -36,7 +37,7 @@ class PydanticResp(pydantic.BaseModel):
 
 @get("/struct", component="Home", sync_to_thread=False)
 def struct_route() -> StructResp:
-    return StructResp(name="x")
+    return StructResp(browser_sessions=["active"], display_name="x")
 
 
 @get("/dataclass", component="Home", sync_to_thread=False)
@@ -52,6 +53,14 @@ def pydantic_route() -> PydanticResp:
 @get("/dict", component="Home", sync_to_thread=False)
 def dict_route() -> dict[str, Any]:
     return {"name": "x"}
+
+
+def _assert_struct_props(props: dict[str, Any]) -> None:
+    assert props["browserSessions"] == ["active"]
+    assert props["name"] == "x"
+    assert "browser_sessions" not in props
+    assert "display_name" not in props
+    assert "content" not in props
 
 
 # ===== Initial (non-Inertia) visit: HTML bootstrap =====
@@ -95,3 +104,5 @@ def test_struct_route_inertia_visit_spreads_props(
             props = response.json()["props"]
             assert props.get("name") == "x", path
             assert "content" not in props, path
+            if path == "/struct":
+                _assert_struct_props(props)


### PR DESCRIPTION
## Summary

Direct `msgspec.Struct` Inertia handler returns used Python attribute names for top-level props, so struct rename rules and explicit field aliases diverged from nested serialization and generated types.

Use msgspec field metadata when creating the shallow prop mapping, retain the existing dataclass and Pydantic behavior, and cover both struct-level and explicit aliases.

Closes #345
