### PR TITLE
docs: correct stale justification for handler-level static route opts

### DIFF
--- a/src/py/litestar_vite/plugin/_core.py
+++ b/src/py/litestar_vite/plugin/_core.py
@@ -556,8 +556,8 @@ class VitePlugin(InitPlugin, CLIPlugin):
         user_config = self._static_files_config.as_router_kwargs() if self._static_files_config else {}
         static_files_config: dict[str, Any] = {**base_config, **user_config}
         router = create_static_files_router(**static_files_config)
-        # Emit opts only at handler level: strict auth integrations reject
-        # exclude_from_auth on parent layers (router/app).
+        # Emit opts at handler level: strict auth integrations inspect handler `opt` at
+        # application startup, so the keys have to be present on each handler itself.
         for route in router.routes:
             for handler in getattr(route, "route_handlers", []):
                 handler.opt.update(opt)


### PR DESCRIPTION
### Description

The comment above the handler-level `opt` emission in `_configure_static_files` gives a justification that is no longer true:

```python
# Emit opts only at handler level: strict auth integrations reject
# exclude_from_auth on parent layers (router/app).
```

`litestar-security` resolves `exclude_from_auth` hierarchically across `RouteHandler` > `Controller` > `Router` > `App`, so placing it on a router excludes that whole subtree. Nothing rejects it on a parent layer.

Handler-level emission is still the right call, and #351 made it deliberate. The issue is only that the stated reason would steer a future reader away from a spelling that now works, and reads as a plugin constraint that no longer exists.

### Change

Comment only, no behavioural change. The new text gives the actual reason from #351: strict auth integrations inspect handler `opt` at application startup, so the keys have to be present on each handler itself.

```python
# Emit opts at handler level: strict auth integrations inspect handler `opt` at
# application startup, so the keys have to be present on each handler itself.
```

The diff is two comment lines. No test is added because no behaviour changes.

Closes #356
